### PR TITLE
fixed authentication failure for special character in du password

### DIFF
--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -236,7 +236,7 @@ func installHostAgentCertless(ctx Config, regionURL string, auth keystone.Keysto
 	}
 	zap.S().Debug("Hostagent download completed successfully")
 
-	installOptions := fmt.Sprintf(`--no-project --controller=%s --username=%s --password=%s`, regionURL, ctx.Username, ctx.Password)
+	installOptions := fmt.Sprintf(`--no-project --controller=%s --username=%s --password='%s'`, regionURL, ctx.Username, ctx.Password)
 
 	_, err = exec.RunWithStdout("bash", "-c", "chmod +x /tmp/installer.sh")
 	if err != nil {


### PR DESCRIPTION
Prep-node was failing if $$ exist in DU password. So passed it in single quotes.
---------logs----------
Downloading the Hostagent (this might take a few minutes...) 2021-04-23T06:23:52.6254Z	DEBUG	Ran command sudo[bash -c /tmp/installer.sh --no-proxy --skip-os-check --ntpd --no-project --controller=pmkft-1610399152-81236.platform9.io --username=devidas+1@platform9.com --password='Password']
2021-04-23T06:23:52.6257Z	DEBUG	stdout:
Extracting Platform9 installer

No TTY available. Skipping all prompts...
No TTY available. Skipping all prompts...
Skipping operating system compatibility questions
Reading package lists...
Building dependency tree...
Reading state information...
ntp is already the newest version (1:4.2.8p10+dfsg-5ubuntu7.3).
The following packages were automatically installed and are no longer required:
  cgroup-tools grub-pc-bin ipvsadm keepalived libcgroup1 libnl-3-200
  libnl-genl-3-200 libnl-route-3-200 libsnmp-base libsnmp30 socat