### PR TITLE
FT: 24 : Wrapper script to download the CLI

### DIFF
--- a/cli_setup.sh
+++ b/cli_setup.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+set -o pipefail
+
+start_time=$(date +"%s.%N")
+
+assert() {
+    if [ $# -gt 0 ]; then stdout_log "ASSERT: ${1}"; fi
+    if [[ -f ${log_file} ]]; then
+        echo -e "\n\n"
+	echo ""
+	echo "Installation failed, Here are the last 10 lines from the log"
+	echo "The full installation log is available at ${log_file}"
+	echo "If more information is needed re-run the install with --debug"
+	echo "$(tail ${log_file})"
+    else
+	echo "Installation failed prior to log file being created"
+	echo "Try re-running with --debug"
+	echo "Installation instructions: https://docs.platform9.com/kubernetes/PMK-CLI/#installation"
+    fi
+    exit 1
+}
+
+debugging() {
+    # This function handles formatting all debugging text.
+    # debugging is always sent to the logfile.
+    # If no debug flag, this function will silently log debugging messages.
+    # If debug flag is present then debug output will be formatted then echo'd to stdout and sent to logfile.
+    # If debug flag is present messages sent to stdout_log will be forwarded to debugging for consistancy.
+
+    # Avoid error if bc is not installed yet
+    if (which bc > /dev/null 2>&1); then
+	output="$(date +"%T")$(bc <<<$(date +"%s.%N")-${start_time}) :$(basename $0) : ${1}"
+    else
+	output="$(date +"%T"):$(basename $0) : ${1}"
+    fi
+
+    if [ -f "${log_file}" ]; then
+	echo "${output}" 2>&1 >> ${log_file}
+    fi
+    echo "${output}"
+}
+
+stdout_log() {
+    echo "$1"
+    debugging "$1"
+}
+
+initialize_basedir() {
+    debugging "Initializing: ${pf9_basedir}"
+    for dir in ${pf9_state_dirs}; do
+	debugging "Ensuring ${dir} exists"
+        if ! mkdir -p "${dir}" > /dev/null 2>&1; then assert "Failed to create directory: ${dir}"; fi
+    done
+    debugging "Ensuring ${log_file} exists"
+    if ! mkdir -p "${dir}" > /dev/null 2>&1; then assert "Failed to create directory: ${dir}"; fi
+    if ! touch "${log_file}" > /dev/null 2>&1; then assert "failed to create log file: ${log_file}"; fi
+}
+
+refresh_symlink() {
+    # Create symlink in /usr/bin
+    if [ -L /usr/bin/pf9ctl ]; then
+	if ! (sudo rm /usr/bin/pf9ctl >> ${log_file} 2>&1); then
+		assert "Failed to remove existing symlink: ${cli_exec}"; fi
+	fi
+    if ! (sudo ln -s ${cli_exec} /usr/bin/pf9ctl >> ${log_file} 2>&1); then
+	    assert "Failed to create Platform9 CLI symlink in /usr/bin"; fi
+}
+
+check_installation() {
+    if ! (${cli_exec} --help >> ${log_file} 2>&1); then
+	assert "Installation of Platform9 CLI Failed"; fi
+}
+
+download_cli_binary() {
+	sudo rm ${cli_exec}
+	cd ${pf9_bin} && sudo curl -O ${cli_path} -o ${log_file} 2>&1 && cd -
+	sudo chmod 555 ${cli_exec}
+}
+
+##main
+
+echo ""
+stdout_log "** SUDO REQUIRED FOR ALL COMMANDS **"
+stdout_log "Why is SUDO required?: The CLI performs operations like installing packages and configuring services. These require SUDO privileges to run successfully."
+echo ""
+
+pf9_basedir=$(dirname ~/pf9/.)
+log_file=${pf9_basedir}/log/cli_install.log
+pf9_bin=${pf9_basedir}/bin
+pf9_state_dirs="${pf9_bin} ${pf9_basedir}/db ${pf9_basedir}/log"
+cli_exec=${pf9_bin}/pf9ctl
+cli_path="https://artifactory.platform9.horse:443/artifactory/pf9-bins/pf9-ctl/pf9ctl"
+
+initialize_basedir
+download_cli_binary
+refresh_symlink
+check_installation
+
+echo ""
+stdout_log "Platform9 CLI installation completed successfully"
+echo "To start building a Kubernetes cluster execute:"
+echo "        ${cli_exec} help"
+echo ""
+eval "${cli_exec}" help


### PR DESCRIPTION
This is a wrapper script that will be used to 
- download the GoCLI binary 
- place it in a well known path
- set it's appropriate executable permissions.

This will be eventually hosted at a well known place and the link will be inserted in the UI in the node-onboarding page.

TC build : Not required, new script.

**Testing done:**

$ bash setup.sh

** SUDO REQUIRED FOR ALL COMMANDS **
12:47:30.008116825 :setup.sh : ** SUDO REQUIRED FOR ALL COMMANDS **
Why is SUDO required?: The CLI performs operations like installing packages and configuring services. These require SUDO privileges to run successfully.
12:47:30.019998110 :setup.sh : Why is SUDO required?: The CLI performs operations like installing packages and configuring services. These require SUDO privileges to run successfully.

12:47:30.031849500 :setup.sh : Initializing: /home/ubuntu/pf9
12:47:30.041526695 :setup.sh : Ensuring /home/ubuntu/pf9/bin exists
12:47:30.053806477 :setup.sh : Ensuring /home/ubuntu/pf9/db exists
12:47:30.066747491 :setup.sh : Ensuring /home/ubuntu/pf9/log exists
12:47:30.079611174 :setup.sh : Ensuring /home/ubuntu/pf9/log/cli_install.log exists
rm: cannot remove '/home/ubuntu/pf9/bin/pf9ctl': No such file or directory
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 13.0M  100 13.0M    0     0  57.8M      0 --:--:-- --:--:-- --:--:-- 57.8M
/home/ubuntu

Platform9 CLI installation completed successfully
12:47:31.448979844 :setup.sh : Platform9 CLI installation completed successfully
To start building a Kubernetes cluster you can execute:
        /home/ubuntu/pf9/bin/pf9ctl help

CLI tool for Platform9 management.
	Platform9 Managed Kubernetes cluster operations. Read more at
	http://pf9.io/cli_clhelp.

Usage:
  pf9ctl [command]

Available Commands:
  bootstrap   Create a single node k8s cluster with your current node
  check-node  Check prerequisites for k8s
  config      Create or get config
  create      Create a resource
  get         Display one or many resources
  help        Help about any command
  prep-node   set up prerequisites & prep the node for k8s
  version     A brief description of your command

Flags:
      --config string   config file (default is $HOME/.pf9ctl.yaml)
  -h, --help            help for pf9ctl
  -t, --toggle          Help message for toggle
      --verbose         print verbose logs

Additional help topics:
  pf9ctl use        Use a specific config

Use "pf9ctl [command] --help" for more information about a command.
$ which pf9ctl
/usr/bin/pf9ctl