### PR TITLE
Added segment key for correct source

### DIFF
--- a/pkg/pmk/segment.go
+++ b/pkg/pmk/segment.go
@@ -13,7 +13,8 @@ import (
 	"gopkg.in/segmentio/analytics-go.v3"
 )
 
-const segmentWriteKey = "P6DycMCALprZrUwWL9ZzRLlfMQwL5Xyl"
+//Added segment key for the source PRD-PMKFT Metrics-Aggregator
+const segmentWriteKey = "4jevYUNBF5sY3vZJWm5TrhfdsFzQIQ3y"
 
 type Segment interface {
 	SendEvent(string, interface{}, string, string) error


### PR DESCRIPTION
Ran check-node command to confirm that the events were sent successfully to the segment source PRD-PMKFT Metrics-Aggregator and the amplitude destination Production - Platform9 K8s.