### PR TITLE
FT:21 Detect clock skew in check node

### DIFF
--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -4,6 +4,7 @@ package pmk
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/platform9/pf9ctl/pkg/platform"
 	"github.com/platform9/pf9ctl/pkg/platform/centos"
@@ -43,6 +44,15 @@ func CheckNode(ctx Config, allClients Client) (bool, error) {
 	)
 
 	if err != nil {
+		// Certificate expiration is detected by the http library and
+		// only error object gets populated, which means that the http
+		// status code does not reflect the actual error code.
+		// So parsing the err to check for certificate expiration.
+		cert_expire_str := "certificate has expired or is not yet valid"
+		if strings.Contains(err.Error(), cert_expire_str) {
+
+			return false, fmt.Errorf("Possible clock skew detected. Check the system time and retry.")
+		}
 		return false, fmt.Errorf("Unable to obtain keystone credentials: %s", err.Error())
 	}
 

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -9,6 +9,7 @@ import (
 	"github.com/platform9/pf9ctl/pkg/platform"
 	"github.com/platform9/pf9ctl/pkg/platform/centos"
 	"github.com/platform9/pf9ctl/pkg/platform/debian"
+	"github.com/platform9/pf9ctl/pkg/util"
 	"go.uber.org/zap"
 )
 
@@ -48,8 +49,7 @@ func CheckNode(ctx Config, allClients Client) (bool, error) {
 		// only error object gets populated, which means that the http
 		// status code does not reflect the actual error code.
 		// So parsing the err to check for certificate expiration.
-		cert_expire_str := "certificate has expired or is not yet valid"
-		if strings.Contains(err.Error(), cert_expire_str) {
+		if strings.Contains(strings.ToLower(err.Error()), util.CertsExpireErr) {
 
 			return false, fmt.Errorf("Possible clock skew detected. Check the system time and retry.")
 		}

--- a/pkg/util/contants.go
+++ b/pkg/util/contants.go
@@ -33,6 +33,7 @@ var (
 	Centos = "centos"
 	Redhat = "redhat"
 	Ubuntu = "ubuntu"
+	CertsExpireErr = "certificate has expired or is not yet valid"
 )
 
 func init() {


### PR DESCRIPTION
set system date to an old date.

> date
Thu Apr 19 12:23:10 UTC 2012
> ./pf9ctl check-node
2012-04-19T12:20:46.9246Z	INFO	Loading config...
2012-04-19T12:20:47.0976Z	FATAL	Unable to perform pre-requisite checks on this node. Error: Possible clock skew detected. Check the system time and retry.

TC build:
http://teamcity.platform9.horse:8111/buildConfiguration/Pf9project_Platform9Components_Pf9ctl/1437445