### PR TITLE
Better retry for resmgr

### DIFF
--- a/pkg/pmk/clients.go
+++ b/pkg/pmk/clients.go
@@ -8,10 +8,12 @@ import (
 	"github.com/platform9/pf9ctl/pkg/cmdexec"
 	"net/http"
 	"crypto/tls"
-
+	"time"
 )
 
-const HTTPMaxRetry = 5
+const HTTPMaxRetry = 15
+const HTTPRetryMinWait = 10 * time.Second
+const HTTPRetryMaxWait = 30 * time.Second
 
 // Clients struct encapsulate the collection of
 // external services
@@ -31,7 +33,7 @@ func NewClient(fqdn string, executor cmdexec.Executor, allowInsecure bool) (Clie
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 	return Client{
-		Resmgr:   resmgr.NewResmgr(fqdn, HTTPMaxRetry, allowInsecure),
+		Resmgr:   resmgr.NewResmgr(fqdn, HTTPMaxRetry, HTTPRetryMinWait, HTTPRetryMaxWait, allowInsecure),
 		Keystone: keystone.NewKeystone(fqdn),
 		Qbert:    qbert.NewQbert(fqdn),
 		Executor: executor,

--- a/pkg/resmgr/resmgr.go
+++ b/pkg/resmgr/resmgr.go
@@ -9,7 +9,7 @@ import (
 	"github.com/platform9/pf9ctl/pkg/util"
 	"net/http"
 	"crypto/tls"
-
+	"time"
 )
 
 type Resmgr interface {
@@ -18,12 +18,15 @@ type Resmgr interface {
 
 type ResmgrImpl struct {
 	fqdn string
+	minWait time.Duration
+	maxWait time.Duration
 	maxHttpRetry int
 	allowInsecure bool
 }
 
-func NewResmgr(fqdn string, maxHttpRetry int, allowInsecure bool) Resmgr {
-	return &ResmgrImpl{fqdn, maxHttpRetry, allowInsecure}
+func NewResmgr(fqdn string, maxHttpRetry int, minWait, maxWait time.Duration, allowInsecure bool) Resmgr {
+
+	return &ResmgrImpl{fqdn, minWait, maxWait, maxHttpRetry, allowInsecure}
 }
 
 // AuthorizeHost registers the host with hostID to the resmgr.
@@ -33,9 +36,11 @@ func (c *ResmgrImpl) AuthorizeHost(hostID string, token string) error {
 	client := rhttp.NewClient()
 	client.HTTPClient.Transport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
+	client.Logger = zap.S()
+	client.RetryWaitMin = c.minWait
+	client.RetryWaitMax = c.maxWait
 	client.RetryMax = c.maxHttpRetry
 	client.CheckRetry = rhttp.CheckRetry(util.RetryPolicyOn404)
-	client.Logger = nil
 
 	url := fmt.Sprintf("%s/resmgr/v1/hosts/%s/roles/pf9-kube", c.fqdn, hostID)
 	req, err := rhttp.NewRequest("PUT", url, nil)


### PR DESCRIPTION
The original sleep of 1 -10 second for 5 tries was not deemed enough
from testing. This change increases that time by sleeping between 10 -30
seconds and trying for 15 times.