### PR TITLE
add executorpair

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -50,7 +50,7 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Unable to load config: %s", err.Error())
 	}
 
-	c, err := pmk.NewClient(ctx.Fqdn, cmdexec.LocalExecutor{}, ctx.AllowInsecure, false)
+	c, err := pmk.NewClient(ctx.Fqdn, cmdexec.ExecutorPair{}, ctx.AllowInsecure, false)
 	if err != nil {
 		zap.S().Fatalf("Unable to load clients: %s", err.Error())
 	}

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/platform9/pf9ctl/pkg/log"
 	"github.com/platform9/pf9ctl/pkg/pmk"
 	"github.com/spf13/cobra"
@@ -35,11 +36,11 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
 	}
 
-	executor, err := getExecutor()
+	executors, err := getExecutors()
 	if err != nil {
 		zap.S().Fatalf("Error connecting to host %s", err.Error())
 	}
-	c, err := pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)
+	c, err := pmk.NewClient(ctx.Fqdn, *executors, ctx.AllowInsecure, false)
 	if err != nil {
 		zap.S().Fatalf("Unable to load clients needed for the Cmd. Error: %s", err.Error())
 	}

--- a/pkg/platform/centos/centos_test.go
+++ b/pkg/platform/centos/centos_test.go
@@ -3,6 +3,7 @@ package centos
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -59,7 +60,7 @@ func TestCPU(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			c := &CentOS{exec: tc.exec}
+			c := &CentOS{execs: cmdexec.ExecutorPair{User: tc.exec}}
 			o, err := c.checkCPU()
 
 			if diff := cmp.Diff(tc.want.err, err); diff != "" {
@@ -115,7 +116,7 @@ func TestRAM(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			c := &CentOS{exec: tc.exec}
+			c := &CentOS{execs: cmdexec.ExecutorPair{User: tc.exec}}
 			o, err := c.checkMem()
 
 			if diff := cmp.Diff(tc.want.err, err); diff != "" {
@@ -171,7 +172,7 @@ func TestDisk(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			c := &CentOS{exec: tc.exec}
+			c := &CentOS{execs: cmdexec.ExecutorPair{User: tc.exec}}
 			o, err := c.checkDisk()
 
 			if diff := cmp.Diff(tc.want.err, err); diff != "" {
@@ -196,13 +197,19 @@ func TestSudo(t *testing.T) {
 		want
 	}{
 		//Success case. User should have sudo permission.
-		//If user id == 0 then user have sudo permission.
-		//Returning 0. Therefore test case should pass.
 		"CheckPass": {
 			args: args{
 				exec: &cmdexec.MockExecutor{
 					MockRunWithStdout: func(name string, args ...string) (string, error) {
-						return "0", nil
+						if strings.Contains(args[1], "getent") {
+							return "user1,user2", nil
+						}
+
+						if strings.Contains(args[1], "echo") {
+							return "user1", nil
+						}
+
+						return "", fmt.Errorf("Invalid command")
 					},
 				},
 			},
@@ -211,12 +218,19 @@ func TestSudo(t *testing.T) {
 			},
 		},
 		//Failure case. User should have id other than zero
-		//Returning 100. Therefore test case should pass
 		"CheckFail": {
 			args: args{
 				exec: &cmdexec.MockExecutor{
 					MockRunWithStdout: func(name string, args ...string) (string, error) {
-						return "100", nil
+						if strings.Contains(args[1], "getent") {
+							return "user1,user2", nil
+						}
+
+						if strings.Contains(args[1], "echo") {
+							return "user3", nil
+						}
+
+						return "", fmt.Errorf("Invalid command")
 					},
 				},
 			},
@@ -228,7 +242,7 @@ func TestSudo(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			c := &CentOS{exec: tc.exec}
+			c := &CentOS{execs: cmdexec.ExecutorPair{User: tc.exec}}
 			o, err := c.checkSudo()
 
 			if diff := cmp.Diff(tc.want.err, err); diff != "" {
@@ -284,7 +298,7 @@ func TestPort(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			c := &CentOS{exec: tc.exec}
+			c := &CentOS{execs: cmdexec.ExecutorPair{Sudoer: tc.exec}}
 			o, err := c.checkPort()
 
 			if diff := cmp.Diff(tc.want.err, err); diff != "" {
@@ -340,7 +354,7 @@ func TestExistingInstallation(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			c := &CentOS{exec: tc.exec}
+			c := &CentOS{execs: cmdexec.ExecutorPair{User: tc.exec}}
 			o, err := c.checkExistingInstallation()
 
 			if diff := cmp.Diff(tc.want.err, err); diff != "" {
@@ -394,7 +408,7 @@ func TestOSPackages(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			c := &CentOS{exec: tc.exec}
+			c := &CentOS{execs: cmdexec.ExecutorPair{User: tc.exec}}
 			o, err := c.checkOSPackages()
 
 			if diff := cmp.Diff(tc.want.result, o); diff != "" {
@@ -450,7 +464,7 @@ func TestRemovePyCli(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			c := &CentOS{exec: tc.exec}
+			c := &CentOS{execs: cmdexec.ExecutorPair{User: tc.exec}}
 			result, err := c.removePyCli()
 
 			assert.Equal(t, tc.want.err, err)

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -23,7 +23,7 @@ func CheckNode(ctx Config, allClients Client) (bool, error) {
 
 	zap.S().Debug("Received a call to check node.")
 
-	os, err := validatePlatform(allClients.Executor)
+	os, err := validatePlatform(allClients.ExecutorPair)
 	if err != nil {
 		return false, err
 	}
@@ -31,9 +31,9 @@ func CheckNode(ctx Config, allClients Client) (bool, error) {
 	var platform platform.Platform
 	switch os {
 	case "debian":
-		platform = debian.NewDebian(allClients.Executor)
+		platform = debian.NewDebian(allClients.ExecutorPair)
 	case "redhat":
-		platform = centos.NewCentOS(allClients.Executor)
+		platform = centos.NewCentOS(allClients.ExecutorPair)
 	}
 
 	// Fetch the keystone token.

--- a/pkg/pmk/clients.go
+++ b/pkg/pmk/clients.go
@@ -2,13 +2,14 @@
 package pmk
 
 import (
-	"github.com/platform9/pf9ctl/pkg/qbert"
-	"github.com/platform9/pf9ctl/pkg/keystone"
-	"github.com/platform9/pf9ctl/pkg/resmgr"
-	"github.com/platform9/pf9ctl/pkg/cmdexec"
-	"net/http"
 	"crypto/tls"
+	"net/http"
 	"time"
+
+	"github.com/platform9/pf9ctl/pkg/cmdexec"
+	"github.com/platform9/pf9ctl/pkg/keystone"
+	"github.com/platform9/pf9ctl/pkg/qbert"
+	"github.com/platform9/pf9ctl/pkg/resmgr"
 )
 
 const HTTPMaxRetry = 15
@@ -18,25 +19,25 @@ const HTTPRetryMaxWait = 30 * time.Second
 // Clients struct encapsulate the collection of
 // external services
 type Client struct {
-	Resmgr   resmgr.Resmgr
-	Keystone keystone.Keystone
-	Qbert    qbert.Qbert
-	Executor cmdexec.Executor
-	Segment  Segment
+	Resmgr       resmgr.Resmgr
+	Keystone     keystone.Keystone
+	Qbert        qbert.Qbert
+	ExecutorPair cmdexec.ExecutorPair
+	Segment      Segment
 }
 
 // New creates the clients needed by the CLI
 // to interact with the external services.
-func NewClient(fqdn string, executor cmdexec.Executor, allowInsecure bool, noTracking bool) (Client, error) {
+func NewClient(fqdn string, executorPair cmdexec.ExecutorPair, allowInsecure bool, noTracking bool) (Client, error) {
 	// Bring the hammer down to make default http allow insecure
 	if allowInsecure {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 	return Client{
-		Resmgr:   resmgr.NewResmgr(fqdn, HTTPMaxRetry, HTTPRetryMinWait, HTTPRetryMaxWait, allowInsecure),
-		Keystone: keystone.NewKeystone(fqdn),
-		Qbert:    qbert.NewQbert(fqdn),
-		Executor: executor,
-		Segment:  NewSegment(fqdn, noTracking),
+		Resmgr:       resmgr.NewResmgr(fqdn, HTTPMaxRetry, HTTPRetryMinWait, HTTPRetryMaxWait, allowInsecure),
+		Keystone:     keystone.NewKeystone(fqdn),
+		Qbert:        qbert.NewQbert(fqdn),
+		ExecutorPair: executorPair,
+		Segment:      NewSegment(fqdn, noTracking),
 	}, nil
 }

--- a/pkg/pmk/cluster.go
+++ b/pkg/pmk/cluster.go
@@ -46,7 +46,7 @@ func Bootstrap(ctx Config, c Client, req qbert.ClusterCreateRequest) error {
 	}
 
 	cmd := `\"cat /etc/pf9/host_id.conf | grep ^host_id | cut -d = -f2 | cut -d ' ' -f2\"`
-	output, err := c.Executor.RunWithStdout("bash", "-c", cmd)
+	output, err := c.ExecutorPair.Sudoer.RunWithStdout("bash", "-c", cmd)
 	if err != nil {
 		return fmt.Errorf("Unable to execute command: %w", err)
 	}

--- a/pkg/ssh/sshclient.go
+++ b/pkg/ssh/sshclient.go
@@ -1,19 +1,22 @@
 // Copyright 2020 Platform9 Systems Inc.
 package ssh
+
 // The content of this files are shamelessly copied from the SSH Provider code base of cctl
 // the CCTL ssh-provider can't handle large files and hence this step was taken, perhaps
 // the original source should have been modified.
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
-    "bufio"
+
 	"github.com/pkg/sftp"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
 )
+
 // Client interface provides ways to run command and upload files to remote hosts
 type Client interface {
 	// RunCommand executes the remote command returning the stdout, stderr and any error associated with it
@@ -46,7 +49,7 @@ func NewClient(host string, port int, username string, privateKey []byte, passwo
 	} else {
 		authMethods[0] = ssh.Password(password)
 	}
-	
+
 	sshConfig := &ssh.ClientConfig{
 		User: string(username),
 		Auth: authMethods,
@@ -65,7 +68,6 @@ func NewClient(host string, port int, username string, privateKey []byte, passwo
 	}, nil
 }
 
-
 // RunCommand runs a command on the machine and returns stdout and stderr
 // separately
 func (c *client) RunCommand(cmd string) ([]byte, []byte, error) {
@@ -82,9 +84,9 @@ func (c *client) RunCommand(cmd string) ([]byte, []byte, error) {
 		return nil, nil, fmt.Errorf("unable to pipe stderr: %s", err)
 	}
 	// Prepend sudo if runAsSudo set to true
-	if runAsSudo {
-		cmd = fmt.Sprintf("sudo %s", cmd)
-	}
+	// if runAsSudo {
+	// 	cmd = fmt.Sprintf("sudo %s", cmd)
+	// }
 	err = session.Start(cmd)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to run command: %s", err)
@@ -102,9 +104,9 @@ func (c *client) RunCommand(cmd string) ([]byte, []byte, error) {
 		default:
 			retError = fmt.Errorf("command %s failed: %s", cmd, err)
 		}
-		zap.L().Error("Error ", zap.String("stdout", string(stdOut)), 
-										zap.String("stderr", string(stdErr)))
-			
+		zap.L().Error("Error ", zap.String("stdout", string(stdOut)),
+			zap.String("stderr", string(stdErr)))
+
 		return stdOut, stdErr, retError
 	}
 	return stdOut, stdErr, nil
@@ -147,10 +149,10 @@ func (c *client) UploadFile(localFile string, remoteFilePath string, mode os.Fil
 	return nil
 }
 
-func newProgressCBReader(totalSize int64, orig io.Reader, cb func(read int64, total int64) )  io.Reader {
+func newProgressCBReader(totalSize int64, orig io.Reader, cb func(read int64, total int64)) io.Reader {
 	progReader := &ProgressCBReader{
-		TotalSize:totalSize,
-		ReadCount:0,
+		TotalSize:  totalSize,
+		ReadCount:  0,
 		ProgressCB: cb,
 		OrigReader: orig,
 	}
@@ -160,14 +162,14 @@ func newProgressCBReader(totalSize int64, orig io.Reader, cb func(read int64, to
 // ProgressCBReader implements a reader that can call back
 // a function on  regular interval to report progress
 type ProgressCBReader struct {
-	TotalSize int64
-	ReadCount int64
+	TotalSize  int64
+	ReadCount  int64
 	ProgressCB func(read int64, total int64)
 	OrigReader io.Reader
 }
 
 func (r *ProgressCBReader) Read(p []byte) (int, error) {
-	read, err:= r.OrigReader.Read(p)
+	read, err := r.OrigReader.Read(p)
 	r.ReadCount = r.ReadCount + int64(read)
 	if r.ProgressCB != nil {
 		r.ProgressCB(r.ReadCount, r.TotalSize)

--- a/pkg/util/slices.go
+++ b/pkg/util/slices.go
@@ -19,3 +19,13 @@ func Intersect(a []string, b []string) []string {
 
 	return set
 }
+
+// IsInSlice checks is element x is in slice a
+func IsInSlice(x string, a []string) bool {
+	for _, i := range a {
+		if i == x {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>

Adds a new struct `ExecutorPair` which hold a executor to be run as normal user and the other has a sudo user
Also added `ExecutorConfig` to hold the config.
The tests are refactored accordingly.

Have tested check-node and prep-node on debian and centos with the changes.