### PR TITLE
Private/piyush271291/check cluster exists

### DIFF
--- a/pkg/pmk/clients/qbert.go
+++ b/pkg/pmk/clients/qbert.go
@@ -215,11 +215,10 @@ func (c QbertImpl) checkClusterExists(name, projectID, token string) (bool, erro
 	}
 
 	for _, val := range payload {
-		fmt.Println(val["name"])
 		if val["name"] == name {
-			return true, err
+			return true, nil
 		}
 	}
 
-	return false, err
+	return false, nil
 }


### PR DESCRIPTION
**Functionality** 
1. If a cluster exists, the bootstrap call would exit informing the user to run bootstrap again with a new cluster name. 

**Testing**

Tested this manually by providing the same cluster name that existed and the results were as expected. 
`ERROR: 2020/10/01 09:41:25 bootstrap.go:74: Unable to bootstrap the cluster: Unable to create cluster: Cluster name already exists, please select a different name while cluster creation`