### PR TITLE
Modified FQDN fetching in supportBundle

### DIFF
--- a/pkg/supportBundle/supportBundle.go
+++ b/pkg/supportBundle/supportBundle.go
@@ -92,6 +92,11 @@ func SupportBundleUpload(ctx pmk.Config, allClients pmk.Client) error {
 		zap.S().Debug("unable to fetch fqdn: %w")
 		return fmt.Errorf("unable to fetch fqdn: %w", err)
 	}
+	//To fetch FQDN from config if region given is invalid
+	if FQDN == "" {
+		FQDN = ctx.Fqdn
+		FQDN = strings.Replace(FQDN, "https://", "", 1)
+	}
 
 	// S3 location to upload the file
 	S3_Location = S3_Loc + "/" + FQDN + "/" + hostIP + "/"


### PR DESCRIPTION
If user provides invalid region during config-set, then FQDN is fetched using the config instead of FetchRegionFQDN function ,while uploading supportBundle to S3.The FetchRegionFQDN function returns an empty string in case of invalid region provided, as in the below user's case.

FT- User issue:
<img width="1404" alt="Screenshot 2021-04-28 at 6 14 54 PM" src="https://user-images.githubusercontent.com/65108449/116415327-f1a97300-a856-11eb-8880-62e2c44b6a3d.png">

DU-URL missing:
<img width="521" alt="Screenshot 2021-04-28 at 7 23 03 PM" src="https://user-images.githubusercontent.com/65108449/116415729-4ea52900-a857-11eb-8f25-440d17f8156b.png">

Output after modification in code:
<img width="1424" alt="Screenshot 2021-04-28 at 7 11 37 PM" src="https://user-images.githubusercontent.com/65108449/116415938-857b3f00-a857-11eb-9007-0ad6d9291057.png">


