### PR TITLE
FT-22, FT-28: Prompt password if not specified, fix config failure log

### DIFF
--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -3,12 +3,14 @@
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"github.com/platform9/pf9ctl/pkg/cmdexec"
 	"github.com/platform9/pf9ctl/pkg/pmk"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // prepNodeCmd represents the prepNode command
@@ -68,7 +70,9 @@ func checkAndValidateRemote() bool {
 		if ip != "localhost" && ip != "127.0.0.1" && ip != "::1" {
 			// lets create a remote executor, but before that check if we got user and either of password or ssh-key
 			if user == "" || (sshKey == "" && password == "") {
-				zap.S().Fatalf("please provider 'user' and one of 'password' or ''ssh-key'")
+				fmt.Printf("Password: ")
+				passwordBytes, _ := terminal.ReadPassword(0)
+				password = string(passwordBytes)
 			}
 			foundRemote = true
 			return foundRemote

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -70,7 +70,7 @@ func checkAndValidateRemote() bool {
 		if ip != "localhost" && ip != "127.0.0.1" && ip != "::1" {
 			// lets create a remote executor, but before that check if we got user and either of password or ssh-key
 			if user == "" || (sshKey == "" && password == "") {
-				fmt.Printf("Password: ")
+				fmt.Printf("Enter Password: ")
 				passwordBytes, _ := terminal.ReadPassword(0)
 				password = string(passwordBytes)
 			}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.6.7
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/sftp v1.12.0
-	github.com/prometheus/common v0.4.0 // indirect
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
 	github.com/sethgrid/pester v1.1.0 // indirect
 	github.com/spf13/cobra v1.0.0

--- a/pkg/pmk/config.go
+++ b/pkg/pmk/config.go
@@ -45,7 +45,7 @@ func LoadConfig(loc string) (Config, error) {
 	if err != nil {
 
 		if os.IsNotExist(err) {
-			return Config{}, errors.New("Config absent")
+			return Config{}, errors.New("Config absent, run `sudo pf9ctl config set`")
 		}
 		return Config{}, err
 	}


### PR DESCRIPTION
Testing done:

When password is not passed, it is prompted:

`# bin/pf9ctl prep-node -i 10.128.242.185 -u ubuntu
2021-02-05T05:37:14.398Z	INFO	Loading config...
Password:`

When config is not set, log message displayed is more verbose.

`# bin/pf9ctl prep-node
2021-02-05T05:38:28.037Z	INFO	Loading config...
2021-02-05T05:38:28.037Z	FATAL	Unable to load the config: Config absent, run `sudo pf9ctl config set``



Teamcity Run: #11 
Link: http://teamcity.platform9.horse:8111/buildConfiguration/Pf9project_Platform9Components_Pf9ctl/1422702
