### PR TITLE
FT-27: Added docs link as part of error message.

### DIFF
--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -27,7 +27,11 @@ func PrepNode(ctx Config, allClients Client) error {
 
 	present := pf9PackagesPresent(hostOS, allClients.Executor)
 	if present {
-		return fmt.Errorf("Platform9 packages already present on the host. Please uninstall these packages if you want to prep the node again")
+		errStr := "\n\nPlatform9 packages already present on the host." +
+			"\nPlease uninstall these packages if you want to prep the node again.\n" +
+			"Instructions to uninstall these are at:" +
+			"\nhttps://docs.platform9.com/kubernetes/pmk-cli-unistall-hostagent"
+		return fmt.Errorf(errStr)
 	}
 
 	err = setupNode(hostOS, allClients.Executor)


### PR DESCRIPTION
Teamcity build URL: http://teamcity.platform9.horse:8111/buildConfiguration/Pf9project_Platform9Components_Pf9ctl/1435486

Testing output:
# ./bin/pf9ctl prep-node
2021-02-17T10:24:07.7231Z	INFO	Loading config...
>> ii  pf9-comms                       5.0.0-810.894d415                           amd64        Platform9 communications deb package. Built on git hash
ii  pf9-hostagent                   5.0.0-498.3e390cf                           all          Platform9 host agent
ii  pf9-kube                        4.5.0-11194                                 all          Platform9 kubernetes deb package. Built on git hash 6ec386f
ii  pf9-muster                      5.0.0-349                                   all          Platform9 Muster deb package. Built on git hash 8323d16

2021-02-17T10:24:07.7709Z	FATAL	Unable to prep node: 

Platform9 packages already present on the host.
Please uninstall these packages if you want to prep the node again.
Instructions to uninstall these are at:
https://docs.platform9.com/kubernetes/pmk-cli-unistall-hostagent
