### PR TITLE
Ft 39

### DIFF
--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -51,8 +51,8 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 	}
 
 	if !result {
-		fmt.Printf("\nPre-requisite check failed. See %s or use --verbose for logs \n", log.GetLogLocation(Pf9Log))
-		zap.S().Debugf("Pre-requisite check failed. See %s or use --verbose for logs", log.GetLogLocation(Pf9Log))
+		fmt.Printf("\nPre-requisite checks failed. See %s or use --verbose for logs \n", log.GetLogLocation(Pf9Log))
+		zap.S().Debugf("Pre-requisite checks failed. See %s or use --verbose for logs", log.GetLogLocation(Pf9Log))
 	}
 	zap.S().Debug("==========Finished running check-node==========")
 }

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/platform9/pf9ctl/pkg/log"
 	"github.com/platform9/pf9ctl/pkg/pmk"
 	"github.com/spf13/cobra"
@@ -50,8 +51,8 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 	}
 
 	if !result {
-		fmt.Printf("Node not ready. See %s or use --verbose for logs \n", log.GetLogLocation(Pf9Log))
-		zap.S().Debugf("Node not ready. See %s or use --verbose for logs", log.GetLogLocation(Pf9Log))
+		fmt.Printf("\nPre-requisite check failed. See %s or use --verbose for logs \n", log.GetLogLocation(Pf9Log))
+		zap.S().Debugf("Pre-requisite check failed. See %s or use --verbose for logs", log.GetLogLocation(Pf9Log))
 	}
 	zap.S().Debug("==========Finished running check-node==========")
 }

--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -134,7 +134,7 @@ func (c *CentOS) checkMem() (bool, error) {
 	if math.Ceil(mem/1024) >= util.MinMem {
 		return true, nil
 	}
-	return false, fmt.Errorf("Total memory found: %.0f", math.Ceil(mem/1024))
+	return false, fmt.Errorf("Total memory found: %.0f GB", math.Ceil(mem/1024))
 }
 
 func (c *CentOS) checkDisk() (bool, error) {
@@ -149,7 +149,7 @@ func (c *CentOS) checkDisk() (bool, error) {
 	}
 
 	if math.Ceil(disk/util.GB) < util.MinDisk {
-		return false, fmt.Errorf("Disk Space found: %.0f", math.Ceil(disk/util.GB))
+		return false, fmt.Errorf("Disk Space found: %.0f GB", math.Ceil(disk/util.GB))
 	}
 
 	zap.S().Debug("Total disk space: ", disk)

--- a/pkg/platform/centos/centos_test.go
+++ b/pkg/platform/centos/centos_test.go
@@ -109,7 +109,7 @@ func TestRAM(t *testing.T) {
 			},
 			want: want{
 				result: false,
-				err:    fmt.Errorf("Total memory found: 8"),
+				err:    fmt.Errorf("Total memory found: 8 GB"),
 			},
 		},
 	}
@@ -165,7 +165,7 @@ func TestDisk(t *testing.T) {
 			},
 			want: want{
 				result: false,
-				err:    fmt.Errorf("Disk Space found: 15"),
+				err:    fmt.Errorf("Disk Space found: 15 GB"),
 			},
 		},
 	}

--- a/pkg/platform/centos/centos_test.go
+++ b/pkg/platform/centos/centos_test.go
@@ -53,6 +53,7 @@ func TestCPU(t *testing.T) {
 			},
 			want: want{
 				result: false,
+				err:    fmt.Errorf("Number of CPUs found: 1"),
 			},
 		},
 	}
@@ -62,12 +63,11 @@ func TestCPU(t *testing.T) {
 			c := &CentOS{exec: tc.exec}
 			o, err := c.checkCPU()
 
-			if diff := cmp.Diff(tc.want.err, err); diff != "" {
-				t.Errorf("r: -want, +got:\n%s", diff)
-			}
 			if diff := cmp.Diff(tc.want.result, o); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
 			}
+
+			assert.Equal(t, tc.err, err)
 		})
 	}
 }
@@ -109,6 +109,7 @@ func TestRAM(t *testing.T) {
 			},
 			want: want{
 				result: false,
+				err:    fmt.Errorf("Total memory found: 8"),
 			},
 		},
 	}
