### PR TITLE
Added message for remote case password passing though -p flag.

### DIFF
--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -24,7 +24,7 @@ var checkNodeCmd = &cobra.Command{
 
 func init() {
 	checkNodeCmd.Flags().StringVarP(&user, "user", "u", "", "ssh username for the nodes")
-	checkNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes")
+	checkNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes (use eg: 'single quotes' to pass password)")
 	checkNodeCmd.Flags().StringVarP(&sshKey, "ssh-key", "s", "", "ssh key file for connecting to the nodes")
 	checkNodeCmd.Flags().StringSliceVarP(&ips, "ip", "i", []string{}, "IP address of host to be prepared")
 	//checkNodeCmd.Flags().BoolVarP(&floatingIP, "floating-ip", "f", false, "") //Unsupported in first version.
@@ -48,8 +48,8 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 
 		executor, err := getExecutor()
 		if err != nil {
+			zap.S().Fatalf(" Invalid (Username/Password/IP) or use eg: 'single quotes' to pass password")
 			zap.S().Debug("Error connecting to host %s", err.Error())
-			zap.S().Fatalf(" Invalid (Username/Password/IP)")
 		}
 
 		c, err = pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -24,7 +24,7 @@ var checkNodeCmd = &cobra.Command{
 
 func init() {
 	checkNodeCmd.Flags().StringVarP(&user, "user", "u", "", "ssh username for the nodes")
-	checkNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes (use eg: 'single quotes' to pass password)")
+	checkNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes (use 'single quotes' to pass password)")
 	checkNodeCmd.Flags().StringVarP(&sshKey, "ssh-key", "s", "", "ssh key file for connecting to the nodes")
 	checkNodeCmd.Flags().StringSliceVarP(&ips, "ip", "i", []string{}, "IP address of host to be prepared")
 	//checkNodeCmd.Flags().BoolVarP(&floatingIP, "floating-ip", "f", false, "") //Unsupported in first version.
@@ -48,7 +48,7 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 
 		executor, err := getExecutor()
 		if err != nil {
-			zap.S().Fatalf(" Invalid (Username/Password/IP) or use eg: 'single quotes' to pass password")
+			zap.S().Fatalf(" Invalid (Username/Password/IP), use 'single quotes' to pass password")
 			zap.S().Debug("Error connecting to host %s", err.Error())
 		}
 

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -46,7 +46,7 @@ var (
 
 func init() {
 	prepNodeCmd.Flags().StringVarP(&user, "user", "u", "", "ssh username for the nodes")
-	prepNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes (use eg: 'single quotes' to pass password)")
+	prepNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes (use 'single quotes' to pass password)")
 	prepNodeCmd.Flags().StringVarP(&sshKey, "ssh-key", "s", "", "ssh key file for connecting to the nodes")
 	prepNodeCmd.Flags().StringSliceVarP(&ips, "ip", "i", []string{}, "IP address of host to be prepared")
 	prepNodeCmd.Flags().BoolVarP(&skipChecks, "skipChecks", "c", false, "Will skip optional checks if true")
@@ -72,7 +72,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 		executor, err := getExecutor()
 		if err != nil {
 			zap.S().Debug("Error connecting to host %s", err.Error())
-			zap.S().Fatalf(" Invalid (Username/Password/IP) or use eg: 'single quotes' to pass password")
+			zap.S().Fatalf(" Invalid (Username/Password/IP), use 'single quotes' to pass password")
 		}
 
 		c, err = pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -46,7 +46,7 @@ var (
 
 func init() {
 	prepNodeCmd.Flags().StringVarP(&user, "user", "u", "", "ssh username for the nodes")
-	prepNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes")
+	prepNodeCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes (use eg: 'single quotes' to pass password)")
 	prepNodeCmd.Flags().StringVarP(&sshKey, "ssh-key", "s", "", "ssh key file for connecting to the nodes")
 	prepNodeCmd.Flags().StringSliceVarP(&ips, "ip", "i", []string{}, "IP address of host to be prepared")
 	prepNodeCmd.Flags().BoolVarP(&skipChecks, "skipChecks", "c", false, "Will skip optional checks if true")
@@ -72,7 +72,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 		executor, err := getExecutor()
 		if err != nil {
 			zap.S().Debug("Error connecting to host %s", err.Error())
-			zap.S().Fatalf(" Invalid (Username/Password/IP)")
+			zap.S().Fatalf(" Invalid (Username/Password/IP) or use eg: 'single quotes' to pass password")
 		}
 
 		c, err = pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)

--- a/cmd/supportBundle.go
+++ b/cmd/supportBundle.go
@@ -24,7 +24,7 @@ var supportBundleCmd = &cobra.Command{
 //This initialization is using create commands which is not in use for now.
 func init() {
 	supportBundleCmd.Flags().StringVarP(&user, "user", "u", "", "ssh username for the nodes")
-	supportBundleCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes (use eg: 'single quotes' to pass password)")
+	supportBundleCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes (use 'single quotes' to pass password)")
 	supportBundleCmd.Flags().StringVarP(&sshKey, "ssh-key", "s", "", "ssh key file for connecting to the nodes")
 	supportBundleCmd.Flags().StringSliceVarP(&ips, "ip", "i", []string{}, "IP address of host to be prepared")
 
@@ -48,7 +48,7 @@ func supportBundleUpload(cmd *cobra.Command, args []string) {
 		executor, err := getExecutor()
 		if err != nil {
 			zap.S().Debug("Error connecting to host %s", err.Error())
-			zap.S().Fatalf(" Invalid (Username/Password/IP) or use eg: 'single quotes' to pass password")
+			zap.S().Fatalf(" Invalid (Username/Password/IP), use 'single quotes' to pass password")
 		}
 
 		c, err = pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)

--- a/cmd/supportBundle.go
+++ b/cmd/supportBundle.go
@@ -24,7 +24,7 @@ var supportBundleCmd = &cobra.Command{
 //This initialization is using create commands which is not in use for now.
 func init() {
 	supportBundleCmd.Flags().StringVarP(&user, "user", "u", "", "ssh username for the nodes")
-	supportBundleCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes")
+	supportBundleCmd.Flags().StringVarP(&password, "password", "p", "", "ssh password for the nodes (use eg: 'single quotes' to pass password)")
 	supportBundleCmd.Flags().StringVarP(&sshKey, "ssh-key", "s", "", "ssh key file for connecting to the nodes")
 	supportBundleCmd.Flags().StringSliceVarP(&ips, "ip", "i", []string{}, "IP address of host to be prepared")
 
@@ -48,7 +48,7 @@ func supportBundleUpload(cmd *cobra.Command, args []string) {
 		executor, err := getExecutor()
 		if err != nil {
 			zap.S().Debug("Error connecting to host %s", err.Error())
-			zap.S().Fatalf(" Invalid (Username/Password/IP)")
+			zap.S().Fatalf(" Invalid (Username/Password/IP) or use eg: 'single quotes' to pass password")
 		}
 
 		c, err = pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)


### PR DESCRIPTION
Added message for remote case password passing though -p flag since "authentication fails if password contains any special characters repeatedly such as ($$, &&, !!, ()). Then we have to pass password in single quotes like eg: 'password single quoted' 

Output:
<img width="1070" alt="Screenshot 2021-05-04 at 11 22 49 AM" src="https://user-images.githubusercontent.com/77390180/116965706-07da8780-accc-11eb-8154-90faf2249f5e.png">
<img width="1070" alt="Screenshot 2021-05-04 at 11 23 19 AM" src="https://user-images.githubusercontent.com/77390180/116965709-090bb480-accc-11eb-9e57-22be55767098.png">

