### PR TITLE
return gracefully for non-supported OS version

### DIFF
--- a/pf9ctl_setup
+++ b/pf9ctl_setup
@@ -100,7 +100,7 @@ checkOS_version() {
     cat /etc/*release &>/dev/null
     if [ $? != 0 ];
     then
-        echo "This OS is not supported. Supported operating systems are: Ubuntu (16.04, 18.04) & CentOS 7+"
+        echo "This OS is not supported. Supported operating systems are: Ubuntu (16.04, 18.04) & CentOS 7.x"
         exit
     fi
 }

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -47,6 +47,8 @@ func CheckNode(ctx Config, allClients Client) (CheckNodeResult, error) {
 		platform = debian.NewDebian(allClients.Executor)
 	case "redhat":
 		platform = centos.NewCentOS(allClients.Executor)
+	default:
+		return RequiredFail, fmt.Errorf("This OS is not supported. Supported operating systems are: Ubuntu (16.04, 18.04) & CentOS 7.x")
 	}
 
 	// Fetch the keystone token.


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>

Returns with correct error if the CLI is being run on non-supported OS