### PR TITLE
core-1063 Make swap permanently off by editing /etc/fstab

### DIFF
--- a/pkg/cmdexec/executor.go
+++ b/pkg/cmdexec/executor.go
@@ -27,6 +27,12 @@ func (c LocalExecutor) Run(name string, args ...string) error {
 // RunWithStdout runs a command locally returning stdout and err
 func (c LocalExecutor) RunWithStdout(name string, args ...string) (string, error) {
 	byt, err := exec.Command(name, args...).Output()
+	stderr := ""
+	if exitError, ok := err.(*exec.ExitError); ok {
+		stderr = string(exitError.Stderr)
+	}
+	zap.S().Debug("Ran command ",name, args)
+	zap.S().Debug( "stdout:", string(byt), "stderr:", stderr)
 	return string(byt), err
 }
 

--- a/pkg/pmk/common.go
+++ b/pkg/pmk/common.go
@@ -1,9 +1,11 @@
 package pmk
 
 import (
-	"go.uber.org/zap"
 	"github.com/platform9/pf9ctl/pkg/cmdexec"
+	"go.uber.org/zap"
+	"fmt"
 )
+
 // This files needs to be organized little better
 func setupNode(hostOS string, exec cmdexec.Executor) (err error) {
 	zap.S().Debug("Received a call to setup the node")
@@ -11,13 +13,29 @@ func setupNode(hostOS string, exec cmdexec.Executor) (err error) {
 	if err := swapOff(exec); err != nil {
 		return err
 	}
+	if err := swapOffFstab(exec, "/etc/fstab"); err != nil {
+		return err
+	}
 	return nil
 }
-
 
 func swapOff(exec cmdexec.Executor) error {
 	zap.S().Info("Disabling swap")
 
 	_, err := exec.RunWithStdout("bash", "-c", "swapoff -a")
 	return err
+}
+
+func swapOffFstab(exec cmdexec.Executor, file string) error {
+	zap.S().Info("Removing swap in fstab")
+	// match the 3rd column to have 'swap' and make sure the line isn't commented out already
+	search := `^[[:space:]]*([^#][^[:space:]]+)[[:space:]]+([^[:space:]]+)[[:space:]]+(swap)[[:space:]](.*)$`
+	replace := `#\1 \2 \3 \4`
+	// also the expression is in the EXTENDED regexp (ERE) form not the BRE, so use the ERE form
+	sedCmd := fmt.Sprintf("s/%s/%s/", search, replace)
+	zap.S().Info("Executing command ",sedCmd, file)
+	stdout, err := exec.RunWithStdout("sed", "-E", "-i.bak", sedCmd, file)
+	zap.S().Info("Returned value: ", stdout)
+	return err
+
 }

--- a/pkg/pmk/common_test.go
+++ b/pkg/pmk/common_test.go
@@ -1,0 +1,68 @@
+package pmk
+import (
+	"testing"
+	"github.com/platform9/pf9ctl/pkg/cmdexec"
+	"io/ioutil"
+	"os"
+	"go.uber.org/zap"
+)
+
+
+
+const content = `UUID=device_UUID none swap defaults 0 0
+UUID=device_UUID none notswap defaults 0
+UUID=device_UUID none notswap defaults
+/swapfile none ext 0
+UUID=device_UUID none nfs defaults 0 0
+UUID=device_UUID none somethingelse defaults 0 0
+#UUID=device_UUID none swap defaults 0 0
+# UUID=device_UUID none swap defaults 0 0
+  # UUID=device_UUID none swap defaults 0 0
+  
+`
+
+func TestFsTabEdit(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	zap.ReplaceGlobals(logger)
+
+	expectedContent := "#" + content
+	tmpFile, err := ioutil.TempFile("/tmp", "pf9ctl_common_test")
+	if err != nil {
+		t.Errorf("Error creating a tempfile %s", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.Write([]byte(content))
+	if err != nil {
+		t.Errorf("Error writing to temp file %s", err)
+	}
+	err = tmpFile.Close()
+	if err != nil {
+		t.Errorf("Error writing to temp file %s", err)
+	}
+
+	// also remove the .bak file we create
+	defer os.Remove(tmpFile.Name()+".bak")
+
+	executor := cmdexec.LocalExecutor{}
+	err = swapOffFstab(executor, tmpFile.Name())
+	if err != nil {
+		t.Errorf("Error editing fstab %s", err)
+	}
+	
+	// now read the file and compare the content
+
+	readContentBytes, err := ioutil.ReadFile(tmpFile.Name())
+	if err != nil {
+		t.Errorf("Error reading the tmpFile after editing the fstab")
+	}
+
+	readContent := string(readContentBytes)
+	
+	if readContent != expectedContent {
+		t.Log("Expected:", expectedContent)
+		t.Log("ReadContent:", readContent)
+		t.Errorf("Test failed,content mistmatch")
+	}
+
+}


### PR DESCRIPTION
This code change adds an ugly sed expression to find and comment out
the swap configuration in addition to the swapoff -a command.

I am reluctantly adding it because kubernetes doesn't like swap and I am
hoping one day I will be able to convince others to let it be enabled.