### PR TITLE
Config is loop backed if credentials are invalid during config set command (config/check-node/prep-node).

### DIFF
--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -32,29 +32,45 @@ func init() {
 
 func checkNodeRun(cmd *cobra.Command, args []string) {
 	zap.S().Debug("==========Running check-node==========")
+	// This flag is used to loop back if user enters invalid credentials during config set.
+	credentialFlag = true
 
-	ctx, err = pmk.LoadConfig(util.Pf9DBLoc)
-	if err != nil {
-		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
-	}
+	for credentialFlag {
 
-	executor, err := getExecutor()
-	if err != nil {
-		zap.S().Debug("Error connecting to host %s", err.Error())
-		zap.S().Fatalf(" Invalid (Username/Password/IP)")
-	}
+		ctx, err = pmk.LoadConfig(util.Pf9DBLoc)
+		if err != nil {
+			zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
+		}
 
-	c, err = pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)
-	if err != nil {
-		zap.S().Fatalf("Unable to load clients needed for the Cmd. Error: %s", err.Error())
+		executor, err := getExecutor()
+		if err != nil {
+			zap.S().Debug("Error connecting to host %s", err.Error())
+			zap.S().Fatalf(" Invalid (Username/Password/IP)")
+		}
+
+		c, err = pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)
+		if err != nil {
+			zap.S().Fatalf("Unable to load clients needed for the Cmd. Error: %s", err.Error())
+		}
+
+		// Validate the user credentials entered during config set and will loop back again if invalid
+		if err := validateUserCredentials(ctx, c); err != nil {
+			//zap.S().Fatalf("Invalid credentials (Username/ Password/ Account), run 'pf9ctl config set' with correct credentials.")
+			zap.S().Info("Invalid credentials entered (Username/Password/Tenant)")
+		} else {
+			// We will store the set config if its set for first time using check-node
+			if pmk.IsNewConfig {
+				if err := pmk.StoreConfig(ctx, util.Pf9DBLoc); err != nil {
+					zap.S().Errorf("Failed to store config: %s", err.Error())
+				} else {
+					pmk.IsNewConfig = false
+				}
+			}
+			credentialFlag = false
+		}
 	}
 
 	defer c.Segment.Close()
-
-	// Validate the user credentials entered during config set and will bail out if invalid
-	if err := validateUserCredentials(ctx, c); err != nil {
-		zap.S().Fatalf("Invalid credentials (Username/ Password/ Account), run 'pf9ctl config set' with correct credentials.")
-	}
 
 	result, err := pmk.CheckNode(ctx, c)
 	if err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -24,34 +24,43 @@ var (
 	ctx pmk.Config
 	err error
 	c   pmk.Client
+	// This flag is used to loop back if user enters invalid credentials during config set.
+	credentialFlag bool
 )
 
 func configCmdCreateRun(cmd *cobra.Command, args []string) {
 	zap.S().Debug("==========Running set config==========")
+	credentialFlag = true
+	for credentialFlag {
+		// invoked the configcreate command from pkg/pmk
+		ctx, _ = pmk.ConfigCmdCreateRun()
 
-	// invoked the configcreate command from pkg/pmk
-	ctx = pmk.ConfigCmdCreateRun()
+		executor, err := getExecutor()
+		if err != nil {
+			zap.S().Fatalf("Error connecting to host %s", err.Error())
+		}
 
-	executor, err := getExecutor()
-	if err != nil {
-		zap.S().Fatalf("Error connecting to host %s", err.Error())
-	}
+		c, err = pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)
+		if err != nil {
+			zap.S().Fatalf("Unable to load clients needed for the Cmd. Error: %s", err.Error())
+		}
 
-	c, err = pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)
-	if err != nil {
-		zap.S().Fatalf("Unable to load clients needed for the Cmd. Error: %s", err.Error())
-	}
+		// Validate the user credentials entered during config set and will bail out if invalid
 
-	// Validate the user credentials entered during config set and will bail out if invalid
+		if err := validateUserCredentials(ctx, c); err != nil {
+			//zap.S().Fatalf("Invalid credentials (Username/ Password/ Account), run 'pf9ctl config set' with correct credentials.")
+			zap.S().Info("Invalid credentials entered (Username/Password/Tenant)")
 
-	if err := validateUserCredentials(ctx, c); err != nil {
-		zap.S().Fatalf("Invalid credentials (Username/ Password/ Account), run 'pf9ctl config set' with correct credentials.")
+		} else {
+			break
+		}
 	}
 
 	defer c.Segment.Close()
 
 	if err := pmk.StoreConfig(ctx, util.Pf9DBLoc); err != nil {
 		zap.S().Errorf("Failed to store config: %s", err.Error())
+
 	}
 
 	zap.S().Debug("==========Finished running set config==========")

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -30,7 +30,9 @@ var (
 
 func configCmdCreateRun(cmd *cobra.Command, args []string) {
 	zap.S().Debug("==========Running set config==========")
+
 	credentialFlag = true
+
 	for credentialFlag {
 		// invoked the configcreate command from pkg/pmk
 		ctx, _ = pmk.ConfigCmdCreateRun()
@@ -52,7 +54,7 @@ func configCmdCreateRun(cmd *cobra.Command, args []string) {
 			zap.S().Info("Invalid credentials entered (Username/Password/Tenant)")
 
 		} else {
-			break
+			credentialFlag = false
 		}
 	}
 

--- a/pkg/pmk/config.go
+++ b/pkg/pmk/config.go
@@ -10,12 +10,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/platform9/pf9ctl/pkg/util"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
 var ErrConfigurationDetailsNotProvided = errors.New("config not set,....")
+
+var IsNewConfig bool
 
 // Config stores information to contact with the pf9 controller.
 type Config struct {
@@ -55,8 +56,12 @@ func LoadConfig(loc string) (Config, error) {
 		if os.IsNotExist(err) {
 			// to initiate the config create and store it
 			zap.S().Info("Existing config not found, prompting for new config.")
-			ctx := ConfigCmdCreateRun()
-			err := StoreConfig(ctx, util.Pf9DBLoc)
+
+			ctx, err := ConfigCmdCreateRun()
+
+			// It is set true when we are setting config for the first time using check-node/prep-node
+			IsNewConfig = true
+			//err := StoreConfig(ctx, util.Pf9DBLoc)
 			return ctx, err
 		}
 		return Config{}, err
@@ -78,7 +83,7 @@ func LoadConfig(loc string) (Config, error) {
 }
 
 // ConfigCmdCreatRun will initiate the config set and return a config given by user
-func ConfigCmdCreateRun() Config {
+func ConfigCmdCreateRun() (Config, error) {
 
 	zap.S().Debug("==========Running set config==========")
 
@@ -121,6 +126,6 @@ func ConfigCmdCreateRun() Config {
 		WaitPeriod:    time.Duration(60),
 		AllowInsecure: false,
 	}
-	return ctx
+	return ctx, nil
 
 }


### PR DESCRIPTION
* Added the loop back part for check-node, config, prep-node if user enters invalid credentials during config set. 
<img width="854" alt="Screenshot 2021-03-08 at 6 30 55 PM" src="https://user-images.githubusercontent.com/77390180/110326090-31659280-803e-11eb-9a22-4c784a701d81.png">

<img width="716" alt="Screenshot 2021-03-08 at 6 35 12 PM" src="https://user-images.githubusercontent.com/77390180/110326100-33c7ec80-803e-11eb-8777-37b41907acb2.png">

<img width="569" alt="Screenshot 2021-03-08 at 4 29 47 PM" src="https://user-images.githubusercontent.com/77390180/110326122-3b879100-803e-11eb-9db1-a4fe79d8728c.png">