@@ -118,12 +119,11 @@ func TestRAM(t *testing.T) {
 			c := &CentOS{exec: tc.exec}
 			o, err := c.checkMem()
 
-			if diff := cmp.Diff(tc.want.err, err); diff != "" {
-				t.Errorf("r: -want, +got:\n%s", diff)
-			}
 			if diff := cmp.Diff(tc.want.result, o); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
 			}
+
+			assert.Equal(t, tc.err, err)
 		})
 	}
 }
@@ -165,6 +165,7 @@ func TestDisk(t *testing.T) {
 			},
 			want: want{
 				result: false,
+				err:    fmt.Errorf("Disk Space found: 15"),
 			},
 		},
 	}
@@ -174,12 +175,11 @@ func TestDisk(t *testing.T) {
 			c := &CentOS{exec: tc.exec}
 			o, err := c.checkDisk()
 
-			if diff := cmp.Diff(tc.want.err, err); diff != "" {
-				t.Errorf("r: -want, +got:\n%s", diff)
-			}
 			if diff := cmp.Diff(tc.want.result, o); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
 			}
+
+			assert.Equal(t, tc.err, err)
 		})
 	}
 }

--- a/pkg/platform/check.go
+++ b/pkg/platform/check.go
@@ -1,7 +1,8 @@
 package platform
 
 type Check struct {
-	Name   string
-	Result bool
-	Err    error
+	Name    string
+	Result  bool
+	Err     error
+	UserErr string
 }

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -133,7 +133,7 @@ func (d *Debian) checkMem() (bool, error) {
 	if math.Ceil(mem/1024) >= util.MinMem {
 		return true, nil
 	}
-	return false, fmt.Errorf("Total memory found: %.0f", math.Ceil(mem/1024))
+	return false, fmt.Errorf("Total memory found: %.0f GB", math.Ceil(mem/1024))
 }
 
 func (d *Debian) checkDisk() (bool, error) {
@@ -148,7 +148,7 @@ func (d *Debian) checkDisk() (bool, error) {
 	}
 
 	if math.Ceil(disk/util.GB) < util.MinDisk {
-		return false, fmt.Errorf("Disk Space found: %.0f", math.Ceil(disk/util.GB))
+		return false, fmt.Errorf("Disk Space found: %.0f GB", math.Ceil(disk/util.GB))
 	}
 
 	zap.S().Debug("Total disk space: ", disk)

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -2,13 +2,14 @@ package debian
 
 import (
 	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
 	"github.com/platform9/pf9ctl/pkg/cmdexec"
 	"github.com/platform9/pf9ctl/pkg/platform"
 	"github.com/platform9/pf9ctl/pkg/util"
 	"go.uber.org/zap"
-	"math"
-	"strconv"
-	"strings"
 )
 
 var (
@@ -30,28 +31,28 @@ func (d *Debian) Check() []platform.Check {
 	var checks []platform.Check
 
 	result, err := d.removePyCli()
-	checks = append(checks, platform.Check{"Removal of existing CLI", result, err})
+	checks = append(checks, platform.Check{"Removal of existing CLI", result, err, util.PyCliErr})
 
 	result, err = d.checkExistingInstallation()
-	checks = append(checks, platform.Check{"Existing Installation Check", result, err})
+	checks = append(checks, platform.Check{"Existing Installation Check", result, err, util.ExisitngInstallationErr})
 
 	result, err = d.checkOSPackages()
-	checks = append(checks, platform.Check{"OS Packages Check", result, err})
+	checks = append(checks, platform.Check{"OS Packages Check", result, err, fmt.Sprintf("%s. %s", util.OSPackagesErr, err)})
 
 	result, err = d.checkSudo()
-	checks = append(checks, platform.Check{"SudoCheck", result, err})
+	checks = append(checks, platform.Check{"SudoCheck", result, err, util.SudoErr})
 
 	result, err = d.checkCPU()
-	checks = append(checks, platform.Check{"CPUCheck", result, err})
+	checks = append(checks, platform.Check{"CPUCheck", result, err, fmt.Sprintf("%s %s", util.CPUErr, err)})
 
 	result, err = d.checkDisk()
-	checks = append(checks, platform.Check{"DiskCheck", result, err})
+	checks = append(checks, platform.Check{"DiskCheck", result, err, fmt.Sprintf("%s %s", util.DiskErr, err)})
 
 	result, err = d.checkMem()
-	checks = append(checks, platform.Check{"MemoryCheck", result, err})
+	checks = append(checks, platform.Check{"MemoryCheck", result, err, fmt.Sprintf("%s %s", util.MemErr, err)})
 
 	result, err = d.checkPort()
-	checks = append(checks, platform.Check{"PortCheck", result, err})
+	checks = append(checks, platform.Check{"PortCheck", result, err, util.PortErr})
 
 	return checks
 }
@@ -110,7 +111,10 @@ func (d *Debian) checkCPU() (bool, error) {
 
 	zap.S().Debug("Number of CPUs found: ", cpu)
 
-	return cpu >= util.MinCPUs, nil
+	if cpu >= util.MinCPUs {
+		return true, nil
+	}
+	return false, fmt.Errorf("Number of CPUs found: %d", cpu)
 }
 
 func (d *Debian) checkMem() (bool, error) {
@@ -126,7 +130,10 @@ func (d *Debian) checkMem() (bool, error) {
 
 	zap.S().Debug("Total memory allocated in GiBs", mem)
 
-	return math.Ceil(mem/1024) >= util.MinMem, nil
+	if math.Ceil(mem/1024) >= util.MinMem {
+		return true, nil
+	}
+	return false, fmt.Errorf("Total memory found: %.0f", math.Ceil(mem/1024))
 }
 
 func (d *Debian) checkDisk() (bool, error) {
@@ -141,7 +148,7 @@ func (d *Debian) checkDisk() (bool, error) {
 	}
 
 	if math.Ceil(disk/util.GB) < util.MinDisk {
-		return false, nil
+		return false, fmt.Errorf("Disk Space found: %.0f", math.Ceil(disk/util.GB))
 	}
 
 	zap.S().Debug("Total disk space: ", disk)
@@ -158,7 +165,10 @@ func (d *Debian) checkDisk() (bool, error) {
 
 	zap.S().Debug("Available disk space: ", avail)
 
-	return math.Ceil(avail/util.GB) >= util.MinAvailDisk, nil
+	if math.Ceil(avail/util.GB) >= util.MinAvailDisk {
+		return true, nil
+	}
+	return false, fmt.Errorf("Available disk space: %.0f GB", math.Trunc(avail/util.GB))
 }
 
 func (d *Debian) checkPort() (bool, error) {

--- a/pkg/platform/debian/debian_test.go
+++ b/pkg/platform/debian/debian_test.go
@@ -53,6 +53,7 @@ func TestCPU(t *testing.T) {
 			},
 			want: want{
 				result: false,
+				err:    fmt.Errorf("Number of CPUs found: 1"),
 			},
 		},
 	}
@@ -62,9 +63,8 @@ func TestCPU(t *testing.T) {
 			c := &Debian{exec: tc.exec}
 			o, err := c.checkCPU()
 
-			if diff := cmp.Diff(tc.want.err, err); diff != "" {
-				t.Errorf("r: -want, +got:\n%s", diff)
-			}
+			assert.Equal(t, tc.err, err)
+
 			if diff := cmp.Diff(tc.want.result, o); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
 			}
@@ -109,6 +109,7 @@ func TestRAM(t *testing.T) {
 			},
 			want: want{
 				result: false,
+				err:    fmt.Errorf("Total memory found: 8"),
 			},
 		},
 	}
@@ -118,9 +119,8 @@ func TestRAM(t *testing.T) {
 			c := &Debian{exec: tc.exec}
 			o, err := c.checkMem()
 
-			if diff := cmp.Diff(tc.want.err, err); diff != "" {
-				t.Errorf("r: -want, +got:\n%s", diff)
-			}
+			assert.Equal(t, tc.err, err)
+
 			if diff := cmp.Diff(tc.want.result, o); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
 			}
@@ -278,6 +278,7 @@ func TestDisk(t *testing.T) {
 			},
 			want: want{
 				result: false,
+				err:    fmt.Errorf("Disk Space found: 15"),
 			},
 		},
 	}
