### PR TITLE
check-node command

### DIFF
--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -1,3 +1,5 @@
+// Copyright © 2020 The pf9ctl authors
+
 package cmd
 
 import (
@@ -41,7 +43,7 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 
 	result, err := pmk.CheckNode(c)
 	if err != nil {
-		c.Segment.SendEvent("Prerequisite Node - Failed", err)
+		c.Segment.SendEvent("Prerequisite Checks for Node - Failed", err)
 		zap.S().Fatalf("Unable to check prerequisites for node: %s\n", err.Error())
 	}
 	if !result {

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 func checkNodeRun(cmd *cobra.Command, args []string) {
-	ctx, err := pmk.LoadContext(Pf9DBLoc)
+	ctx, err := pmk.LoadConfig(Pf9DBLoc)
 	if err != nil {
 		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
 	}
@@ -41,12 +41,9 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Unable to load clients needed for the Cmd. Error: %s", err.Error())
 	}
 
-	result, err := pmk.CheckNode(c)
-	if err != nil {
-		c.Segment.SendEvent("Prerequisite Checks for Node - Failed", err)
-		zap.S().Fatalf("Unable to check prerequisites for node: %s\n", err.Error())
-	}
+	result := pmk.CheckNode(c)
+
 	if !result {
-		zap.S().Fatal("Node not ready")
+		zap.S().Fatal("Node not ready. See verbose logs for more")
 	}
 }

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"github.com/platform9/pf9ctl/pkg/pmk"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var checkNodeCmd = &cobra.Command{
+	Use:   "check-node",
+	Short: "Check prerequisites for k8s",
+	Long: `Check if a node satisfies prerequisites to be ready to be added to a Kubernetes cluster. Read more
+	at https://platform9.com/blog/support/managed-container-cloud-requirements-checklist/`,
+	Run: checkNodeRun,
+}
+
+func init() {
+	checkNodeCmd.Flags().StringVarP(&user, "user", "u", "", "ssh username for the nodes")
+	checkNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes")
+	checkNodeCmd.Flags().StringVarP(&sshKey, "ssh-key", "s", "", "ssh key file for connecting to the nodes")
+	checkNodeCmd.Flags().StringSliceVarP(&ips, "ips", "i", []string{}, "ips of host to be prepared")
+	checkNodeCmd.Flags().BoolVarP(&floatingIP, "floating-ip", "f", false, "")
+
+	rootCmd.AddCommand(checkNodeCmd)
+}
+
+func checkNodeRun(cmd *cobra.Command, args []string) {
+	ctx, err := pmk.LoadContext(Pf9DBLoc)
+	if err != nil {
+		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
+	}
+
+	executor, err := getExecutor()
+	if err != nil {
+		zap.S().Fatalf("Error connecting to host %s", err.Error())
+	}
+	c, err := pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)
+	if err != nil {
+		zap.S().Fatalf("Unable to load clients needed for the Cmd. Error: %s", err.Error())
+	}
+
+	result, err := pmk.CheckNode(c)
+	if err != nil {
+		c.Segment.SendEvent("Prerequisite Node - Failed", err)
+		zap.S().Fatalf("Unable to check prerequisites for node: %s\n", err.Error())
+	}
+	if !result {
+		zap.S().Fatal("Node not ready")
+	}
+}

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -74,7 +74,7 @@ func checkAndValidateRemote() bool {
 			return foundRemote
 		}
 	}
-	zap.S().Info("Using local exeuctor")
+	zap.S().Info("Using local executor")
 	return foundRemote
 }
 
@@ -91,6 +91,6 @@ func getExecutor() (cmdexec.Executor, error) {
 		}
 		return cmdexec.NewRemoteExecutor(ips[0], 22, user, pKey, password)
 	}
-	zap.S().Info("Using local exeuctor")
+	zap.S().Info("Using local executor")
 	return cmdexec.LocalExecutor{}, nil
 }

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -74,7 +74,7 @@ func checkAndValidateRemote() bool {
 			return foundRemote
 		}
 	}
-	zap.S().Info("Using local executor")
+	zap.S().Debug("Using local executor")
 	return foundRemote
 }
 
@@ -86,11 +86,11 @@ func getExecutor() (cmdexec.Executor, error) {
 		if sshKey != "" {
 			pKey, err = ioutil.ReadFile(sshKey)
 			if err != nil {
-				zap.S().Fatalf("Unale to read the sshKey %s, %s", sshKey, err.Error())
+				zap.S().Fatalf("Unable to read the sshKey %s, %s", sshKey, err.Error())
 			}
 		}
 		return cmdexec.NewRemoteExecutor(ips[0], 22, user, pKey, password)
 	}
