### PR TITLE
CORE-1083 making segment optional - for offline installs

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -49,7 +49,7 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Unable to load context: %s", err.Error())
 	}
 
-	c, err := pmk.NewClient(ctx.Fqdn, cmdexec.LocalExecutor{}, ctx.AllowInsecure)
+	c, err := pmk.NewClient(ctx.Fqdn, cmdexec.LocalExecutor{}, ctx.AllowInsecure, false)
 	if err != nil {
 		zap.S().Fatalf("Unable to load clients: %s", err.Error())
 	}

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -50,7 +50,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 	if err != nil {
 		zap.S().Fatalf("Error connecting to host %s",err.Error())
 	}
-	c, err := pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure)
+	c, err := pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)
 	if err != nil {
 		zap.S().Fatalf("Unable to load clients needed for the Cmd. Error: %s", err.Error())
 	}

--- a/pkg/pmk/clients.go
+++ b/pkg/pmk/clients.go
@@ -27,7 +27,7 @@ type Client struct {
 
 // New creates the clients needed by the CLI
 // to interact with the external services.
-func NewClient(fqdn string, executor cmdexec.Executor, allowInsecure bool) (Client, error) {
+func NewClient(fqdn string, executor cmdexec.Executor, allowInsecure bool, noTracking bool) (Client, error) {
 	// Bring the hammer down to make default http allow insecure
 	if allowInsecure {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
@@ -37,6 +37,6 @@ func NewClient(fqdn string, executor cmdexec.Executor, allowInsecure bool) (Clie
 		Keystone: keystone.NewKeystone(fqdn),
 		Qbert:    qbert.NewQbert(fqdn),
 		Executor: executor,
-		Segment:  NewSegment(fqdn),
+		Segment:  NewSegment(fqdn, noTracking),
 	}, nil
 }

--- a/pkg/pmk/segment.go
+++ b/pkg/pmk/segment.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/segmentio/analytics-go.v3"
 )
 
-const WriteKey = "P6DycMCALprZrUwWL9ZzRLlfMQwL5Xyl"
+const segmentWriteKey = "P6DycMCALprZrUwWL9ZzRLlfMQwL5Xyl"
 
 type Segment interface {
 	SendEvent(string, interface{}) error
@@ -22,8 +22,17 @@ type SegmentImpl struct {
 	client analytics.Client
 }
 
-func NewSegment(fqdn string) Segment {
-	client := analytics.New(WriteKey)
+type NoopSegment struct {
+
+}
+
+
+func NewSegment(fqdn string, noTracking bool) Segment {
+	// mock out segment if the user wants no Tracking
+	if noTracking {
+		return NoopSegment{}
+	}
+	client := analytics.New(segmentWriteKey)
 
 	return SegmentImpl{
 		fqdn:   fqdn,
@@ -55,4 +64,18 @@ func (c SegmentImpl) SendGroupTraits(name string, data interface{}) error {
 
 func (c SegmentImpl) Close() {
 	c.client.Close()
+}
+
+
+// The Noop Implementation of Segment
+func (c NoopSegment) SendEvent(name string, data interface{}) error {
+	return nil
+}
+
+func (c NoopSegment) SendGroupTraits(name string, data interface{}) error {
+	return nil
+}
+
+func (c NoopSegment) Close() {
+	return
 }

--- a/pkg/qbert/qbert.go
+++ b/pkg/qbert/qbert.go
@@ -126,6 +126,8 @@ func (c QbertImpl) AttachNode(clusterID, nodeID, projectID, token string) error 
 	client := rhttp.Client{}
 	client.RetryMax = 5
 	client.CheckRetry = rhttp.CheckRetry(util.RetryPolicyOn404)
+	client.Logger = &util.ZapWrapper{}
+
 
 	req, err := rhttp.NewRequest("POST", attachEndpoint, strings.NewReader(string(byt)))
 	if err != nil {

--- a/pkg/resmgr/resmgr.go
+++ b/pkg/resmgr/resmgr.go
@@ -40,6 +40,7 @@ func (c *ResmgrImpl) AuthorizeHost(hostID string, token string) error {
 	client.RetryWaitMax = c.maxWait
 	client.RetryMax = c.maxHttpRetry
 	client.CheckRetry = rhttp.CheckRetry(util.RetryPolicyOn404)
+	client.Logger = &util.ZapWrapper{}
 
 	url := fmt.Sprintf("%s/resmgr/v1/hosts/%s/roles/pf9-kube", c.fqdn, hostID)
 	req, err := rhttp.NewRequest("PUT", url, nil)

--- a/pkg/resmgr/resmgr_test.go
+++ b/pkg/resmgr/resmgr_test.go
@@ -1,0 +1,27 @@
+package resmgr
+import (
+	"testing"
+	rhttp "github.com/hashicorp/go-retryablehttp"
+	"github.com/platform9/pf9ctl/pkg/util"
+	"fmt"
+)
+
+
+func TestRetryHTTP(t *testing.T) {
+
+	client := rhttp.NewClient()
+	
+	client.Logger = &util.ZapWrapper{}
+	
+    req, err := rhttp.NewRequest("GET", "http://www.google.com", nil)
+	if err != nil {
+		t.Errorf("Unable to create a new request: %s", err)
+	}
+	fmt.Printf("Send the request now")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Errorf("Unable to send request to the client: %s", err)
+	}
+	defer resp.Body.Close()
+
+}

--- a/pkg/util/helper.go
+++ b/pkg/util/helper.go
@@ -9,7 +9,10 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"go.uber.org/zap"
+
 )
+
 
 var (
 
@@ -72,6 +75,9 @@ func RetryPolicyOn404(ctx context.Context, resp *http.Response, err error) (bool
 	return false, nil
 }
 
+
+
+
 // AskBool function asks for the user input
 // for a boolean input
 func AskBool(msg string, args ...interface{}) (bool, error) {
@@ -97,4 +103,33 @@ func AskBool(msg string, args ...interface{}) (bool, error) {
 	}
 
 	return false, fmt.Errorf("Please provide input as y or n, provided: %s", resp)
+}
+
+// Logger interface allows to use other loggers than
+// standard log.Logger.
+type ZapWrapper struct {
+}
+/* 
+	Implmenting the LeveledLogger for retry http
+	type LeveledLogger interface {
+		Error(msg string, keysAndValues ...interface{})
+		Info(msg string, keysAndValues ...interface{})
+		Debug(msg string, keysAndValues ...interface{})
+		Warn(msg string, keysAndValues ...interface{})
+	}
+*/
+func (z *ZapWrapper) Error(msg string, args ...interface{}) {
+	zap.S().Errorf(msg, args)
+}
+
+func (z *ZapWrapper) Info(msg string, args ...interface{}) {
+	zap.S().Infof(msg, args)
+}
+
+func (z *ZapWrapper) Debug(msg string, args ...interface{}) {
+	zap.S().Debugf(msg, args)
+}
+
+func (z *ZapWrapper) Warn(msg string, args ...interface{}) {
+	zap.S().Warnf(msg, args)
 }


### PR DESCRIPTION
This makes the use of segment optional, it is controlled by
a flag. Also fixed the logging issue with the retry http module
by putting in a warpper on top of zap logger.