### PR TITLE
fix /etc/os-release read

### DIFF
--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -133,7 +133,7 @@ func installHostAgentCertless(ctx Context, auth keystone.KeystoneAuth, hostOS st
 func validatePlatform(exec cmdexec.Executor) (string, error) {
 	zap.S().Debug("Received a call to validate platform")
 
-	data, err := exec.RunWithStdout("cat /etc/os-release")
+	data, err := exec.RunWithStdout("cat", "/etc/os-release")
 	if err != nil {
 		return "", fmt.Errorf("failed reading data from file: %s", err)
 	}


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>

The command formed with the current code does not read the `/etc/os-release` file, hence the prep-node command fails.

Checked on Ubuntu and CentOS VMs.