### PR TITLE
removed -f flag for remote

### DIFF
--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -22,8 +22,8 @@ func init() {
 	checkNodeCmd.Flags().StringVarP(&user, "user", "u", "", "ssh username for the nodes")
 	checkNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes")
 	checkNodeCmd.Flags().StringVarP(&sshKey, "ssh-key", "s", "", "ssh key file for connecting to the nodes")
-	checkNodeCmd.Flags().StringSliceVarP(&ips, "ips", "i", []string{}, "ips of host to be prepared")
-	checkNodeCmd.Flags().BoolVarP(&floatingIP, "floating-ip", "f", false, "")
+	checkNodeCmd.Flags().StringSliceVarP(&ips, "IPs", "i", []string{}, "IPs of host to be prepared")
+	//checkNodeCmd.Flags().BoolVarP(&floatingIP, "floating-ip", "f", false, "")
 
 	rootCmd.AddCommand(checkNodeCmd)
 }

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -22,8 +22,8 @@ func init() {
 	checkNodeCmd.Flags().StringVarP(&user, "user", "u", "", "ssh username for the nodes")
 	checkNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes")
 	checkNodeCmd.Flags().StringVarP(&sshKey, "ssh-key", "s", "", "ssh key file for connecting to the nodes")
-	checkNodeCmd.Flags().StringSliceVarP(&ips, "IPs", "i", []string{}, "IPs of host to be prepared")
-	//checkNodeCmd.Flags().BoolVarP(&floatingIP, "floating-ip", "f", false, "")
+	checkNodeCmd.Flags().StringSliceVarP(&ips, "IP", "i", []string{}, "IP of host to be prepared")
+	//checkNodeCmd.Flags().BoolVarP(&floatingIP, "floating-ip", "f", false, "") //Unsupported in first version.
 
 	rootCmd.AddCommand(checkNodeCmd)
 }

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -22,7 +22,7 @@ func init() {
 	checkNodeCmd.Flags().StringVarP(&user, "user", "u", "", "ssh username for the nodes")
 	checkNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes")
 	checkNodeCmd.Flags().StringVarP(&sshKey, "ssh-key", "s", "", "ssh key file for connecting to the nodes")
-	checkNodeCmd.Flags().StringSliceVarP(&ips, "IP", "i", []string{}, "IP of host to be prepared")
+	checkNodeCmd.Flags().StringSliceVarP(&ips, "ip", "i", []string{}, "IP address of host to be prepared")
 	//checkNodeCmd.Flags().BoolVarP(&floatingIP, "floating-ip", "f", false, "") //Unsupported in first version.
 
 	rootCmd.AddCommand(checkNodeCmd)

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -34,8 +34,8 @@ func init() {
 	prepNodeCmd.Flags().StringVarP(&user, "user", "u", "", "ssh username for the nodes")
 	prepNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes")
 	prepNodeCmd.Flags().StringVarP(&sshKey, "ssh-key", "s", "", "ssh key file for connecting to the nodes")
-	prepNodeCmd.Flags().StringSliceVarP(&ips, "IPs", "i", []string{}, "IPs of host to be prepared")
-	//prepNodeCmd.Flags().BoolVarP(&floatingIP, "floating-ip", "f", false, "")
+	prepNodeCmd.Flags().StringSliceVarP(&ips, "IP", "i", []string{}, "IP of host to be prepared")
+	//prepNodeCmd.Flags().BoolVarP(&floatingIP, "floating-ip", "f", false, "") //Unsupported in first version.
 
 	rootCmd.AddCommand(prepNodeCmd)
 }

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -34,8 +34,8 @@ func init() {
 	prepNodeCmd.Flags().StringVarP(&user, "user", "u", "", "ssh username for the nodes")
 	prepNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes")
 	prepNodeCmd.Flags().StringVarP(&sshKey, "ssh-key", "s", "", "ssh key file for connecting to the nodes")
-	prepNodeCmd.Flags().StringSliceVarP(&ips, "ips", "i", []string{}, "ips of host to be prepared")
-	prepNodeCmd.Flags().BoolVarP(&floatingIP, "floating-ip", "f", false, "")
+	prepNodeCmd.Flags().StringSliceVarP(&ips, "IPs", "i", []string{}, "IPs of host to be prepared")
+	//prepNodeCmd.Flags().BoolVarP(&floatingIP, "floating-ip", "f", false, "")
 
 	rootCmd.AddCommand(prepNodeCmd)
 }

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -34,7 +34,7 @@ func init() {
 	prepNodeCmd.Flags().StringVarP(&user, "user", "u", "", "ssh username for the nodes")
 	prepNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes")
 	prepNodeCmd.Flags().StringVarP(&sshKey, "ssh-key", "s", "", "ssh key file for connecting to the nodes")
-	prepNodeCmd.Flags().StringSliceVarP(&ips, "IP", "i", []string{}, "IP of host to be prepared")
+	prepNodeCmd.Flags().StringSliceVarP(&ips, "ip", "i", []string{}, "IP address of host to be prepared")
 	//prepNodeCmd.Flags().BoolVarP(&floatingIP, "floating-ip", "f", false, "") //Unsupported in first version.
 
 	rootCmd.AddCommand(prepNodeCmd)


### PR DESCRIPTION
sudo ./pf9ctl check-node --help
Check if a node satisfies prerequisites to be ready to be added to a Kubernetes cluster. Read more
	at https://platform9.com/blog/support/managed-container-cloud-requirements-checklist/

Usage:
  pf9ctl check-node [flags]

Flags:
  -h, --help              help for check-node
  -i, --ip strings        IP address of host to be prepared
  -p, --password string   ssh password for the nodes
  -s, --ssh-key string    ssh key file for connecting to the nodes
  -u, --user string       ssh username for the nodes

Global Flags:
      --verbose   print verbose logs