### PR TITLE
dpk/yum fail fix

### DIFF
--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -51,7 +51,7 @@ func (c *CentOS) Check() []platform.Check {
 
 func (c *CentOS) checkPackages() (bool, error) {
 	var err error
-	err = c.exec.Run("bash", "-c", "yum list installed | grep -i 'pf9-'")
+	err = c.exec.Run("bash", "-c", "yum list installed | { grep -i 'pf9-' || true; }")
 
 	return !(err == nil), nil
 }

--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -50,10 +50,13 @@ func (c *CentOS) Check() []platform.Check {
 }
 
 func (c *CentOS) checkPackages() (bool, error) {
-	var err error
-	err = c.exec.Run("bash", "-c", "yum list installed | { grep -i 'pf9-' || true; }")
 
-	return !(err == nil), nil
+	out, err := c.exec.RunWithStdout("bash", "-c", "yum list installed | { grep -i 'pf9-' || true; }")
+	if err != nil {
+		return false, nil
+	}
+
+	return out == "", nil
 }
 
 func (c *CentOS) checkSudo() (bool, error) {
@@ -171,6 +174,6 @@ func (c *CentOS) removePyCli() (bool, error) {
 		return false, err
 	}
 	zap.S().Debug("Removed Python CLI directory")
-	
+
 	return true, nil
 }

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -52,8 +52,7 @@ func (d *Debian) Check() []platform.Check {
 func (d *Debian) checkPackages() (bool, error) {
 
 	var err error
-	err = d.exec.Run("bash", "-c", "dpkg -l | grep -i 'pf9-'")
-
+	err = d.exec.Run("bash", "-c", "dpkg -l | { grep -i 'pf9-' || true; }")
 	return !(err == nil), nil
 }
 

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -51,9 +51,12 @@ func (d *Debian) Check() []platform.Check {
 
 func (d *Debian) checkPackages() (bool, error) {
 
-	var err error
-	err = d.exec.Run("bash", "-c", "dpkg -l | { grep -i 'pf9-' || true; }")
-	return !(err == nil), nil
+	out, err := d.exec.RunWithStdout("bash", "-c", "dpkg -l | { grep -i 'pf9-' || true; }")
+	if err != nil {
+		return false, err
+	}
+
+	return out == "", nil
 }
 
 func (d *Debian) checkSudo() (bool, error) {

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -174,13 +174,13 @@ func pf9PackagesPresent(hostOS string, exec cmdexec.Executor) bool {
 	if hostOS == "debian" {
 		err = exec.Run("bash",
 			"-c",
-			"dpkg -l | grep -i 'pf9-'")
+			"dpkg -l | { grep -i 'pf9-' || true; }")
 	} else {
 		// not checking for redhat because if it has already passed validation
 		// it must be either debian or redhat based
 		err = exec.Run("bash",
 			"-c",
-			"yum list installed | grep -i 'pf9-'")
+			"yum list installed | { grep -i 'pf9-' || true; }")
 	}
 
 	return err == nil

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -170,20 +170,22 @@ func validatePlatform(exec cmdexec.Executor) (string, error) {
 }
 
 func pf9PackagesPresent(hostOS string, exec cmdexec.Executor) bool {
-	var err error
+	var out string
 	if hostOS == "debian" {
-		err = exec.Run("bash",
+		out, _ = exec.RunWithStdout("bash",
 			"-c",
 			"dpkg -l | { grep -i 'pf9-' || true; }")
 	} else {
 		// not checking for redhat because if it has already passed validation
 		// it must be either debian or redhat based
-		err = exec.Run("bash",
+		out, _ = exec.RunWithStdout("bash",
 			"-c",
 			"yum list installed | { grep -i 'pf9-' || true; }")
 	}
 
-	return err == nil
+	fmt.Println(">>", out)
+
+	return !(out == "")
 }
 
 func installHostAgentLegacy(ctx Config, auth keystone.KeystoneAuth, hostOS string, exec cmdexec.Executor) error {


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>

The command `dpkg -l | grep -i 'pf9'` returns exit code 1 if there's no match found. This creates an impression the command itslef failed. This PR fixes that.

Remote check-node execution
```
$ ./pf9ctl check-node -i 10.128.243.10 -s ~/.ssh/sahil -u ubuntu 
2021-02-09T13:47:21.9176Z	INFO	Loading config...
Python CLI Removal : PASS
Existing Installation Check : PASS
SudoCheck : PASS
CPUCheck : PASS
DiskCheck : FAIL
MemoryCheck : PASS
PortCheck : PASS
2021-02-09T13:47:31.4944Z	ERROR	Node not ready. See /home/sahil/pf9/log/pf9ctl.log or use --verbose for logs
```