### PR TITLE
Added more appropriate message for OS packages check.

### DIFF
--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -39,7 +39,7 @@ func (c *CentOS) Check() []platform.Check {
 	checks = append(checks, platform.Check{"Removal of existing CLI", false, result, err, util.PyCliErr})
 
 	result, err = c.checkExistingInstallation()
-	checks = append(checks, platform.Check{"Existing pf9 Packages Check", true, result, err, util.ExisitngInstallationErr})
+	checks = append(checks, platform.Check{"Existing Platform9 Packages Check", true, result, err, util.ExisitngInstallationErr})
 
 	result, err = c.checkOSPackages()
 	checks = append(checks, platform.Check{"Required OS Packages Check", true, result, err, fmt.Sprintf("%s. %s", util.OSPackagesErr, err)})

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -38,7 +38,7 @@ func (d *Debian) Check() []platform.Check {
 	checks = append(checks, platform.Check{"Removal of existing CLI", false, result, err, util.PyCliErr})
 
 	result, err = d.checkExistingInstallation()
-	checks = append(checks, platform.Check{"Existing pf9 Packages Check", true, result, err, util.ExisitngInstallationErr})
+	checks = append(checks, platform.Check{"Existing Platform9 Packages Check", true, result, err, util.ExisitngInstallationErr})
 
 	result, err = d.checkOSPackages()
 	checks = append(checks, platform.Check{"Required OS Packages Check", true, result, err, fmt.Sprintf("%s. %s", util.OSPackagesErr, err)})


### PR DESCRIPTION
 ./pf9ctl check-node
✓ Loaded Config Successfully
✓ Removal of existing CLI
x Existing Installation Check - Platform9 packages already exist. These must be uninstalled.
✓ Required OS Packages Check
✓ SudoCheck
✓ CPUCheck
✓ DiskCheck
✓ MemoryCheck
x PortCheck - Following port(s) should not be in use: 10250, 3306
x Existing Kubernetes Cluster Check - A Kubernetes cluster is already running on node

x Required pre-requisite check(s) failed. See /home/ubuntu/pf9/log/pf9ctl-20210325.log or use --verbose for logs 


✓ Loaded Config Successfully
✓ Removal of existing CLI
x Existing pf9 Packages Check - Platform9 packages already exist. These must be uninstalled.
✓ Required OS Packages Check
✓ SudoCheck
✓ CPUCheck
✓ DiskCheck
✓ MemoryCheck
x PortCheck - Following port(s) should not be in use: 10250, 3306
x Existing Kubernetes Cluster Check - A Kubernetes cluster is already running on node

x Required pre-requisite check(s) failed. See /home/ubuntu/pf9/log/pf9ctl-20210325.log or use --verbose for logs 