### PR TITLE
fix port check for remote nodes

### DIFF
--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -136,7 +136,16 @@ func (c *CentOS) checkDisk() (bool, error) {
 }
 
 func (c *CentOS) checkPort() (bool, error) {
-	openPorts, err := c.exec.RunWithStdout("bash", "-c", "netstat -tupna | awk '{print $4}' | sed -e 's/.*://' | sort | uniq")
+	var arg string
+
+	switch c.exec.(type) {
+	case cmdexec.LocalExecutor:
+		arg = "netstat -tupna | awk '{print $4}' | sed -e 's/.*://' | sort | uniq"
+	case *cmdexec.RemoteExecutor:
+		arg = "netstat -tupna | awk '{print \\$4}' | sed -e 's/.*://' | sort | uniq"
+	}
+
+	openPorts, err := c.exec.RunWithStdout("bash", "-c", arg)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -138,6 +138,9 @@ func (c *CentOS) checkDisk() (bool, error) {
 func (c *CentOS) checkPort() (bool, error) {
 	var arg string
 
+	// For remote execution the command is wrapped under quotes ("") which creates
+	// problems for the awk command. To resolve this, $4 is escaped.
+	// Tweaks like this can be prevented by modifying the remote executor.
 	switch c.exec.(type) {
 	case cmdexec.LocalExecutor:
 		arg = "netstat -tupna | awk '{print $4}' | sed -e 's/.*://' | sort | uniq"

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -139,6 +139,9 @@ func (d *Debian) checkDisk() (bool, error) {
 func (d *Debian) checkPort() (bool, error) {
 	var arg string
 
+	// For remote execution the command is wrapped under quotes ("") which creates
+	// problems for the awk command. To resolve this, $4 is escaped.
+	// Tweaks like this can be prevented by modifying the remote executor.
 	switch d.exec.(type) {
 	case cmdexec.LocalExecutor:
 		arg = "netstat -tupna | awk '{print $4}' | sed -e 's/.*://' | sort | uniq"

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -137,7 +137,16 @@ func (d *Debian) checkDisk() (bool, error) {
 }
 
 func (d *Debian) checkPort() (bool, error) {
-	openPorts, err := d.exec.RunWithStdout("bash", "-c", "netstat -tupna | awk '{print $4}' | sed -e 's/.*://' | sort | uniq")
+	var arg string
+
+	switch d.exec.(type) {
+	case cmdexec.LocalExecutor:
+		arg = "netstat -tupna | awk '{print $4}' | sed -e 's/.*://' | sort | uniq"
+	case *cmdexec.RemoteExecutor:
+		arg = "netstat -tupna | awk '{print \\$4}' | sed -e 's/.*://' | sort | uniq"
+	}
+
+	openPorts, err := d.exec.RunWithStdout("bash", "-c", arg)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>


Modifies a different command for port check with remote executor.
The difference is that that while running the command with sshclient, it is wrapped by `""` hence the input to awk is to be escaped.

The executor should be refactored in future to avoid such things.