### PR TITLE
run all commands with sudo after checking for sudo

### DIFF
--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/platform9/pf9ctl/pkg/log"
 	"github.com/platform9/pf9ctl/pkg/pmk"
 	"github.com/spf13/cobra"
@@ -46,7 +47,7 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 
 	result, err := pmk.CheckNode(ctx, c)
 	if err != nil {
-		zap.S().Fatalf("Unable to perform pre-requisite checks on this node. Error: %s", err.Error())
+		zap.S().Fatalf("Unable to perform pre-requisite checks on this node: %s", err.Error())
 	}
 
 	if !result {

--- a/pkg/cmdexec/executor.go
+++ b/pkg/cmdexec/executor.go
@@ -3,10 +3,11 @@
 package cmdexec
 
 import (
+	"fmt"
 	"os/exec"
+
 	"github.com/platform9/pf9ctl/pkg/ssh"
 	"go.uber.org/zap"
-	"fmt"
 )
 
 // Executor interace abstracts us from local or remote execution
@@ -20,30 +21,32 @@ type LocalExecutor struct{}
 
 // Run runs a command locally returning just success or failure
 func (c LocalExecutor) Run(name string, args ...string) error {
-	cmd := exec.Command(name, args...)
+	args = append([]string{name}, args...)
+	cmd := exec.Command("sudo", args...)
 	return cmd.Run()
 }
 
 // RunWithStdout runs a command locally returning stdout and err
 func (c LocalExecutor) RunWithStdout(name string, args ...string) (string, error) {
-	byt, err := exec.Command(name, args...).Output()
+	args = append([]string{name}, args...)
+	byt, err := exec.Command("sudo", args...).Output()
 	stderr := ""
 	if exitError, ok := err.(*exec.ExitError); ok {
 		stderr = string(exitError.Stderr)
 	}
-	zap.S().Debug("Ran command ",name, args)
-	zap.S().Debug( "stdout:", string(byt), "stderr:", stderr)
+	zap.S().Debug("Ran command ", "sudo", args)
+	zap.S().Debug("stdout:", string(byt), "stderr:", stderr)
 	return string(byt), err
 }
 
 // RemoteExecutor as the name implies runs commands usign SSH on remote host
-type RemoteExecutor struct{
+type RemoteExecutor struct {
 	Client ssh.Client
 }
 
 // Run runs a command locally returning just success or failure
 func (r *RemoteExecutor) Run(name string, args ...string) error {
-	 _,err := r.RunWithStdout(name, args...)
+	_, err := r.RunWithStdout(name, args...)
 	return err
 }
 
@@ -54,16 +57,16 @@ func (r *RemoteExecutor) RunWithStdout(name string, args ...string) (string, err
 		cmd = fmt.Sprintf("%s \"%s\"", cmd, arg)
 	}
 	stdout, stderr, err := r.Client.RunCommand(cmd)
-	zap.S().Debug("Running command ",cmd, "stdout:", string(stdout), "stderr:", string(stderr))
+	zap.S().Debug("Running command ", cmd, "stdout:", string(stdout), "stderr:", string(stderr))
 	return string(stdout), err
 }
 
 // NewRemoteExecutor create an Executor interface to execute commands remotely
 func NewRemoteExecutor(host string, port int, username string, privateKey []byte, password string) (Executor, error) {
-	 client, err := ssh.NewClient(host, port, username, privateKey, password)
-	 if err != nil {
-		 return nil, err
-	 }
-	 re := &RemoteExecutor{Client: client}
-	 return re, nil
+	client, err := ssh.NewClient(host, port, username, privateKey, password)
+	if err != nil {
+		return nil, err
+	}
+	re := &RemoteExecutor{Client: client}
+	return re, nil
 }

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -23,6 +23,11 @@ func CheckNode(ctx Config, allClients Client) (bool, error) {
 
 	zap.S().Debug("Received a call to check node.")
 
+	isSudo := checkSudo(allClients.Executor)
+	if !isSudo {
+		return false, fmt.Errorf("User executing this CLI is not allowed to switch to privileged (sudo) mode")
+	}
+
 	os, err := validatePlatform(allClients.Executor)
 	if err != nil {
 		return false, err

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -3,6 +3,10 @@ package pmk
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/platform9/pf9ctl/pkg/cmdexec"
 	"github.com/platform9/pf9ctl/pkg/keystone"
 	"github.com/platform9/pf9ctl/pkg/platform"
@@ -10,9 +14,6 @@ import (
 	"github.com/platform9/pf9ctl/pkg/platform/debian"
 	"github.com/platform9/pf9ctl/pkg/util"
 	"go.uber.org/zap"
-	"net/http"
-	"strings"
-	"time"
 )
 
 // Sends an event to segment based on the input string and uses auth as keystone UUID property.
@@ -233,4 +234,9 @@ func installHostAgentLegacy(ctx Config, auth keystone.KeystoneAuth, hostOS strin
 	// TODO: here we actually need additional validation by checking /tmp/agent_install. log
 	zap.S().Info("Hostagent installed successfully")
 	return nil
+}
+
+func checkSudo(exec cmdexec.Executor) bool {
+	_, err := exec.RunWithStdout("bash", "-c", "echo '$(logname) ALL=(ALL:ALL) NOPASSWD: ALL' | (EDITOR='tee -a' visudo)")
+	return err == nil
 }

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -237,6 +237,6 @@ func installHostAgentLegacy(ctx Config, auth keystone.KeystoneAuth, hostOS strin
 }
 
 func checkSudo(exec cmdexec.Executor) bool {
-	_, err := exec.RunWithStdout("bash", "-c", "echo '$(logname) ALL=(ALL:ALL) NOPASSWD: ALL' | (EDITOR='tee -a' visudo)")
+	_, err := exec.RunWithStdout("-l")
 	return err == nil
 }


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>

Changes the LocalExecutor to run all commands with sudo
Checks if the current user is ableto sudo.

Have tested this with Ubuntu and CentOS

When running with non sudoer
```
./pf9ctl check-node
2021-02-24T11:22:26.2234Z	INFO	Loading configuration details
[sudo] password for dummy1: 
2021-02-24T11:22:28.6002Z	FATAL	Unable to perform pre-requisite checks on this node: User executing this CLI is not allowed to switch to privileged (sudo) mode
```