### PR TITLE
Moved swap off to check-node

### DIFF
--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -29,7 +29,7 @@ var prepNodeCmd = &cobra.Command{
 	Run: prepNodeRun,
 	Args: func(prepNodeCmd *cobra.Command, args []string) error {
 		if prepNodeCmd.Flags().Changed("disableSwapOff") {
-			pmk.SwapOffDisabled = true
+			util.SwapOffDisabled = true
 		}
 		return nil
 	},

--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -296,7 +296,7 @@ func (c *CentOS) installOSPackages(p string) error {
 func (c *CentOS) disableSwap() (bool, error) {
 	err := swapoff.SetupNode(c.exec)
 	if err != nil {
-		return false, errors.New("error occured while removing swap")
+		return false, errors.New("error occured while disabling swap")
 	} else {
 		return true, nil
 	}

--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/platform9/pf9ctl/pkg/cmdexec"
 	"github.com/platform9/pf9ctl/pkg/platform"
+	"github.com/platform9/pf9ctl/pkg/swapoff"
 	"github.com/platform9/pf9ctl/pkg/util"
 	"go.uber.org/zap"
 )
@@ -61,6 +62,11 @@ func (c *CentOS) Check() []platform.Check {
 
 	result, err = c.checkKubernetesCluster()
 	checks = append(checks, platform.Check{"Existing Kubernetes Cluster Check", true, result, err, fmt.Sprintf("%s", err)})
+
+	if !util.SwapOffDisabled {
+		result, err = c.disableSwap()
+		checks = append(checks, platform.Check{"Disabling swap and removing swap in fstab", true, result, err, fmt.Sprintf("%s", err)})
+	}
 
 	return checks
 }
@@ -268,7 +274,7 @@ func (c *CentOS) Version() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Couldn't read the OS configuration file os-release: %s", err.Error())
 	}
-	if match, _:= regexp.MatchString(`.*7\.[3-9]\.*|.*8\.[3]\.*`, string(out)); match {
+	if match, _ := regexp.MatchString(`.*7\.[3-9]\.*|.*8\.[3]\.*`, string(out)); match {
 		return "redhat", nil
 	}
 	return "", fmt.Errorf("Unable to determine OS type: %s", string(out))
@@ -285,4 +291,13 @@ func (c *CentOS) installOSPackages(p string) error {
 	zap.S().Debugf("Trying to install package %s", p)
 	_, err = c.exec.RunWithStdout("bash", "-c", fmt.Sprintf("yum -q -y install %s", p))
 	return nil
+}
+
+func (c *CentOS) disableSwap() (bool, error) {
+	err := swapoff.SetupNode(c.exec)
+	if err != nil {
+		return false, errors.New("error occured while removing swap")
+	} else {
+		return true, nil
+	}
 }

--- a/pkg/platform/centos/centos_test.go
+++ b/pkg/platform/centos/centos_test.go
@@ -563,3 +563,53 @@ func TestCheckDocker(t *testing.T) {
 		})
 	}
 }