@@ -287,9 +288,7 @@ func TestDisk(t *testing.T) {
 			c := &Debian{exec: tc.exec}
 			o, err := c.checkDisk()
 
-			if diff := cmp.Diff(tc.want.err, err); diff != "" {
-				t.Errorf("r: -want, +got:\n%s", diff)
-			}
+			assert.Equal(t, tc.err, err)
 			if diff := cmp.Diff(tc.want.result, o); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
 			}

--- a/pkg/platform/debian/debian_test.go
+++ b/pkg/platform/debian/debian_test.go
@@ -109,7 +109,7 @@ func TestRAM(t *testing.T) {
 			},
 			want: want{
 				result: false,
-				err:    fmt.Errorf("Total memory found: 8"),
+				err:    fmt.Errorf("Total memory found: 8 GB"),
 			},
 		},
 	}
@@ -278,7 +278,7 @@ func TestDisk(t *testing.T) {
 			},
 			want: want{
 				result: false,
-				err:    fmt.Errorf("Disk Space found: 15"),
+				err:    fmt.Errorf("Disk Space found: 15 GB"),
 			},
 		},
 	}

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -72,7 +72,7 @@ func CheckNode(ctx Config, allClients Client) (bool, error) {
 			if err := allClients.Segment.SendEvent(segment_str, auth); err != nil {
 				zap.S().Errorf("Unable to send Segment event for check node. Error: %s", err.Error())
 			}
-			fmt.Printf("%s : %s\n", check.Name, checkFail)
+			fmt.Printf("%s : %s - %s\n", check.Name, checkFail, check.UserErr)
 			result = false
 		}
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,11 +1,13 @@
 package util
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
 
 var RequiredPorts []string