-	zap.S().Info("Using local executor")
+	zap.S().Debug("Using local executor")
 	return cmdexec.LocalExecutor{}, nil
 }

--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -1,0 +1,151 @@
+package centos
+
+import (
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/platform9/pf9ctl/pkg/cmdexec"
+	"github.com/platform9/pf9ctl/pkg/platform"
+	"github.com/platform9/pf9ctl/pkg/util"
+	"go.uber.org/zap"
+)
+
+// CentOS reprents centos based host machine
+type CentOS struct {
+	exec cmdexec.Executor
+}
+
+// NewCentOS creates and returns a new instance of CentOS
+func NewCentOS(exec cmdexec.Executor) *CentOS {
+	return &CentOS{exec}
+}
+
+// Check inspects if a host machine meets all the requirements to be a cluster node
+func (c *CentOS) Check() []platform.Check {
+	var checks []platform.Check
+
+	result, err := c.checkPackages()
+	checks = append(checks, platform.Check{"PackageCheck", result, err})
+
+	result, err = c.checkSudo()
+	checks = append(checks, platform.Check{"SudoCheck", result, err})
+
+	result, err = c.checkCPU()
+	checks = append(checks, platform.Check{"CPUCheck", result, err})
+
+	result, err = c.checkDisk()
+	checks = append(checks, platform.Check{"DiskCheck", result, err})
+
+	result, err = c.checkMem()
+	checks = append(checks, platform.Check{"MemoryCheck", result, err})
+
+	result, err = c.checkPort()
+	checks = append(checks, platform.Check{"PortCheck", result, err})
+
+	return checks
+}
+
+func (c *CentOS) checkPackages() (bool, error) {
+	var err error
+	err = c.exec.Run("bash", "-c", "yum list installed | grep -i 'pf9-'")
+
+	return !(err == nil), nil
+}
+
+func (c *CentOS) checkSudo() (bool, error) {
+	idS, err := c.exec.RunWithStdout("bash", "-c", "id -u | tr -d '\\n'")
+	if err != nil {
+		return false, err
+	}
+
+	id, err := strconv.Atoi(idS)
+	if err != nil {
+		zap.S().Info(">", err)
+		return false, err
+	}
+
+	return id == 0, nil
+}
+
+func (c *CentOS) checkCPU() (bool, error) {
+	cpuS, err := c.exec.RunWithStdout("bash", "-c", "grep -c ^processor /proc/cpuinfo | tr -d '\\n'")
+	if err != nil {
+		return false, err
+	}
+
+	cpu, err := strconv.Atoi(cpuS)
+	if err != nil {
+		return false, err
+	}
+
+	zap.S().Debug("Number of CPUs found: ", cpu)
+
+	return cpu >= util.MinCPUs, nil
+}
+
+func (c *CentOS) checkMem() (bool, error) {
+	memS, err := c.exec.RunWithStdout("bash", "-c", "echo $(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) / (1024 * 1024))) | tr -d '\\n'")
+	if err != nil {
+		return false, err
+	}
+
+	mem, err := strconv.ParseFloat(memS, 32)
+	if err != nil {
+		return false, err
+	}
+
+	zap.S().Debug("Total memory allocated in GiBs", mem)
+
+	return math.Ceil(mem/1024) >= util.MinMem, nil
+}
+
+func (c *CentOS) checkDisk() (bool, error) {
+	diskS, err := c.exec.RunWithStdout("bash", "-c", "df -k . --output=size | sed 1d | xargs | tr -d '\\n'")
+	if err != nil {
+		return false, err
+	}
+
+	disk, err := strconv.ParseFloat(diskS, 32)
+	if err != nil {
+		return false, err
+	}
+
+	if math.Ceil(disk/util.GB) < util.MinDisk {
+		return false, nil
+	}
+
+	zap.S().Debug("Total disk space: ", disk)
+
+	availS, err := c.exec.RunWithStdout("bash", "-c", "df -k . --output=avail | sed 1d | xargs | tr -d '\\n'")
+	if err != nil {
+		return false, err
+	}
+
+	avail, err := strconv.ParseFloat(availS, 32)
+	if err != nil {
+		return false, err
+	}
+
+	zap.S().Debug("Available disk space: ", avail)
+
+	return math.Ceil(avail/util.GB) >= util.MinAvailDisk, nil
+}
+
+func (c *CentOS) checkPort() (bool, error) {
+	openPorts, err := c.exec.RunWithStdout("bash", "-c", "netstat -tupna | awk '{print $4}' | sed -e 's/.*://' | sort | uniq")
+	if err != nil {
+		return false, err
+	}
+
+	openPortsArray := strings.Split(string(openPorts), "\n")
+
+	intersection := util.Intersect(util.RequiredPorts, openPortsArray)
+
+	if len(intersection) != 0 {
+		zap.S().Debug("Ports required but not available: ", intersection)
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/pkg/platform/check.go
+++ b/pkg/platform/check.go
@@ -1,0 +1,7 @@
+package platform
+
+type Check struct {
+	Name   string
+	Result bool
+	Err    error
+}

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -1,0 +1,152 @@
+package debian
+
+import (
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/platform9/pf9ctl/pkg/cmdexec"
+	"github.com/platform9/pf9ctl/pkg/platform"
+	"github.com/platform9/pf9ctl/pkg/util"
+	"go.uber.org/zap"
+)
+
+// Debian represents debian based host machine
+type Debian struct {
+	exec cmdexec.Executor
+}
+
+// NewDebian creates and returns a new instance of Debian
+func NewDebian(exec cmdexec.Executor) *Debian {
+	return &Debian{exec}
+}
+
+// Check inspects if a host machine meets all the requirements to be a cluster node
+func (d *Debian) Check() []platform.Check {
+	var checks []platform.Check
+
+	result, err := d.checkPackages()
+	checks = append(checks, platform.Check{"PackageCheck", result, err})
+
+	result, err = d.checkSudo()
+	checks = append(checks, platform.Check{"SudoCheck", result, err})
+
+	result, err = d.checkCPU()
+	checks = append(checks, platform.Check{"CPUCheck", result, err})
+
+	result, err = d.checkDisk()
+	checks = append(checks, platform.Check{"DiskCheck", result, err})
+
+	result, err = d.checkMem()
+	checks = append(checks, platform.Check{"MemoryCheck", result, err})
+
+	result, err = d.checkPort()
+	checks = append(checks, platform.Check{"PortCheck", result, err})
+
+	return checks
+}
+
+func (d *Debian) checkPackages() (bool, error) {
+
+	var err error
+	err = d.exec.Run("bash", "-c", "dpkg -l | grep -i 'pf9-'")
+
+	return !(err == nil), nil
+}
+
+func (d *Debian) checkSudo() (bool, error) {
+	idS, err := d.exec.RunWithStdout("bash", "-c", "id -u | tr -d '\\n'")
+	if err != nil {
+		return false, err
+	}
+
+	id, err := strconv.Atoi(idS)
+	if err != nil {
+		zap.S().Info(">", err)
+		return false, err
+	}
+
+	return id == 0, nil
+}
+
+func (d *Debian) checkCPU() (bool, error) {
+	cpuS, err := d.exec.RunWithStdout("bash", "-c", "grep -c ^processor /proc/cpuinfo | tr -d '\\n'")
+	if err != nil {
+		return false, err
+	}
+
+	cpu, err := strconv.Atoi(cpuS)
+	if err != nil {
+		return false, err
+	}
+
+	zap.S().Debug("Number of CPUs found: ", cpu)
+
+	return cpu >= util.MinCPUs, nil
+}
+
+func (d *Debian) checkMem() (bool, error) {
+	memS, err := d.exec.RunWithStdout("bash", "-c", "echo $(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) / (1024 * 1024))) | tr -d '\\n'")
+	if err != nil {
+		return false, err
+	}
+
+	mem, err := strconv.ParseFloat(memS, 32)
+	if err != nil {
+		return false, err
+	}
+
+	zap.S().Debug("Total memory allocated in GiBs", mem)
+
+	return math.Ceil(mem/1024) >= util.MinMem, nil
+}
+
+func (d *Debian) checkDisk() (bool, error) {
+	diskS, err := d.exec.RunWithStdout("bash", "-c", "df -k . --output=size | sed 1d | xargs | tr -d '\\n'")
+	if err != nil {
+		return false, err
+	}
+
+	disk, err := strconv.ParseFloat(diskS, 32)
+	if err != nil {
+		return false, err
+	}
+
+	if math.Ceil(disk/util.GB) < util.MinDisk {
+		return false, nil
+	}
+
+	zap.S().Debug("Total disk space: ", disk)
+
+	availS, err := d.exec.RunWithStdout("bash", "-c", "df -k . --output=avail | sed 1d | xargs | tr -d '\\n'")
+	if err != nil {
+		return false, err
+	}
+
+	avail, err := strconv.ParseFloat(availS, 32)
+	if err != nil {
+		return false, err
+	}
+
+	zap.S().Debug("Available disk space: ", avail)
+
+	return math.Ceil(avail/util.GB) >= util.MinAvailDisk, nil
+}
+
+func (d *Debian) checkPort() (bool, error) {
+	openPorts, err := d.exec.RunWithStdout("bash", "-c", "netstat -tupna | awk '{print $4}' | sed -e 's/.*://' | sort | uniq")
+	if err != nil {
+		return false, err
+	}
+
+	openPortsArray := strings.Split(string(openPorts), "\n")
+
+	intersection := util.Intersect(util.RequiredPorts, openPortsArray)
+
+	if len(intersection) != 0 {
+		zap.S().Debug("Ports required but not available: ", intersection)
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1,0 +1,5 @@
+package platform
+
+type Platform interface {
+	Check() []Check
+}

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -1,4 +1,5 @@
 // Copyright © 2020 The Platform9 Systems Inc.
+
 package pmk
 
 import (
@@ -13,10 +14,15 @@ import (
 )
 
 const (
-	minCPUs      = 2
-	minMem       = 12
-	gB           = 1024.00 * 1024
-	minDisk      = 30
+	// number of CPUs
+	minCPUs = 2
+	// RAM in GiBs
+	minMem = 12
+	// Measure of a GiB in terms of bytes
+	gB = 1024 * 1024
+	// Disk size in GiBs
+	minDisk = 30
+	// Disk size in GiBs
 	minAvailDisk = 15
 
 	checkPass = "PASS"

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -174,14 +174,14 @@ func (c memoryCheck) check(exec cmdexec.Executor) (bool, error) {
 		return false, err
 	}
 
-	mem, err := strconv.Atoi(memS)
+	mem, err := strconv.ParseFloat(memS, 32)
 	if err != nil {
 		return false, err
 	}
 
 	zap.S().Debug("Total memory allocated in GiBs", mem)
 
-	return mem/1024 >= minMem, nil
+	return math.Ceil(mem/1024) >= minMem, nil
 }
 
 func (c memoryCheck) errMessage() string {

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -1,0 +1,253 @@
+// Copyright © 2020 The Platform9 Systems Inc.
+package pmk
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/platform9/pf9ctl/pkg/cmdexec"
+	"github.com/platform9/pf9ctl/pkg/util"
+	"go.uber.org/zap"
+)
+
+const (
+	minCPUs      = 2
+	minMem       = 12
+	gB           = 1024.00 * 1024
+	minDisk      = 30
+	minAvailDisk = 15
+
+	checkPass = "PASS"
+	checkFail = "FAIL"
+)
+
+var requiredPorts = []string{"443", "2379", "2380", "8285", "10250", "10255", "4194", "8285"}
+
+// CheckNode checks the prerequisites for k8s stack
+func CheckNode(allClients Client) (bool, error) {
+
+	zap.S().Debug("Received a call to check node.")
+
+	var checks []NodeCheck
+	checks = append(checks, osCheck{}, packagesCheck{}, sudoCheck{}, cpuCheck{}, memoryCheck{}, diskCheck{}, portCheck{})
+
+	for _, check := range checks {
+		result, err := check.check(allClients.Executor)
+		if err != nil {
+			zap.S().Errorf("Unable to complete %s: %s ", check.name(), err)
+			return false, err
+		}
+
+		if result {
+			zap.S().Infof("%s : %s", check.name(), checkPass)
+		} else {
+			zap.S().Infof("%s : %s", check.name(), checkFail)
+			zap.S().Debug(check.errMessage())
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// NodeCheck declares contract for all checks
+type NodeCheck interface {
+	name() string
+	check(exec cmdexec.Executor) (bool, error)
+	errMessage() string
+}
+
+type osCheck struct{}
+
+func (c osCheck) name() string {
+	return "OSCheck"
+}
+
+func (c osCheck) check(exec cmdexec.Executor) (bool, error) {
+	os, err := validatePlatform(exec)
+	if err != nil {
+		return false, err
+	}
+
+	zap.S().Debug("OS running: ", os)
+
+	if os != "redhat" && os != "debian" {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (c osCheck) errMessage() string {
+	return fmt.Sprint("Only Ubuntu and CentOS VMs are supported")
+}
+
+type packagesCheck struct{}
+
+func (c packagesCheck) name() string {
+	return "PackagesCheck"
+}
+
+func (c packagesCheck) check(exec cmdexec.Executor) (bool, error) {
+	os, err := validatePlatform(exec)
+	if err != nil {
+		return false, err
+	}
+
+	present := pf9PackagesPresent(os, exec)
+
+	return !present, nil
+}
+
+func (c packagesCheck) errMessage() string {
+	return fmt.Sprint("PF9 package are already present on this machine")
+}
+
+type sudoCheck struct{}
+
+func (c sudoCheck) name() string {
+	return "SudoCheck"
+}
+
+func (c sudoCheck) check(exec cmdexec.Executor) (bool, error) {
+	idS, err := exec.RunWithStdout("bash", "-c", "id -u | tr -d '\\n'")
+	if err != nil {
+		return false, err
+	}
+
+	id, err := strconv.Atoi(idS)
+	if err != nil {
+		zap.S().Info(">", err)
+		return false, err
+	}
+
+	return id == 0, nil
+}
+
+func (c sudoCheck) errMessage() string {
+	return fmt.Sprint("You need to run this command with sudo")
+}
+
+type cpuCheck struct{}
+
+func (c cpuCheck) name() string {
+	return "CPUCheck"
+}
+
+func (c cpuCheck) check(exec cmdexec.Executor) (bool, error) {
+	cpuS, err := exec.RunWithStdout("bash", "-c", "grep -c ^processor /proc/cpuinfo | tr -d '\\n'")
+	if err != nil {
+		return false, err
+	}
+
+	cpu, err := strconv.Atoi(cpuS)
+	if err != nil {
+		return false, err
+	}
+
+	zap.S().Debug("Number of CPUs found: ", cpu)
+
+	return cpu >= minCPUs, nil
+}
+
+func (c cpuCheck) errMessage() string {
+	return fmt.Sprint("Required minimum %d number of CPUs", minCPUs)
+}
+
+type memoryCheck struct{}
+
+func (c memoryCheck) name() string {
+	return "MemoryCheck"
+}
+
+func (c memoryCheck) check(exec cmdexec.Executor) (bool, error) {
+	memS, err := exec.RunWithStdout("bash", "-c", "echo $(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) / (1024 * 1024))) | tr -d '\\n'")
+	if err != nil {
+		return false, err
+	}
+
+	mem, err := strconv.Atoi(memS)
+	if err != nil {
+		return false, err
+	}
+
+	zap.S().Debug("Total memory allocated in GiBs", mem)
+
+	return mem/1024 >= minMem, nil
+}
+
+func (c memoryCheck) errMessage() string {
+	return fmt.Sprint("Required minimum %d GiB of total memory space", minMem)
+}
+
+type diskCheck struct{}
+
+func (c diskCheck) name() string {
+	return "DiskCheck"
+}
+
+func (c diskCheck) check(exec cmdexec.Executor) (bool, error) {
+	diskS, err := exec.RunWithStdout("bash", "-c", "df -k . --output=size | sed 1d | xargs | tr -d '\\n'")
+	if err != nil {
+		return false, err
+	}
+
+	disk, err := strconv.ParseFloat(diskS, 32)
+	if err != nil {
+		return false, err
+	}
+
+	if math.Ceil(disk/gB) < minDisk {
+		return false, nil
+	}
+
+	zap.S().Debug("Total disk space: ", disk)
+
+	availS, err := exec.RunWithStdout("bash", "-c", "df -k . --output=avail | sed 1d | xargs | tr -d '\\n'")
+	if err != nil {
+		return false, err
+	}
+
+	avail, err := strconv.ParseFloat(availS, 32)
+	if err != nil {
+		return false, err
+	}
+
+	zap.S().Debug("Available disk space: ", avail)
+
+	return math.Ceil(avail/gB) >= minAvailDisk, nil
+}
+
+func (c diskCheck) errMessage() string {
+	return fmt.Sprintf("Required minimum %d GiB of total disk space and %d GiB of free disk space", minDisk, minAvailDisk)
+}
+
+type portCheck struct{}
+
+func (c portCheck) name() string {
+	return "PortCheck"
+}
+
+func (c portCheck) check(exec cmdexec.Executor) (bool, error) {
+	openPorts, err := exec.RunWithStdout("bash", "-c", "netstat -tupna | awk '{print $4}' | sed -e 's/.*://' | sort | uniq")
+	if err != nil {
+		return false, err
+	}
+
+	openPortsArray := strings.Split(string(openPorts), "\n")
+
+	intersection := util.Intersect(requiredPorts, openPortsArray)
+
+	if len(intersection) != 0 {
+		zap.S().Debug("Ports required but not available: ", intersection)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (c portCheck) errMessage() string {
+	return fmt.Sprintf("Required minimum %d GiB of total disk space and %d GiB of free disk space", minDisk, minAvailDisk)
+}

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -4,256 +4,51 @@ package pmk
 
 import (
 	"fmt"
-	"math"
-	"strconv"
-	"strings"
 
-	"github.com/platform9/pf9ctl/pkg/cmdexec"
-	"github.com/platform9/pf9ctl/pkg/util"
+	"github.com/platform9/pf9ctl/pkg/platform"
+	"github.com/platform9/pf9ctl/pkg/platform/centos"
+	"github.com/platform9/pf9ctl/pkg/platform/debian"
 	"go.uber.org/zap"
 )
 
 const (
-	// number of CPUs
-	minCPUs = 2
-	// RAM in GiBs
-	minMem = 12
-	// Measure of a GiB in terms of bytes
-	gB = 1024 * 1024
-	// Disk size in GiBs
-	minDisk = 30
-	// Disk size in GiBs
-	minAvailDisk = 15
-
 	checkPass = "PASS"
 	checkFail = "FAIL"
 )
 
-var requiredPorts = []string{"443", "2379", "2380", "8285", "10250", "10255", "4194", "8285"}
-
 // CheckNode checks the prerequisites for k8s stack
-func CheckNode(allClients Client) (bool, error) {
+func CheckNode(allClients Client) bool {
 
 	zap.S().Debug("Received a call to check node.")
 
-	var checks []NodeCheck
-	checks = append(checks, osCheck{}, packagesCheck{}, sudoCheck{}, cpuCheck{}, memoryCheck{}, diskCheck{}, portCheck{})
+	os, err := validatePlatform(allClients.Executor)
+	if err != nil {
+		return false
+	}
 
+	var platform platform.Platform
+	switch os {
+	case "debian":
+		platform = debian.NewDebian(allClients.Executor)
+	case "redhat":
+		platform = centos.NewCentOS(allClients.Executor)
+	}
+
+	checks := platform.Check()
+	result := true
 	for _, check := range checks {
-		result, err := check.check(allClients.Executor)
-		if err != nil {
-			zap.S().Errorf("Unable to complete %s: %s ", check.name(), err)
-			return false, err
-		}
-
-		if result {
-			zap.S().Infof("%s : %s", check.name(), checkPass)
+		if check.Result {
+			fmt.Printf("%s : %s\n", check.Name, checkPass)
 		} else {
-			zap.S().Infof("%s : %s", check.name(), checkFail)
-			zap.S().Debug(check.errMessage())
-			return false, nil
+			fmt.Printf("%s : %s\n", check.Name, checkFail)
+			result = false
+		}
+
+		if check.Err != nil {
+			zap.S().Debugf("Error in %s : %s", check.Name, err)
+			result = false
 		}
 	}
 
-	return true, nil
-}
-
-// NodeCheck declares contract for all checks
-type NodeCheck interface {
-	name() string
-	check(exec cmdexec.Executor) (bool, error)
-	errMessage() string
-}
-
-type osCheck struct{}
-
-func (c osCheck) name() string {
-	return "OSCheck"
-}
-
-func (c osCheck) check(exec cmdexec.Executor) (bool, error) {
-	os, err := validatePlatform(exec)
-	if err != nil {
-		return false, err
-	}
-
-	zap.S().Debug("OS running: ", os)
-
-	if os != "redhat" && os != "debian" {
-		return false, nil
-	}
-
-	return true, nil
-}
-
-func (c osCheck) errMessage() string {
-	return fmt.Sprint("Only Ubuntu and CentOS VMs are supported")
-}
-
-type packagesCheck struct{}
-
-func (c packagesCheck) name() string {
-	return "PackagesCheck"
-}
-
-func (c packagesCheck) check(exec cmdexec.Executor) (bool, error) {
-	os, err := validatePlatform(exec)
-	if err != nil {
-		return false, err
-	}
-
-	present := pf9PackagesPresent(os, exec)
-
-	return !present, nil
-}
-
-func (c packagesCheck) errMessage() string {
-	return fmt.Sprint("PF9 package are already present on this machine")
-}
-
-type sudoCheck struct{}
-
-func (c sudoCheck) name() string {
-	return "SudoCheck"
-}
-
-func (c sudoCheck) check(exec cmdexec.Executor) (bool, error) {
-	idS, err := exec.RunWithStdout("bash", "-c", "id -u | tr -d '\\n'")
-	if err != nil {
-		return false, err
-	}
-
-	id, err := strconv.Atoi(idS)
-	if err != nil {
-		zap.S().Info(">", err)
-		return false, err
-	}
-
-	return id == 0, nil
-}
-
-func (c sudoCheck) errMessage() string {
-	return fmt.Sprint("You need to run this command with sudo")
-}
-
-type cpuCheck struct{}
-
-func (c cpuCheck) name() string {
-	return "CPUCheck"
-}
-
-func (c cpuCheck) check(exec cmdexec.Executor) (bool, error) {
-	cpuS, err := exec.RunWithStdout("bash", "-c", "grep -c ^processor /proc/cpuinfo | tr -d '\\n'")
-	if err != nil {
-		return false, err
-	}
-
-	cpu, err := strconv.Atoi(cpuS)
-	if err != nil {
-		return false, err
-	}
-
-	zap.S().Debug("Number of CPUs found: ", cpu)
-
-	return cpu >= minCPUs, nil
-}
-
-func (c cpuCheck) errMessage() string {
-	return fmt.Sprint("Required minimum %d number of CPUs", minCPUs)
-}
-
-type memoryCheck struct{}
-
-func (c memoryCheck) name() string {
-	return "MemoryCheck"
-}
-
-func (c memoryCheck) check(exec cmdexec.Executor) (bool, error) {
-	memS, err := exec.RunWithStdout("bash", "-c", "echo $(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) / (1024 * 1024))) | tr -d '\\n'")
-	if err != nil {
-		return false, err
-	}
-
-	mem, err := strconv.ParseFloat(memS, 32)
-	if err != nil {
-		return false, err
-	}
-
-	zap.S().Debug("Total memory allocated in GiBs", mem)
-
-	return math.Ceil(mem/1024) >= minMem, nil
-}
-
-func (c memoryCheck) errMessage() string {
-	return fmt.Sprint("Required minimum %d GiB of total memory space", minMem)
-}
-
-type diskCheck struct{}
-
-func (c diskCheck) name() string {
-	return "DiskCheck"
-}
-
-func (c diskCheck) check(exec cmdexec.Executor) (bool, error) {
-	diskS, err := exec.RunWithStdout("bash", "-c", "df -k . --output=size | sed 1d | xargs | tr -d '\\n'")
-	if err != nil {
-		return false, err
-	}
-
-	disk, err := strconv.ParseFloat(diskS, 32)
-	if err != nil {
-		return false, err
-	}
-
-	if math.Ceil(disk/gB) < minDisk {
-		return false, nil
-	}
-
-	zap.S().Debug("Total disk space: ", disk)
-
-	availS, err := exec.RunWithStdout("bash", "-c", "df -k . --output=avail | sed 1d | xargs | tr -d '\\n'")
-	if err != nil {
-		return false, err
-	}
-
-	avail, err := strconv.ParseFloat(availS, 32)
-	if err != nil {
-		return false, err
-	}
-
-	zap.S().Debug("Available disk space: ", avail)
-
-	return math.Ceil(avail/gB) >= minAvailDisk, nil
-}
-
-func (c diskCheck) errMessage() string {
-	return fmt.Sprintf("Required minimum %d GiB of total disk space and %d GiB of free disk space", minDisk, minAvailDisk)
-}
-
-type portCheck struct{}
-
-func (c portCheck) name() string {
-	return "PortCheck"
-}
-
-func (c portCheck) check(exec cmdexec.Executor) (bool, error) {
-	openPorts, err := exec.RunWithStdout("bash", "-c", "netstat -tupna | awk '{print $4}' | sed -e 's/.*://' | sort | uniq")
-	if err != nil {
-		return false, err
-	}
-
-	openPortsArray := strings.Split(string(openPorts), "\n")
-
-	intersection := util.Intersect(requiredPorts, openPortsArray)
-
-	if len(intersection) != 0 {
-		zap.S().Debug("Ports required but not available: ", intersection)
-		return false, nil
-	}
-
-	return true, nil
-}
-
-func (c portCheck) errMessage() string {
-	return fmt.Sprintf("Required minimum %d GiB of total disk space and %d GiB of free disk space", minDisk, minAvailDisk)
+	return result
 }

--- a/pkg/util/contants.go
+++ b/pkg/util/contants.go
@@ -1,0 +1,24 @@
+package util
+
+var RequiredPorts []string
+
+const (
+
+	// number of CPUs
+	MinCPUs = 2
+	// RAM in GiBs
+	MinMem = 12
+	// Measure of a GiB in terms of bytes
+	GB = 1024 * 1024
+	// Disk size in GiBs
+	MinDisk = 30
+	// Disk size in GiBs
+	MinAvailDisk = 15
+
+	CheckPass = "PASS"
+	CheckFail = "FAIL"
+)
+
+func init() {
+	RequiredPorts = []string{"443", "2379", "2380", "8285", "10250", "10255", "4194", "8285"}
+}

--- a/pkg/util/slices.go
+++ b/pkg/util/slices.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"reflect"
+)
+
+func Intersect(a interface{}, b interface{}) []interface{} {
+	set := make([]interface{}, 0)
+	hash := make(map[interface{}]bool)
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+
+	for i := 0; i < av.Len(); i++ {
+		el := av.Index(i).Interface()
+		hash[el] = true
+	}
+
+	for i := 0; i < bv.Len(); i++ {
+		el := bv.Index(i).Interface()
+		if _, found := hash[el]; found {
+			set = append(set, el)
+		}
+	}
+
+	return set
+}
+
+func Contains(a interface{}, e interface{}) bool {
+	v := reflect.ValueOf(a)
+
+	for i := 0; i < v.Len(); i++ {
+		if v.Index(i).Interface() == e {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/slices.go
+++ b/pkg/util/slices.go
@@ -1,23 +1,17 @@
 package util
 
-import (
-	"reflect"
-)
-
 // Intersect returns a list of common items between two lists
-func Intersect(a interface{}, b interface{}) []interface{} {
-	set := make([]interface{}, 0)
-	hash := make(map[interface{}]bool)
-	av := reflect.ValueOf(a)
-	bv := reflect.ValueOf(b)
+func Intersect(a []string, b []string) []string {
+	set := make([]string, 0)
+	hash := make(map[string]bool)
 
-	for i := 0; i < av.Len(); i++ {
-		el := av.Index(i).Interface()
+	for i := 0; i < len(a); i++ {
+		el := a[i]
 		hash[el] = true
 	}
 
-	for i := 0; i < bv.Len(); i++ {
-		el := bv.Index(i).Interface()
+	for i := 0; i < len(b); i++ {
+		el := b[i]
 		if _, found := hash[el]; found {
 			set = append(set, el)
 		}

--- a/pkg/util/slices.go
+++ b/pkg/util/slices.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 )
 
+// Intersect returns a list of common items between two lists
 func Intersect(a interface{}, b interface{}) []interface{} {
 	set := make([]interface{}, 0)
 	hash := make(map[interface{}]bool)
@@ -23,15 +24,4 @@ func Intersect(a interface{}, b interface{}) []interface{} {
 	}
 
 	return set
-}
-
-func Contains(a interface{}, e interface{}) bool {
-	v := reflect.ValueOf(a)
-
-	for i := 0; i < v.Len(); i++ {
-		if v.Index(i).Interface() == e {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>

Adds a new sub-command to check if a VM meets the prerequisites to be registered as a Kubernetes node.

Success case:
```
pf9ctl check-node
2021-01-25T16:42:48.630+0530	INFO	Loading config...
PackageCheck : PASS
SudoCheck : FAIL
CPUCheck : PASS
DiskCheck : PASS
MemoryCheck : PASS
PortCheck : PASS
```

Failure case
```

pf9ctl check-node
2021-01-25T16:42:48.630+0530	INFO	Loading config...
PackageCheck : PASS
SudoCheck : FAIL
CPUCheck : PASS
DiskCheck : PASS
MemoryCheck : PASS
PortCheck : FAIL
2021-01-25T16:42:48.903+0530	FATAL	Node not ready. See verbose logs for more
```