### PR TITLE
For redhat family make sure to use 'yum list installed' instead of 'yum

### DIFF
--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -186,7 +186,7 @@ func pf9PackagesPresent(hostOS string, exec clients.Executor) bool {
 		// it must be either debian or redhat based
 		err = exec.Run("bash",
 			"-c",
-			"yum list | grep -i 'pf9-'")
+			"yum list installed | grep -i 'pf9-'")
 	}
 
 	return err == nil


### PR DESCRIPTION
list'

For redhat command 'yum list' shows list of RPMs by name that can be
fetched from the repos (not just installed). We should be using 'yum
list installed'