+var PortErr string
 
 const (
 
@@ -25,17 +27,29 @@ const (
 )
 
 var (
+	// Constants for check failure messages
+	PyCliErr                = "Earlier version of pf9ctl already exists. This must be uninstalled."
+	ExisitngInstallationErr = "Platform9 packages already exist. These must be uninstalled."
+	SudoErr                 = "User running pf9ctl must have privilege (sudo) mode enabled."
+	OSPackagesErr           = "Some OS packages needed for the CLI not found"
+	CPUErr                  = "At least 2 CPUs are needed on host."
+	DiskErr                 = "At least 30 GB of disk space is needed on host."
+	MemErr                  = "At least 12 GB of memory is needed on host."
+)
+
+var (
 	homeDir, _ = os.UserHomeDir()
 	// PyCliPath is the path of virtual env directory of the Python CLI
 	PyCliPath = filepath.Join(homeDir, "pf9/pf9-venv")
 	// PyCliLink is the Symlink of the Python CLI
-	PyCliLink = "/usr/bin/pf9ctl"
-	Centos = "centos"
-	Redhat = "redhat"
-	Ubuntu = "ubuntu"
+	PyCliLink      = "/usr/bin/pf9ctl"
+	Centos         = "centos"
+	Redhat         = "redhat"
+	Ubuntu         = "ubuntu"
 	CertsExpireErr = "certificate has expired or is not yet valid"
 )
 
 func init() {
 	RequiredPorts = []string{"443", "2379", "2380", "8285", "10250", "10255", "4194", "8285"}
+	PortErr = fmt.Sprintf("Ports required to be available %s", RequiredPorts)
 }

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -33,7 +33,7 @@ var (
 	SudoErr                 = "User running pf9ctl must have privilege (sudo) mode enabled."
 	OSPackagesErr           = "Some OS packages needed for the CLI not found"
 	CPUErr                  = "At least 2 CPUs are needed on host."
-	DiskErr                 = "At least 30 GB of disk space is needed on host."
+	DiskErr                 = "At least 30 GB of total disk space and 15 GB of free space is needed on host."
 	MemErr                  = "At least 12 GB of memory is needed on host."
 )
 


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>

Added better user messages  for the failing prerequisite checks.

Sample output showing all error messages

```
./pf9ctl check-node
2021-02-24T07:46:27.3412Z	INFO	Loading configuration details


Removal of existing CLI : FAIL - Earlier version of pf9ctl already exists. This must be uninstalled.
Existing Installation Check : FAIL - Platform9 packages already exist. These must be uninstalled.
OS Packages Check : FAIL - Some OS packages needed for the CLI not found. Packages not found:  curla
SudoCheck : FAIL - User running pf9ctl must have privilege (sudo) mode enabled.
CPUCheck : FAIL - At least 2 CPUs are needed on host. Number of CPUs found: 1
DiskCheck : FAIL - At least 30 GB of disk space is needed on host. Available disk space: 10 GB
MemoryCheck : FAIL - At least 12 GB of memory is needed on host. Total memory found: 8
PortCheck : FAIL - Ports required to be available [443 2379 2380 8285 10250 10255 4194 8285]

Pre-requisite check failed. See /home/sahil/pf9/log/pf9ctl-20210222.log or use --verbose for logs 
```

The test cases are also modified.
