### PR TITLE
zap: log file per run

### DIFF
--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -27,6 +27,7 @@ func init() {
 }
 
 func checkNodeRun(cmd *cobra.Command, args []string) {
+	zap.S().Debug("==========Running check-node==========")
 	ctx, err := pmk.LoadConfig(Pf9DBLoc)
 	if err != nil {
 		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
@@ -46,4 +47,5 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 	if !result {
 		zap.S().Errorf("Node not ready. See %s or use --verbose for logs", Pf9Log)
 	}
+	zap.S().Debug("==========Finished running check-node==========")
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -23,6 +23,7 @@ var configCmdCreate = &cobra.Command{
 }
 
 func configCmdCreateRun(cmd *cobra.Command, args []string) {
+	zap.S().Debug("==========Running set config==========")
 	reader := bufio.NewReader(os.Stdin)
 
 	fmt.Printf("Platform9 Account URL: ")
@@ -66,6 +67,7 @@ func configCmdCreateRun(cmd *cobra.Command, args []string) {
 	if err := pmk.StoreConfig(ctx, Pf9DBLoc); err != nil {
 		zap.S().Errorf("Failed to store config: %s", err.Error())
 	}
+	zap.S().Debug("==========Finished running set config==========")
 }
 
 var configCmdGet = &cobra.Command{
@@ -73,6 +75,7 @@ var configCmdGet = &cobra.Command{
 	Short: "Print stored config",
 	Long:  `Print details of the stored config`,
 	Run: func(cmd *cobra.Command, args []string) {
+		zap.S().Debug("==========Running get config==========")
 		_, err := os.Stat(Pf9DBLoc)
 		if err != nil || os.IsNotExist(err) {
 			zap.S().Fatal("Could not load config: ", err)
@@ -94,6 +97,7 @@ var configCmdGet = &cobra.Command{
 		}
 
 		fmt.Printf(string(data))
+		zap.S().Debug("==========Finished running get config==========")
 	},
 }
 

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -41,7 +41,7 @@ func init() {
 }
 
 func prepNodeRun(cmd *cobra.Command, args []string) {
-
+	zap.S().Debug("==========Running prep-node==========")
 	ctx, err := pmk.LoadConfig(Pf9DBLoc)
 	if err != nil {
 		zap.S().Fatalf("Unable to load the config: %s\n", err.Error())
@@ -61,6 +61,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 		c.Segment.SendEvent("Prep Node - Failed", err)
 		zap.S().Fatalf("Unable to prep node: %s\n", err.Error())
 	}
+	zap.S().Debug("==========Finished running prep-node==========")
 }
 
 // checkAndValidateRemote check if any of the command line

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -3,18 +3,21 @@ package log
 import (
 	"fmt"
 	"os"
+	"strings"
+	"time"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
-
 
 // ConfigureGlobalLog global uber zap logger, there are two modes possible.
 // the very first one is debug or not, used by CLI a debug mode is fantastic way
 // to print more information and a logFile where the logs would be saved
 func ConfigureGlobalLog(debug bool, logFile string) error {
 
+	runLogLocation := fmt.Sprintf("%s-%s.%s", logFile[:strings.LastIndex(logFile, ".")], time.Now().Format("2006010-2150405"), logFile[strings.LastIndex(logFile, ".")+1:])
 	// If the file doesn't exist, create it, or append to the file
-	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(runLogLocation, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("Couldn't open the log file: %s. \nError is: %s", logFile, err.Error())
 	}
@@ -34,7 +37,7 @@ func ConfigureGlobalLog(debug bool, logFile string) error {
 	// Create custom zap config
 	core := zapcore.NewTee(
 		zapcore.NewCore(zapcore.NewConsoleEncoder(setCustomConfig()), consoleLogs, lvl),
-		zapcore.NewCore(zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), fileLogs, zap.DebugLevel),
+		zapcore.NewCore(zapcore.NewJSONEncoder(setCustomConfig()), fileLogs, zap.DebugLevel),
 	)
 
 	logger := zap.New(core, zap.AddCaller(), zap.AddCallerSkip(1))
@@ -50,6 +53,8 @@ func setCustomConfig() zapcore.EncoderConfig {
 		TimeKey:     "ts",
 		MessageKey:  "msg",
 		EncodeLevel: zapcore.CapitalLevelEncoder,
-		EncodeTime:  zapcore.ISO8601TimeEncoder,
+		EncodeTime: zapcore.TimeEncoder(func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+			enc.AppendString(t.UTC().Format("2006-01-02T15:04:05.9999Z"))
+		}),
 	}
 }


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>

Create a new log file on each run, with the format: `pf9ctl-YYYYMMDD-HHMMSS.log`


Change the time in log statements to UTC and to format: `2021-02-03T10:30:14.5678Z`