### PR TITLE
Resolved the issues found during testing.

### DIFF
--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -40,7 +40,8 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 
 	executor, err := getExecutor()
 	if err != nil {
-		zap.S().Fatalf("Error connecting to host %s", err.Error())
+		zap.S().Debug("Error connecting to host %s", err.Error())
+		zap.S().Fatalf(" Invalid (Username/Password/IP)")
 	}
 
 	c, err = pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -55,7 +55,8 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 
 	executor, err := getExecutor()
 	if err != nil {
-		zap.S().Fatalf("Error connecting to host %s", err.Error())
+		zap.S().Debug("Error connecting to host %s", err.Error())
+		zap.S().Fatalf(" Invalid (Username/Password/IP)")
 	}
 
 	c, err = pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)

--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	packages            = []string{"ntp", "curl", "uuid-runtime"}
+	packages            = []string{"ntp", "curl", "uuid"}
 	packageInstallError = "Packages not found and could not be installed"
 )
 

--- a/pkg/ssh/sshclient.go
+++ b/pkg/ssh/sshclient.go
@@ -1,19 +1,22 @@
 // Copyright 2020 Platform9 Systems Inc.
 package ssh
+
 // The content of this files are shamelessly copied from the SSH Provider code base of cctl
 // the CCTL ssh-provider can't handle large files and hence this step was taken, perhaps
 // the original source should have been modified.
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
-    "bufio"
+
 	"github.com/pkg/sftp"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
 )
+
 // Client interface provides ways to run command and upload files to remote hosts
 type Client interface {
 	// RunCommand executes the remote command returning the stdout, stderr and any error associated with it
@@ -46,7 +49,7 @@ func NewClient(host string, port int, username string, privateKey []byte, passwo
 	} else {
 		authMethods[0] = ssh.Password(password)
 	}
-	
+
 	sshConfig := &ssh.ClientConfig{
 		User: string(username),
 		Auth: authMethods,
@@ -64,7 +67,6 @@ func NewClient(host string, port int, username string, privateKey []byte, passwo
 		sftpClient: sftpClient,
 	}, nil
 }
-
 
 // RunCommand runs a command on the machine and returns stdout and stderr
 // separately
@@ -102,9 +104,9 @@ func (c *client) RunCommand(cmd string) ([]byte, []byte, error) {
 		default:
 			retError = fmt.Errorf("command %s failed: %s", cmd, err)
 		}
-		zap.L().Error("Error ", zap.String("stdout", string(stdOut)), 
-										zap.String("stderr", string(stdErr)))
-			
+
+		zap.L().Debug("Error ", zap.String("stdout", string(stdOut)), zap.String("stderr", string(stdErr)))
+
 		return stdOut, stdErr, retError
 	}
 	return stdOut, stdErr, nil
@@ -147,10 +149,10 @@ func (c *client) UploadFile(localFile string, remoteFilePath string, mode os.Fil
 	return nil
 }
 
-func newProgressCBReader(totalSize int64, orig io.Reader, cb func(read int64, total int64) )  io.Reader {
+func newProgressCBReader(totalSize int64, orig io.Reader, cb func(read int64, total int64)) io.Reader {
 	progReader := &ProgressCBReader{
-		TotalSize:totalSize,
-		ReadCount:0,
+		TotalSize:  totalSize,
+		ReadCount:  0,
 		ProgressCB: cb,
 		OrigReader: orig,
 	}
@@ -160,14 +162,14 @@ func newProgressCBReader(totalSize int64, orig io.Reader, cb func(read int64, to
 // ProgressCBReader implements a reader that can call back
 // a function on  regular interval to report progress
 type ProgressCBReader struct {
-	TotalSize int64
-	ReadCount int64
+	TotalSize  int64
+	ReadCount  int64
 	ProgressCB func(read int64, total int64)
 	OrigReader io.Reader
 }
 
 func (r *ProgressCBReader) Read(p []byte) (int, error) {
-	read, err:= r.OrigReader.Read(p)
+	read, err := r.OrigReader.Read(p)
 	r.ReadCount = r.ReadCount + int64(read)
 	if r.ProgressCB != nil {
 		r.ProgressCB(r.ReadCount, r.TotalSize)


### PR DESCRIPTION
1) Missing packages being installed during check-node/prep-node execution for remote and local case for uuid-runtime in centos was not getting installed using "yum -q -y install uuid-runtime", so modified it to uuid for centos case. 

2) Modified extra console error message to **debug** type which were found during checknode and prep-node execution when os packages were missing (remote).

3) Modified the error message we get while we enter invalid Username/Password/IP during remote running of commands. 

TC link : http://teamcity.platform9.horse:8111/buildConfiguration/Pf9project_Platform9Components_Pf9ctl/1454163

<img width="816" alt="Screenshot 2021-03-03 at 2 46 30 PM" src="https://user-images.githubusercontent.com/77390180/109784625-45ba2180-7c31-11eb-92da-6f5dd53088bf.png">

<img width="893" alt="Screenshot 2021-03-03 at 2 48 51 PM" src="https://user-images.githubusercontent.com/77390180/109784632-481c7b80-7c31-11eb-8f77-967a5b04a4f2.png">

![Screenshot 2021-03-03 at 2 50 41 PM](https://user-images.githubusercontent.com/77390180/109784638-494da880-7c31-11eb-9516-4a8130364a3b.png)

<img width="893" alt="Screenshot 2021-03-03 at 2 51 34 PM" src="https://user-images.githubusercontent.com/77390180/109784641-4b176c00-7c31-11eb-9994-8bd86521dda3.png">



