### PR TITLE
Remove unnecessary arguments to PrepNode

### DIFF
--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -56,7 +56,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 		log.Fatalf("Unable to load clients needed for the Cmd. Error: %s", err.Error())
 	}
 
-	if err := pmk.PrepNode(ctx, c, user, password, sshKey, ips); err != nil {
+	if err := pmk.PrepNode(ctx, c); err != nil {
 		c.Segment.SendEvent("Prep Node - Failed", err)
 		log.Fatalf("Unable to prep node: %s\n", err.Error())
 	}

--- a/pkg/pmk/cluster.go
+++ b/pkg/pmk/cluster.go
@@ -23,7 +23,7 @@ func Bootstrap(ctx Context, c Client, req qbert.ClusterCreateRequest) error {
 		log.Errorf("Couldn't fetch user content")
 	}
 
-	if err := PrepNode(ctx, c, "", "", "", []string{}); err != nil {
+	if err := PrepNode(ctx, c); err != nil {
 		return fmt.Errorf("Unable to prepnode: %w", err)
 	}
 

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -16,13 +16,7 @@ import (
 )
 
 // PrepNode sets up prerequisites for k8s stack
-func PrepNode(
-	ctx Context,
-	allClients Client,
-	user string,
-	password string,
-	sshkey string,
-	ips []string) error {
+func PrepNode(ctx Context, allClients Client) error {
 
 	log.Debug("Received a call to start preping node(s).")
 


### PR DESCRIPTION
A simple refactoring to remove extra parameter from the PrepNode call.
These parameters were not used and didn't belong there in the first
place.