### PR TITLE
Run all test cases in GitHub action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,4 +33,4 @@ jobs:
       run: go build -v .
 
     - name: Test
-      run: go test -v .
+      run: go test -v ./...


### PR DESCRIPTION
The current GitHub action executes test cases only in the root directory of this project. This PR changes it to tun all the test cases in the project.