### PR TITLE
If user provides wrong credentials will verify and re-ask if invalid during setting config

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -8,7 +8,6 @@ import (
 	"github.com/platform9/pf9ctl/pkg/cmdexec"
 	"github.com/platform9/pf9ctl/pkg/pmk"
 	"github.com/platform9/pf9ctl/pkg/qbert"
-	"github.com/platform9/pf9ctl/pkg/util"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
@@ -46,7 +45,7 @@ var (
 func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 	zap.S().Debug("Received a call to bootstrap the node")
 
-	ctx, err := pmk.LoadConfig(util.Pf9DBLoc)
+	//ctx, err := pmk.LoadConfig(util.Pf9DBLoc)
 	if err != nil {
 		zap.S().Fatalf("Unable to load config: %s", err.Error())
 	}

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"github.com/platform9/pf9ctl/pkg/cmdexec"
 	"github.com/platform9/pf9ctl/pkg/pmk"
 	"github.com/platform9/pf9ctl/pkg/qbert"
+	"github.com/platform9/pf9ctl/pkg/util"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
@@ -45,7 +46,7 @@ var (
 func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 	zap.S().Debug("Received a call to bootstrap the node")
 
-	//ctx, err := pmk.LoadConfig(util.Pf9DBLoc)
+	ctx, err := pmk.LoadConfig(util.Pf9DBLoc)
 	if err != nil {
 		zap.S().Fatalf("Unable to load config: %s", err.Error())
 	}

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -21,6 +21,15 @@ var checkNodeCmd = &cobra.Command{
 	Run: checkNodeRun,
 }
 
+var (
+	ctx  pmk.Config
+	c    pmk.Client
+	err  error
+	auth keystone.KeystoneAuth
+	// This flag helps us to loop-back the config set until the user enters valid credentials.
+	credentialsFlag = true
+)
+
 func init() {
 	checkNodeCmd.Flags().StringVarP(&user, "user", "u", "", "ssh username for the nodes")
 	checkNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes")
@@ -34,50 +43,15 @@ func init() {
 func checkNodeRun(cmd *cobra.Command, args []string) {
 	zap.S().Debug("==========Running check-node==========")
 
-	var (
-		ctx  pmk.Config
-		c    pmk.Client
-		err  error
-		auth keystone.KeystoneAuth
-		// This flag helps us to loop-back the config set until the user enters valid credentials.
-		credentialsFlag = true
-	)
-
+	// Loading the config if exists or creating config and storing it if valid.
 	for credentialsFlag {
-		ctx, err = pmk.LoadConfig(util.Pf9DBLoc)
-		if err != nil {
-			zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
-		}
 
-		executor, err := getExecutor()
-		if err != nil {
-			zap.S().Fatalf("Error connecting to host %s", err.Error())
-		}
-		c, err = pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)
-		if err != nil {
-			zap.S().Fatalf("Unable to load clients needed for the Cmd. Error: %s", err.Error())
-		}
-
-		defer c.Segment.Close()
-
-		zap.S().Debug("==========Validating the User Credentials==========")
-
-		// Validating the credentials enterd (Username, Password, Service) by user using config setting.
-		auth, err = c.Keystone.GetAuth(
-			ctx.Username,
-			ctx.Password,
-			ctx.Tenant,
-		)
-		// If the credentials are invalid we will loop-back the config set before storing it till the credentials entered are valid.
-		if err != nil {
-			zap.S().Info("Invalid credentials entered (Username/Password/Tenant)")
-		} else {
-			if err := pmk.StoreConfig(ctx, util.Pf9DBLoc); err != nil {
-				zap.S().Errorf("Failed to store config: %s", err.Error())
-			}
-			credentialsFlag = false
-		}
+		zap.S().Debug("Loading the config if exist or setting config and validating the user credentials")
+		ctx, c, auth, credentialsFlag = configLoadAndValidate()
 	}
+
+	defer c.Segment.Close()
+
 	result, err := pmk.CheckNode(ctx, c, auth)
 	if err != nil {
 		zap.S().Fatalf("Unable to perform pre-requisite checks on this node: %s", err.Error())
@@ -89,4 +63,53 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 	}
 
 	zap.S().Debug("==========Finished running check-node==========")
+}
+
+func configLoadAndValidate() (pmk.Config, pmk.Client, keystone.KeystoneAuth, bool) {
+
+	ctx, pmk.IfNewConfig, err = pmk.LoadConfig(util.Pf9DBLoc)
+	if err != nil {
+		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
+	}
+
+	executor, err := getExecutor()
+	if err != nil {
+		zap.S().Fatalf("Error connecting to host %s", err.Error())
+	}
+
+	c, err = pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)
+	if err != nil {
+		zap.S().Fatalf("Unable to load clients needed for the Cmd. Error: %s", err.Error())
+	}
+	// Validating the config received after loading.
+	auth, credentialsFlag = authenticateUserCredentials(c, ctx)
+
+	return ctx, c, auth, credentialsFlag
+}
+
+func authenticateUserCredentials(pmk.Client, pmk.Config) (keystone.KeystoneAuth, bool) {
+
+	zap.S().Debug("==========Validating the User Credentials==========")
+
+	// Validating the credentials enterd (Username, Password, Service) by user using config setting.
+	auth, err = c.Keystone.GetAuth(
+		ctx.Username,
+		ctx.Password,
+		ctx.Tenant,
+	)
+
+	// If the credentials are invalid we will loop-back the config set before storing it till the credentials entered are valid.
+	if err != nil {
+		zap.S().Info("Invalid credentials entered (Username/Password/Tenant)\n")
+	} else if pmk.IfNewConfig {
+		if err := pmk.StoreConfig(ctx, util.Pf9DBLoc); err != nil {
+			zap.S().Errorf("Failed to store config: %s", err.Error())
+		} else {
+			credentialsFlag = false
+		}
+	} else {
+		credentialsFlag = false
+	}
+
+	return auth, credentialsFlag
 }

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -67,7 +67,7 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 
 func configLoadAndValidate() (pmk.Config, pmk.Client, keystone.KeystoneAuth, bool) {
 
-	ctx, pmk.IfNewConfig, err = pmk.LoadConfig(util.Pf9DBLoc)
+	ctx, err = pmk.LoadConfig(util.Pf9DBLoc)
 	if err != nil {
 		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
 	}

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -39,10 +39,11 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 		c    pmk.Client
 		err  error
 		auth keystone.KeystoneAuth
-		flag = true
+		// This flag helps us to loop-back the config set until the user enters valid credentials.
+		credentialsFlag = true
 	)
 
-	for flag {
+	for credentialsFlag {
 		ctx, err = pmk.LoadConfig(util.Pf9DBLoc)
 		if err != nil {
 			zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
@@ -61,19 +62,20 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 
 		zap.S().Debug("==========Validating the User Credentials==========")
 
+		// Validating the credentials enterd (Username, Password, Service) by user using config setting.
 		auth, err = c.Keystone.GetAuth(
 			ctx.Username,
 			ctx.Password,
 			ctx.Tenant,
 		)
-
+		// If the credentials are invalid we will loop-back the config set before storing it till the credentials entered are valid.
 		if err != nil {
-			zap.S().Debug("Invalid credentials entered (Username/Password/Tenant)")
+			zap.S().Info("Invalid credentials entered (Username/Password/Tenant)")
 		} else {
 			if err := pmk.StoreConfig(ctx, util.Pf9DBLoc); err != nil {
 				zap.S().Errorf("Failed to store config: %s", err.Error())
 			}
-			flag = false
+			credentialsFlag = false
 		}
 	}
 	result, err := pmk.CheckNode(ctx, c, auth)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -27,7 +27,7 @@ func configCmdCreateRun(cmd *cobra.Command, args []string) {
 
 	for credentialsFlag {
 		// invoked the configcreate command from pkg/pmk
-		ctx, pmk.IfNewConfig, _ = pmk.ConfigCmdCreateRun()
+		ctx, _ = pmk.ConfigCmdCreateRun()
 
 		executor, err := getExecutor()
 		if err != nil {

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -53,10 +53,11 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 		c    pmk.Client
 		err  error
 		auth keystone.KeystoneAuth
-		flag = true
+		// This flag helps us to loop-back the config set until the user enters valid credentials.
+		credentialsFlag = true
 	)
 
-	for flag {
+	for credentialsFlag {
 		ctx, err = pmk.LoadConfig(util.Pf9DBLoc)
 		if err != nil {
 			zap.S().Fatalf("Unable to load the config: %s\n", err.Error())
@@ -74,20 +75,21 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 		defer c.Segment.Close()
 
 		zap.S().Debug("==========Validating the User Credentials==========")
+		// Validating the credentials enterd (Username, Password, Service) by user using config setting
 
 		auth, err = c.Keystone.GetAuth(
 			ctx.Username,
 			ctx.Password,
 			ctx.Tenant,
 		)
-
+		// If the credentials are invalid we will loop-back the config set before storing it till the credentials entered are valid.
 		if err != nil {
-			zap.S().Debug("Invalid credentials entered (Username/Password/Tenant)")
+			zap.S().Info("Invalid credentials entered (Username/Password/Tenant)")
 		} else {
 			if err := pmk.StoreConfig(ctx, util.Pf9DBLoc); err != nil {
 				zap.S().Errorf("Failed to store config: %s", err.Error())
 			}
-			flag = false
+			credentialsFlag = false
 		}
 	}
 

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/platform9/pf9ctl/pkg/keystone"
 	"github.com/platform9/pf9ctl/pkg/platform"
 	"github.com/platform9/pf9ctl/pkg/platform/centos"
 	"github.com/platform9/pf9ctl/pkg/platform/debian"
@@ -19,7 +20,7 @@ const (
 )
 
 // CheckNode checks the prerequisites for k8s stack
-func CheckNode(ctx Config, allClients Client) (bool, error) {
+func CheckNode(ctx Config, allClients Client, auth keystone.KeystoneAuth) (bool, error) {
 
 	zap.S().Debug("Received a call to check node.")
 
@@ -43,11 +44,11 @@ func CheckNode(ctx Config, allClients Client) (bool, error) {
 
 	// Fetch the keystone token.
 	// This is used as a reference to the segment event.
-	auth, err := allClients.Keystone.GetAuth(
+	/*auth, err := allClients.Keystone.GetAuth(
 		ctx.Username,
 		ctx.Password,
 		ctx.Tenant,
-	)
+	)*/
 
 	if err != nil {
 		// Certificate expiration is detected by the http library and

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -50,14 +50,6 @@ func CheckNode(ctx Config, allClients Client, auth keystone.KeystoneAuth) (Check
 		platform = centos.NewCentOS(allClients.Executor)
 	}
 
-	// Fetch the keystone token.
-	// This is used as a reference to the segment event.
-	/*auth, err := allClients.Keystone.GetAuth(
-		ctx.Username,
-		ctx.Password,
-		ctx.Tenant,
-	)*/
-
 	if err != nil {
 		// Certificate expiration is detected by the http library and
 		// only error object gets populated, which means that the http

--- a/pkg/pmk/config.go
+++ b/pkg/pmk/config.go
@@ -123,39 +123,3 @@ func ConfigCmdCreateRun() (Config, error) {
 	}
 	return ctx, nil
 }
-
-/*
-func ValidateCmdRun() (Config, Client) {
-
-	ctx, err := LoadConfig(util.Pf9DBLoc)
-	if err != nil {
-		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
-	}
-
-	executor, err := GetExecutor()
-	if err != nil {
-		zap.S().Fatalf("Error connecting to host %s", err.Error())
-	}
-	c, err := NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)
-	if err != nil {
-		zap.S().Fatalf("Unable to load clients needed for the Cmd. Error: %s", err.Error())
-	}
-
-	defer c.Segment.Close()
-
-	_, err = c.Keystone.GetAuth(
-		ctx.Username,
-		ctx.Password,
-		ctx.Tenant,
-	)
-
-	if err != nil {
-		zap.S().Fatalf("Invalid credentials(): %s", err.Error())
-	} else {
-		if err := StoreConfig(ctx, util.Pf9DBLoc); err != nil {
-			zap.S().Errorf("Failed to store config: %s", err.Error())
-		}
-	}
-   return ctx, c
-}
-*/

--- a/pkg/pmk/config.go
+++ b/pkg/pmk/config.go
@@ -52,7 +52,7 @@ func StoreConfig(ctx Config, loc string) error {
 }
 
 // LoadConfig returns the information for communication with PF9 controller.
-func LoadConfig(loc string) (Config, bool, error) {
+func LoadConfig(loc string) (Config, error) {
 	zap.S().Info("Loading configuration details")
 
 	f, err := os.Open(loc)
@@ -61,11 +61,11 @@ func LoadConfig(loc string) (Config, bool, error) {
 		if os.IsNotExist(err) {
 			// to initiate the config create and store it
 			zap.S().Info("Existing config not found, prompting for new config.")
-			ctx, IfNewConfig, err = ConfigCmdCreateRun()
+			ctx, err = ConfigCmdCreateRun()
 
-			return ctx, IfNewConfig, err
+			return ctx, err
 		}
-		return Config{}, IfNewConfig, err
+		return Config{}, err
 	}
 
 	defer f.Close()
@@ -76,15 +76,15 @@ func LoadConfig(loc string) (Config, bool, error) {
 	// Decoding base64 encoded password
 	decodedBytePassword, err := base64.StdEncoding.DecodeString(ctx.Password)
 	if err != nil {
-		return ctx, IfNewConfig, err
+		return ctx, err
 	}
 	ctx.Password = string(decodedBytePassword)
 
-	return ctx, IfNewConfig, err
+	return ctx, err
 }
 
 // ConfigCmdCreatRun will initiate the config set and return a config given by user
-func ConfigCmdCreateRun() (Config, bool, error) {
+func ConfigCmdCreateRun() (Config, error) {
 
 	zap.S().Info("==========Running set config==========")
 
@@ -128,5 +128,5 @@ func ConfigCmdCreateRun() (Config, bool, error) {
 		AllowInsecure: false,
 	}
 	IfNewConfig = true
-	return ctx, IfNewConfig, nil
+	return ctx, nil
 }


### PR DESCRIPTION
* Added the validation of credentials during config setting ( config, check-node, prep-node command), and will re-run the config setting if not entered valid user credentials. 
* Removed the redundancy of authentication token generation during check-node, and created a new argument auth for checkNode function.
<img width="710" alt="Screenshot 2021-02-26 at 8 03 53 PM" src="https://user-images.githubusercontent.com/77390180/109313989-cd3d1480-786e-11eb-9073-37b133e46db2.png">