+
+func TestDisableSwap(t *testing.T) {
+	type want struct {
+		result bool
+		err    error
+	}
+
+	cases := map[string]struct {
+		args
+		want
+	}{
+		//Success case. returns true on successful execution
+		"CheckPass": {
+			args: args{
+				exec: &cmdexec.MockExecutor{
+					MockRunWithStdout: func(name string, args ...string) (string, error) {
+						return "0", nil
+					},
+				},
+			},
+			want: want{
+				result: true,
+				err:    nil,
+			},
+		},
+		//Failure case. returns false if error occured while disabling swap.
+		"CheckFail": {
+			args: args{
+				exec: &cmdexec.MockExecutor{
+					MockRunWithStdout: func(name string, args ...string) (string, error) {
+						return "1", errors.New("error occured while disabling swap")
+					},
+				},
+			},
+			want: want{
+				result: false,
+				err:    errors.New("error occured while disabling swap"),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &CentOS{exec: tc.exec}
+			result, err := c.disableSwap()
+			assert.Equal(t, tc.result, result)
+			assert.Equal(t, tc.err, err)
+		})
+	}
+}

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -297,7 +297,7 @@ func (d *Debian) installOSPackages(p string) error {
 func (d *Debian) disableSwap() (bool, error) {
 	err := swapoff.SetupNode(d.exec)
 	if err != nil {
-		return false, errors.New("error occured while removing swap")
+		return false, errors.New("error occured while disabling swap")
 	} else {
 		return true, nil
 	}

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/platform9/pf9ctl/pkg/cmdexec"
 	"github.com/platform9/pf9ctl/pkg/platform"
+	"github.com/platform9/pf9ctl/pkg/swapoff"
 	"github.com/platform9/pf9ctl/pkg/util"
 	"go.uber.org/zap"
 )
@@ -61,6 +62,10 @@ func (d *Debian) Check() []platform.Check {
 	result, err = d.checkKubernetesCluster()
 	checks = append(checks, platform.Check{"Existing Kubernetes Cluster Check", true, result, err, fmt.Sprintf("%s", err)})
 
+	if !util.SwapOffDisabled {
+		result, err = d.disableSwap()
+		checks = append(checks, platform.Check{"Disabling swap and removing swap in fstab", true, result, err, fmt.Sprintf("%s", err)})
+	}
 	return checks
 }
 
@@ -287,4 +292,13 @@ func (d *Debian) installOSPackages(p string) error {
 	zap.S().Debugf("Trying to install package %s", p)
 	_, err = d.exec.RunWithStdout("bash", "-c", fmt.Sprintf("apt install -qq -y %s", p))
 	return nil
+}
+
+func (d *Debian) disableSwap() (bool, error) {
+	err := swapoff.SetupNode(d.exec)
+	if err != nil {
+		return false, errors.New("error occured while removing swap")
+	} else {
+		return true, nil
+	}
 }

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
-	"github.com/platform9/pf9ctl/pkg/cmdexec"
 	"github.com/platform9/pf9ctl/pkg/color"
 	"github.com/platform9/pf9ctl/pkg/platform"
 	"github.com/platform9/pf9ctl/pkg/platform/centos"
@@ -86,11 +85,6 @@ func CheckNode(ctx Config, allClients Client) (CheckNodeResult, error) {
 	defer s.Stop()
 	s.Suffix = " Running pre-requisite checks and installing any missing OS packages"
 	checks := platform.Check()
-	if !SwapOffDisabled {
-		checks = disableSwap(os, allClients.Executor, checks)
-	} else {
-		zap.S().Debug("disableSwapOff is set, not disabling the swap")
-	}
 	s.Stop()
 
 	//We will print console if any missing os packages installed
@@ -144,18 +138,4 @@ func CheckNode(ctx Config, allClients Client) (CheckNodeResult, error) {
 		return PASS, nil
 	}
 
-}
-
-func disableSwap(os string, exec cmdexec.Executor, checks []platform.Check) []platform.Check {
-	var isSwapRemoved bool
-	err := setupNode(os, exec)
-	if err != nil {
-		errStr := "Error: Unable to disable swap. " + err.Error()
-		isSwapRemoved = false
-		checks = append(checks, platform.Check{"Disabling swap and removing swap in fstab", true, isSwapRemoved, err, errStr})
-	} else {
-		isSwapRemoved = true
-		checks = append(checks, platform.Check{"Disabling swap and removing swap in fstab", true, isSwapRemoved, err, ""})
-	}
-	return checks
 }

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -94,25 +94,6 @@ func PrepNode(ctx Config, allClients Client) error {
 		return fmt.Errorf(errStr)
 	}
 
-	if !SwapOffDisabled {
-		sendSegmentEvent(allClients, "Disabling swap - 1", auth, false)
-		s.Suffix = " Disabling swap and removing swap in fstab"
-
-		err = setupNode(hostOS, allClients.Executor)
-
-		if err != nil {
-			errStr := "Error: Unable to disable swap. " + err.Error()
-			sendSegmentEvent(allClients, errStr, auth, true)
-			return fmt.Errorf(errStr)
-		}
-
-		s.Stop()
-		fmt.Println(color.Green("✓ ") + "Disabled swap and removed swap in fstab")
-		s.Restart()
-	} else {
-		zap.S().Debug("disableSwapOff is set, not disabling the swap")
-	}
-
 	sendSegmentEvent(allClients, "Installing hostagent - 2", auth, false)
 	s.Suffix = " Downloading the Hostagent (this might take a few minutes...)"
 	if err := installHostAgent(ctx, auth, hostOS, allClients.Executor); err != nil {

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -21,9 +21,6 @@ import (
 // This variable is assigned with StatusCode during hostagent installation
 var HostAgent int
 
-//If this is true the swapOff functionality will be disabled.
-var SwapOffDisabled bool
-
 const (
 	// Response Status Codes
 	HostAgentCertless = 200

--- a/pkg/swapoff/swapoff.go
+++ b/pkg/swapoff/swapoff.go
@@ -1,4 +1,4 @@
-package pmk
+package swapoff
 
 import (
 	"fmt"
@@ -8,7 +8,7 @@ import (
 )
 
 // This files needs to be organized little better
-func setupNode(hostOS string, exec cmdexec.Executor) (err error) {
+func SetupNode(exec cmdexec.Executor) (err error) {
 	zap.S().Debug("Received a call to setup the node")
 
 	if err := swapOff(exec); err != nil {

--- a/pkg/swapoff/swapoff_test.go
+++ b/pkg/swapoff/swapoff_test.go
@@ -1,4 +1,4 @@
-package pmk
+package swapoff
 
 import (
 	"fmt"

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -9,6 +9,7 @@ import (
 var RequiredPorts []string
 var PortErr string
 var ProcessesList []string //Kubernetes clusters processes list
+var SwapOffDisabled bool   //If this is true the swapOff functionality will be disabled.
 
 const (
 


### PR DESCRIPTION
Moved swap off functionality from prep-node to check-node

./pf9ctl prep-node -i 172.20.7.2 -u ubuntu -s /home/ubuntu/.ssh/mykey
✓ Loaded Config Successfully
✓ Removal of existing CLI
✓ Existing Platform9 Packages Check
✓ Required OS Packages Check
✓ SudoCheck
✓ CPUCheck
✓ DiskCheck
✓ MemoryCheck
✓ PortCheck
✓ Existing Kubernetes Cluster Check
✓ Disabling swap and removing swap in fstab

✓ Completed Pre-Requisite Checks successfully

------------------------------------------------------------
./pf9ctl prep-node -i 172.20.7.109 -u ubuntu -s /home/ubuntu/.ssh/mykey --disableSwapOff
✓ Loaded Config Successfully
✓ Removal of existing CLI
x Existing Platform9 Packages Check - Platform9 packages already exist. These must be uninstalled.
✓ Required OS Packages Check
✓ SudoCheck
✓ CPUCheck
✓ DiskCheck
✓ MemoryCheck
x PortCheck - Following port(s) should not be in use: 10250, 3306
x Existing Kubernetes Cluster Check - A Kubernetes cluster is already running on node

x Required pre-requisite check(s) failed.