### PR TITLE
added skipCheck flag to prep-node

### DIFF
--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -29,11 +29,11 @@ var prepNodeCmd = &cobra.Command{
 }
 
 var (
-	user      string
-	password  string
-	sshKey    string
-	ips       []string
-	skipCheck bool
+	user       string
+	password   string
+	sshKey     string
+	ips        []string
+	skipChecks bool
 	//floatingIP bool
 )
 
@@ -42,7 +42,7 @@ func init() {
 	prepNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes")
 	prepNodeCmd.Flags().StringVarP(&sshKey, "ssh-key", "s", "", "ssh key file for connecting to the nodes")
 	prepNodeCmd.Flags().StringSliceVarP(&ips, "ip", "i", []string{}, "IP address of host to be prepared")
-	prepNodeCmd.Flags().BoolVarP(&skipCheck, "skipCheck", "c", false, "Will skip optional check if true")
+	prepNodeCmd.Flags().BoolVarP(&skipChecks, "skipChecks", "c", false, "Will skip optional checks if true")
 	//prepNodeCmd.Flags().BoolVarP(&floatingIP, "floating-ip", "f", false, "") //Unsupported in first version.
 
 	rootCmd.AddCommand(prepNodeCmd)
@@ -100,7 +100,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 	if result == pmk.RequiredFail {
 		fmt.Println(color.Red("x ") + "Required pre-requisite check(s) failed.")
 		return
-	} else if !skipCheck {
+	} else if !skipChecks {
 		if result == pmk.OptionalFail {
 			fmt.Print("\nOptional pre-requisite check(s) failed. Do you want to continue? (y/n) ")
 			reader := bufio.NewReader(os.Stdin)


### PR DESCRIPTION
Added flag in prep-node command to skip optional checks during node onboarding.

./pf9ctl prep-node --help
Prepare a node to be ready to be added to a Kubernetes cluster. Read more
	at http://pf9.io/cli_clprep.

Usage:
  pf9ctl prep-node [flags]

Flags:
  -h, --help              help for prep-node
  -i, --ip strings        IP address of host to be prepared
  -p, --password string   ssh password for the nodes
  -c, --skipCheck         Will skip optional check if true
  -s, --ssh-key string    ssh key file for connecting to the nodes
  -u, --user string       ssh username for the nodes

Global Flags:
      --verbose   print verbose logs