### PR TITLE
Added segment events to the check-node path.

### DIFF
--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -42,7 +42,10 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Unable to load clients needed for the Cmd. Error: %s", err.Error())
 	}
 
-	result := pmk.CheckNode(c)
+	result, err := pmk.CheckNode(ctx, c)
+	if err != nil {
+		zap.S().Fatalf("Unable to perform pre-requisite checks on this node. Error: %s", err.Error())
+	}
 
 	if !result {
 		zap.S().Errorf("Node not ready. See %s or use --verbose for logs", Pf9Log)

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -43,20 +43,20 @@ func CheckNode(ctx Config, allClients Client) (bool, error) {
 	)
 
 	if err != nil {
-		return false, fmt.Errorf("Unable to locate keystone credentials: %s", err.Error())
+		return false, fmt.Errorf("Unable to obtain keystone credentials: %s", err.Error())
 	}
 
 	checks := platform.Check()
 	result := true
 	for _, check := range checks {
 		if check.Result {
-			segment_str := "Check Node: " + check.Name + " Status: " + checkPass
+			segment_str := "CheckNode: " + check.Name + " Status: " + checkPass
 			if err := allClients.Segment.SendEvent(segment_str, auth); err != nil {
 				zap.S().Errorf("Unable to send Segment event for check node. Error: %s", err.Error())
 			}
 			fmt.Printf("%s : %s\n", check.Name, checkPass)
 		} else {
-			segment_str := "Check Node: " + check.Name + " Status: " + checkFail
+			segment_str := "CheckNode: " + check.Name + " Status: " + checkFail
 			if err := allClients.Segment.SendEvent(segment_str, auth); err != nil {
 				zap.S().Errorf("Unable to send Segment event for check node. Error: %s", err.Error())
 			}

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -17,13 +17,13 @@ const (
 )
 
 // CheckNode checks the prerequisites for k8s stack
-func CheckNode(allClients Client) bool {
+func CheckNode(ctx Config, allClients Client) (bool, error) {
 
 	zap.S().Debug("Received a call to check node.")
 
 	os, err := validatePlatform(allClients.Executor)
 	if err != nil {
-		return false
+		return false, err
 	}
 
 	var platform platform.Platform
@@ -34,21 +34,43 @@ func CheckNode(allClients Client) bool {
 		platform = centos.NewCentOS(allClients.Executor)
 	}
 
+	// Fetch the keystone token.
+	// This is used as a reference to the segment event.
+	auth, err := allClients.Keystone.GetAuth(
+		ctx.Username,
+		ctx.Password,
+		ctx.Tenant,
+	)
+
+	if err != nil {
+		return false, fmt.Errorf("Unable to locate keystone credentials: %s", err.Error())
+	}
+
 	checks := platform.Check()
 	result := true
 	for _, check := range checks {
 		if check.Result {
+			segment_str := "Check Node: " + check.Name + " Status: " + checkPass
+			if err := allClients.Segment.SendEvent(segment_str, auth); err != nil {
+				zap.S().Errorf("Unable to send Segment event for check node. Error: %s", err.Error())
+			}
 			fmt.Printf("%s : %s\n", check.Name, checkPass)
 		} else {
+			segment_str := "Check Node: " + check.Name + " Status: " + checkFail
+			if err := allClients.Segment.SendEvent(segment_str, auth); err != nil {
+				zap.S().Errorf("Unable to send Segment event for check node. Error: %s", err.Error())
+			}
 			fmt.Printf("%s : %s\n", check.Name, checkFail)
 			result = false
 		}
 
 		if check.Err != nil {
-			zap.S().Debugf("Error in %s : %s", check.Name, err)
+			zap.S().Debugf("Error in %s : %s", check.Name, check.Err)
 			result = false
 		}
 	}
 
-	return result
+	// Segment events get posted from it's queue only after closing the client.
+	allClients.Segment.Close()
+	return result, nil
 }

--- a/pkg/pmk/segment.go
+++ b/pkg/pmk/segment.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 	"gopkg.in/segmentio/analytics-go.v3"
 )
 
@@ -23,9 +24,7 @@ type SegmentImpl struct {
 }
 
 type NoopSegment struct {
-
 }
-
 
 func NewSegment(fqdn string, noTracking bool) Segment {
 	// mock out segment if the user wants no Tracking
@@ -41,6 +40,7 @@ func NewSegment(fqdn string, noTracking bool) Segment {
 }
 
 func (c SegmentImpl) SendEvent(name string, data interface{}) error {
+	zap.S().Debug("Sending Segment Event: %s", name)
 	return c.client.Enqueue(analytics.Track{
 		AnonymousId: uuid.New().String(),
 		Event:       name,
@@ -65,7 +65,6 @@ func (c SegmentImpl) SendGroupTraits(name string, data interface{}) error {
 func (c SegmentImpl) Close() {
 	c.client.Close()
 }
-
 
 // The Noop Implementation of Segment
 func (c NoopSegment) SendEvent(name string, data interface{}) error {


### PR DESCRIPTION
This patch adds segment events to the check-node code path.

Following is the snippet of an event seen in the segment debugger:

Success case:

client.Track(&analytics.Track{
  AnonymousId: "574de189-24b8-4869-a4f3-789682d68f62",
  Event: "Check Node: MemoryCheck Status: PASS",
  Properties: map[string]interface{}{
    "data": map[string]interface{}{
      "ProjectID": "1fc864503b2c4439bca59e8fa8c07be8",
      "Token": "g***-8***-K***-Z***_A***-p***",
      "UserID": "bc8afb54b3ca464bb9bf6de204d8f585",
    },
  },
})

Failure case:

client.Track(&analytics.Track{
  AnonymousId: "8e8ff06f-bd8d-489a-9128-8743c3c18316",
  Event: "Check Node: DiskCheck Status: FAIL",
  Properties: map[string]interface{}{
    "data": map[string]interface{}{
      "ProjectID": "1fc864503b2c4439bca59e8fa8c07be8",
      "Token": "g***-8***-K***-Z***_A***-p***",
      "UserID": "bc8afb54b3ca464bb9bf6de204d8f585",
    },
  },
})


Note: Here, the UserID is the keystone ID which would enable to map all these requests against a particular user.


Teamcity build link : http://teamcity.platform9.horse:8111/buildConfiguration/Pf9project_Platform9Components_Pf9ctl/1435423