### PR TITLE
rename context to config

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -4,11 +4,12 @@ package cmd
 
 import (
 	"fmt"
-	"go.uber.org/zap"
+
+	"github.com/platform9/pf9ctl/pkg/cmdexec"
 	"github.com/platform9/pf9ctl/pkg/pmk"
 	"github.com/platform9/pf9ctl/pkg/qbert"
-	"github.com/platform9/pf9ctl/pkg/cmdexec"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
 // bootstrapCmd represents the bootstrap command
@@ -44,9 +45,9 @@ var (
 func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 	zap.S().Debug("Received a call to bootstrap the node")
 
-	ctx, err := pmk.LoadContext(Pf9DBLoc)
+	ctx, err := pmk.LoadConfig(Pf9DBLoc)
 	if err != nil {
-		zap.S().Fatalf("Unable to load context: %s", err.Error())
+		zap.S().Fatalf("Unable to load config: %s", err.Error())
 	}
 
 	c, err := pmk.NewClient(ctx.Fqdn, cmdexec.LocalExecutor{}, ctx.AllowInsecure, false)

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -3,15 +3,15 @@
 package cmd
 
 import (
-	"go.uber.org/zap"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
 // clusterCmdGet represents the cluster get command
 var clusterCmdGet = &cobra.Command{
 	Use:   "cluster",
 	Short: "Display one or many clusters",
-	Long: `Query your controller using the current context and list
+	Long: `Query your controller using the current config and list
 	 the clusters`,
 	Run: func(cmd *cobra.Command, args []string) {
 		zap.S().Info("Get cluster called")

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -15,15 +15,15 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-// contextCmdCreate represents the context command
-var contextCmdCreate = &cobra.Command{
-	Use:   "context",
-	Short: "Create a new context",
-	Long:  `Create a new context that can be used to query Platform9 controller`,
-	Run:   contextCmdCreateRun,
+// configCmdCreate represents the config command
+var configCmdCreate = &cobra.Command{
+	Use:   "config",
+	Short: "Create a new config",
+	Long:  `Create a new config that can be used to query Platform9 controller`,
+	Run:   configCmdCreateRun,
 }
 
-func contextCmdCreateRun(cmd *cobra.Command, args []string) {
+func configCmdCreateRun(cmd *cobra.Command, args []string) {
 	reader := bufio.NewReader(os.Stdin)
 
 	fmt.Printf("Platform9 Account URL: ")
@@ -54,7 +54,7 @@ func contextCmdCreateRun(cmd *cobra.Command, args []string) {
 		service = "service"
 	}
 
-	ctx := pmk.Context{
+	ctx := pmk.Config{
 		Fqdn:          fqdn,
 		Username:      username,
 		Password:      password,
@@ -64,24 +64,24 @@ func contextCmdCreateRun(cmd *cobra.Command, args []string) {
 		AllowInsecure: false,
 	}
 
-	if err := pmk.StoreContext(ctx, Pf9DBLoc); err != nil {
-		zap.S().Errorf("Failed to store context: %s", err.Error())
+	if err := pmk.StoreConfig(ctx, Pf9DBLoc); err != nil {
+		zap.S().Errorf("Failed to store config: %s", err.Error())
 	}
 }
 
-var contextCmdGet = &cobra.Command{
+var configCmdGet = &cobra.Command{
 	Use:   "get",
-	Short: "Print stored context",
-	Long:  `Print details of the stored context`,
+	Short: "Print stored config",
+	Long:  `Print details of the stored config`,
 	Run: func(cmd *cobra.Command, args []string) {
 		_, err := os.Stat(Pf9DBLoc)
 		if err != nil || os.IsNotExist(err) {
-			zap.S().Fatal("Could not load context: ", err)
+			zap.S().Fatal("Could not load config: ", err)
 		}
 
 		file, err := os.Open(Pf9DBLoc)
 		if err != nil {
-			zap.S().Fatal("Could not load context: ", err)
+			zap.S().Fatal("Could not load config: ", err)
 		}
 		defer func() {
 			if err = file.Close(); err != nil {
@@ -91,7 +91,7 @@ var contextCmdGet = &cobra.Command{
 
 		data, err := ioutil.ReadAll(file)
 		if err != nil {
-			zap.S().Fatal("Could not load context: ", err)
+			zap.S().Fatal("Could not load config: ", err)
 		}
 
 		fmt.Printf(string(data))
@@ -99,6 +99,6 @@ var contextCmdGet = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(contextCmdCreate)
-	contextCmdCreate.AddCommand(contextCmdGet)
+	rootCmd.AddCommand(configCmdCreate)
+	configCmdCreate.AddCommand(configCmdGet)
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -18,9 +18,8 @@ import (
 // configCmdCreate represents the config command
 var configCmdCreate = &cobra.Command{
 	Use:   "config",
-	Short: "Create a new config",
-	Long:  `Create a new config that can be used to query Platform9 controller`,
-	Run:   configCmdCreateRun,
+	Short: "Create or get config",
+	Long:  `Create or get PF9 controller config used by this CLI`,
 }
 
 func configCmdCreateRun(cmd *cobra.Command, args []string) {
@@ -98,7 +97,15 @@ var configCmdGet = &cobra.Command{
 	},
 }
 
+var configCmdSet = &cobra.Command{
+	Use:   "set",
+	Short: "Create a new config",
+	Long:  `Create a new config that can be used to query Platform9 controller`,
+	Run:   configCmdCreateRun,
+}
+
 func init() {
 	rootCmd.AddCommand(configCmdCreate)
 	configCmdCreate.AddCommand(configCmdGet)
+	configCmdCreate.AddCommand(configCmdSet)
 }

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -14,9 +14,9 @@ var (
 	Pf9Dir = filepath.Join(homeDir, "pf9")
 	//Pf9LogDir is the base path for creating log dir
 	Pf9LogDir = filepath.Join(Pf9Dir, "log")
-	// Pf9DBDir is the base dir for storing pf9 db context
+	// Pf9DBDir is the base dir for storing pf9 db config
 	Pf9DBDir = filepath.Join(Pf9Dir, "db")
-	// Pf9DBLoc represents location of the context file.
+	// Pf9DBLoc represents location of the config file.
 	Pf9DBLoc = filepath.Join(Pf9DBDir, "config.json")
 	// Pf9Log represents location of the log.
 	Pf9Log = filepath.Join(Pf9LogDir, "pf9ctl.log")

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -3,15 +3,15 @@
 package cmd
 
 import (
-	"go.uber.org/zap"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
 // createCmd represents the create command
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a resource",
-	Long: `Use the create command to create cluster, context, support bundle and
+	Long: `Use the create command to create cluster, config, support bundle and
 	other resources`,
 	Run: func(cmd *cobra.Command, args []string) {
 		zap.S().Info("Create called")

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -40,9 +40,9 @@ func init() {
 
 func prepNodeRun(cmd *cobra.Command, args []string) {
 
-	ctx, err := pmk.LoadContext(Pf9DBLoc)
+	ctx, err := pmk.LoadConfig(Pf9DBLoc)
 	if err != nil {
-		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
+		zap.S().Fatalf("Unable to load the config: %s\n", err.Error())
 	}
 	// TODO: there seems to be a bug, we will need multiple executors one per ip, so at this moment
 	// it will only work with one remote host

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -9,7 +9,7 @@ import (
 // useCmd represents the use command
 var useCmd = &cobra.Command{
 	Use:   "use",
-	Short: "Use a specific context",
+	Short: "Use a specific config",
 	// Run: func(cmd *cobra.Command, args []string) {
 	// 	log.Info("Use called")
 	// },

--- a/pkg/pmk/cluster.go
+++ b/pkg/pmk/cluster.go
@@ -6,14 +6,15 @@ import (
 	"fmt"
 	"strings"
 	"time"
-	"go.uber.org/zap"
+
 	"github.com/platform9/pf9ctl/pkg/qbert"
 	"github.com/platform9/pf9ctl/pkg/util"
+	"go.uber.org/zap"
 )
 
 // Bootstrap simply preps the local node and attach it as master to a newly
 // created cluster.
-func Bootstrap(ctx Context, c Client, req qbert.ClusterCreateRequest) error {
+func Bootstrap(ctx Config, c Client, req qbert.ClusterCreateRequest) error {
 	zap.S().Debug("Received a call to boostrap the local node")
 
 	resp, err := util.AskBool("Prep local node for kubernetes cluster")

--- a/pkg/pmk/config.go
+++ b/pkg/pmk/config.go
@@ -10,20 +10,20 @@ import (
 	"go.uber.org/zap"
 )
 
-// Context stores information to contact with the pf9 controller.
-type Context struct {
+// Config stores information to contact with the pf9 controller.
+type Config struct {
 	Fqdn          string        `json:"fqdn"`
-	Username      string        `json:"os_username"`
-	Password      string        `json:"os_password"`
-	Tenant        string        `json:"os_tenant"`
-	Region        string        `json:"os_region"`
+	Username      string        `json:"username"`
+	Password      string        `json:"password"`
+	Tenant        string        `json:"tenant"`
+	Region        string        `json:"region"`
 	WaitPeriod    time.Duration `json:"wait_period"`
 	AllowInsecure bool          `json:"allow_insecure"`
 }
 
-// StoreContext simply updates the in-memory object
-func StoreContext(ctx Context, loc string) error {
-	zap.S().Info("Storing context")
+// StoreConfig simply updates the in-memory object
+func StoreConfig(ctx Config, loc string) error {
+	zap.S().Info("Storing config")
 	// obscure the password
 	ctx.Password = base64.StdEncoding.EncodeToString([]byte(ctx.Password))
 	f, err := os.Create(loc)
@@ -37,22 +37,22 @@ func StoreContext(ctx Context, loc string) error {
 	return encoder.Encode(ctx)
 }
 
-// LoadContext returns the information for communication with PF9 controller.
-func LoadContext(loc string) (Context, error) {
-	zap.S().Info("Loading context...")
+// LoadConfig returns the information for communication with PF9 controller.
+func LoadConfig(loc string) (Config, error) {
+	zap.S().Info("Loading config...")
 
 	f, err := os.Open(loc)
 	if err != nil {
 
 		if os.IsNotExist(err) {
-			return Context{}, errors.New("Context absent")
+			return Config{}, errors.New("Config absent")
 		}
-		return Context{}, err
+		return Config{}, err
 	}
 
 	defer f.Close()
 
-	ctx := Context{WaitPeriod: time.Duration(60), AllowInsecure: false}
+	ctx := Config{WaitPeriod: time.Duration(60), AllowInsecure: false}
 	err = json.NewDecoder(f).Decode(&ctx)
 	// decode the password
 	// Decoding base64 encoded password

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -4,18 +4,17 @@ package pmk
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
-	"regexp"
 
-	"go.uber.org/zap"
-	"github.com/platform9/pf9ctl/pkg/keystone"
 	"github.com/platform9/pf9ctl/pkg/cmdexec"
-
+	"github.com/platform9/pf9ctl/pkg/keystone"
+	"go.uber.org/zap"
 )
 
 // PrepNode sets up prerequisites for k8s stack
-func PrepNode(ctx Context, allClients Client) error {
+func PrepNode(ctx Config, allClients Client) error {
 
 	zap.S().Debug("Received a call to start preping node(s).")
 
@@ -70,7 +69,7 @@ func PrepNode(ctx Context, allClients Client) error {
 	return nil
 }
 
-func installHostAgent(ctx Context, auth keystone.KeystoneAuth, hostOS string, exec cmdexec.Executor) error {
+func installHostAgent(ctx Config, auth keystone.KeystoneAuth, hostOS string, exec cmdexec.Executor) error {
 	zap.S().Debug("Downloading Hostagent")
 
 	url := fmt.Sprintf("%s/clarity/platform9-install-%s.sh", ctx.Fqdn, hostOS)
@@ -95,7 +94,7 @@ func installHostAgent(ctx Context, auth keystone.KeystoneAuth, hostOS string, ex
 	}
 }
 
-func installHostAgentCertless(ctx Context, auth keystone.KeystoneAuth, hostOS string, exec cmdexec.Executor) error {
+func installHostAgentCertless(ctx Config, auth keystone.KeystoneAuth, hostOS string, exec cmdexec.Executor) error {
 	zap.S().Info("Downloading Hostagent Installer Certless")
 
 	url := fmt.Sprintf(
@@ -148,7 +147,7 @@ func validatePlatform(exec cmdexec.Executor) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("Couldn't read the OS configuration file os-release: %s", err.Error())
 		}
-		if match, _:= regexp.MatchString(`.*7\.[3-9]\.*`, string(out)); match  {
+		if match, _ := regexp.MatchString(`.*7\.[3-9]\.*`, string(out)); match {
 			return "redhat", nil
 		}
 		return "", fmt.Errorf("Unable to determine OS type: %s", string(out))
@@ -187,7 +186,7 @@ func pf9PackagesPresent(hostOS string, exec cmdexec.Executor) bool {
 	return err == nil
 }
 
-func installHostAgentLegacy(ctx Context, auth keystone.KeystoneAuth, hostOS string, exec cmdexec.Executor) error {
+func installHostAgentLegacy(ctx Config, auth keystone.KeystoneAuth, hostOS string, exec cmdexec.Executor) error {
 	zap.S().Info("Downloading Hostagent Installer Legacy")
 
 	url := fmt.Sprintf("%s/private/platform9-install-%s.sh", ctx.Fqdn, hostOS)

--- a/pkg/pmk/types.go
+++ b/pkg/pmk/types.go
@@ -7,10 +7,10 @@ type CloudProviderType string
 type CNIBackend string
 
 const (
-	// ContextFile is used to store context information
-	ContextFile string = "pf9_context.json"
-	// DefaultContextDir is the default path for context file
-	DefaultContextDir string = "~/"
+	// ConfigFile is used to store config information
+	ConfigFile string = "pf9_config.json"
+	// DefaultConfigDir is the default path for config file
+	DefaultConfigDir string = "~/"
 	// LogFile specifies the filename to which CLI logs o/p and errors
 	LogFile string = "pf9ctl.log"
 
@@ -30,4 +30,4 @@ const (
 	Weave CNIBackend = "weave"
 )
 
-// Context specifies information required to connect to the PF9 Controller
+// Config specifies information required to connect to the PF9 Controller


### PR DESCRIPTION
Renames the `context` sub-command to `config`. Also changes the related method names, variable names, etc

After the change: 

Creating config - 
```
$ pf9ctl config set
Platform9 Account URL: https://du-test-kplane-anup-3711.platform9.horse
Username: sahil@infracloud.io
Password: 
Region [RegionOne]: 
Tenant [service]: 
2021-01-21T15:10:37.980+0530	INFO	Storing config
```

Printing the config 

```
$ pf9ctl config get
{"fqdn":"https://du-test-kplane-anup-3711.platform9.horse","username":"sahil@infracloud.io","password":"c2FoaWw=","tenant":"service","region":"RegionOne","wait_period":60,"allow_insecure":false}
```