### PR TITLE
Added noexec permission check for /tmp dir

### DIFF
--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -63,6 +63,9 @@ func (c *CentOS) Check() []platform.Check {
 	result, err = c.checkKubernetesCluster()
 	checks = append(checks, platform.Check{"Existing Kubernetes Cluster Check", true, result, err, fmt.Sprintf("%s", err)})
 
+	result, err = c.checkNoexecPermission()
+	checks = append(checks, platform.Check{"Check exec permission on /tmp", true, result, err, fmt.Sprintf("%s", err)})
+
 	if !util.SwapOffDisabled {
 		result, err = c.disableSwap()
 		checks = append(checks, platform.Check{"Disabling swap and removing swap in fstab", true, result, err, fmt.Sprintf("%s", err)})
@@ -299,5 +302,14 @@ func (c *CentOS) disableSwap() (bool, error) {
 		return false, errors.New("error occured while disabling swap")
 	} else {
 		return true, nil
+	}
+}
+
+func (c *CentOS) checkNoexecPermission() (bool, error) {
+	_, err := c.exec.RunWithStdout("bash", "-c", "mount | grep /tmp")
+	if err != nil {
+		return true, nil
+	} else {
+		return false, errors.New("/tmp is not having exec permission")
 	}
 }

--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -306,7 +306,7 @@ func (c *CentOS) disableSwap() (bool, error) {
 }
 
 func (c *CentOS) checkNoexecPermission() (bool, error) {
-	_, err := c.exec.RunWithStdout("bash", "-c", "mount | grep /tmp")
+	_, err := c.exec.RunWithStdout("bash", "-c", "mount | grep /tmp | grep noexec")
 	if err != nil {
 		return true, nil
 	} else {

--- a/pkg/platform/centos/centos_test.go
+++ b/pkg/platform/centos/centos_test.go
@@ -613,3 +613,53 @@ func TestDisableSwap(t *testing.T) {
 		})
 	}
 }
+
+func TestNoexecPermissionCheck(t *testing.T) {
+	type want struct {
+		result bool
+		err    error
+	}
+
+	cases := map[string]struct {
+		args
+		want
+	}{
+		//Success case. successful execution of grep command returns error.
+		"CheckPass": {
+			args: args{
+				exec: &cmdexec.MockExecutor{
+					MockRunWithStdout: func(name string, args ...string) (string, error) {
+						return "0", nil
+					},
+				},
+			},
+			want: want{
+				result: false,
+				err:    errors.New("/tmp is not having exec permission"),
+			},
+		},
+		//Failure case. if output of grep command is empty then it returns nil error.
+		"CheckFail": {
+			args: args{
+				exec: &cmdexec.MockExecutor{
+					MockRunWithStdout: func(name string, args ...string) (string, error) {
+						return "1", errors.New("ERROR")
+					},
+				},
+			},
+			want: want{
+				result: true,
+				err:    nil,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &CentOS{exec: tc.exec}
+			result, err := c.checkNoexecPermission()
+			assert.Equal(t, tc.result, result)
+			assert.Equal(t, tc.err, err)
+		})
+	}
+}

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -307,7 +307,7 @@ func (d *Debian) disableSwap() (bool, error) {
 }
 
 func (d *Debian) checkNoexecPermission() (bool, error) {
-	_, err := d.exec.RunWithStdout("bash", "-c", "mount | grep /tmp")
+	_, err := d.exec.RunWithStdout("bash", "-c", "mount | grep /tmp | grep noexec")
 	if err != nil {
 		return true, nil
 	} else {

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -62,6 +62,9 @@ func (d *Debian) Check() []platform.Check {
 	result, err = d.checkKubernetesCluster()
 	checks = append(checks, platform.Check{"Existing Kubernetes Cluster Check", true, result, err, fmt.Sprintf("%s", err)})
 
+	result, err = d.checkNoexecPermission()
+	checks = append(checks, platform.Check{"Check exec permission on /tmp", true, result, err, fmt.Sprintf("%s", err)})
+
 	if !util.SwapOffDisabled {
 		result, err = d.disableSwap()
 		checks = append(checks, platform.Check{"Disabling swap and removing swap in fstab", true, result, err, fmt.Sprintf("%s", err)})
@@ -300,5 +303,14 @@ func (d *Debian) disableSwap() (bool, error) {
 		return false, errors.New("error occured while disabling swap")
 	} else {
 		return true, nil
+	}
+}
+
+func (d *Debian) checkNoexecPermission() (bool, error) {
+	_, err := d.exec.RunWithStdout("bash", "-c", "mount | grep /tmp")
+	if err != nil {
+		return true, nil
+	} else {
+		return false, errors.New("/tmp is not having exec permission")
 	}
 }

--- a/pkg/platform/debian/debian_test.go
+++ b/pkg/platform/debian/debian_test.go
@@ -610,3 +610,53 @@ func TestDisableSwap(t *testing.T) {
 		})
 	}
 }
+
+func TestNoexecPermissionCheck(t *testing.T) {
+	type want struct {
+		result bool
+		err    error
+	}
+
+	cases := map[string]struct {
+		args
+		want
+	}{
+		//Success case. successful execution of grep command returns error.
+		"CheckPass": {
+			args: args{
+				exec: &cmdexec.MockExecutor{
+					MockRunWithStdout: func(name string, args ...string) (string, error) {
+						return "0", nil
+					},
+				},
+			},
+			want: want{
+				result: false,
+				err:    errors.New("/tmp is not having exec permission"),
+			},
+		},
+		//Failure case. if output of grep command is empty then it returns nil error.
+		"CheckFail": {
+			args: args{
+				exec: &cmdexec.MockExecutor{
+					MockRunWithStdout: func(name string, args ...string) (string, error) {
+						return "1", errors.New("ERROR")
+					},
+				},
+			},
+			want: want{
+				result: true,
+				err:    nil,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := &Debian{exec: tc.exec}
+			result, err := d.checkNoexecPermission()
+			assert.Equal(t, tc.result, result)
+			assert.Equal(t, tc.err, err)
+		})
+	}
+}


### PR DESCRIPTION
./pf9ctl check-node
✓ Loaded Config Successfully
✓ Removal of existing CLI
✓ Existing Platform9 Packages Check
✓ Required OS Packages Check
✓ SudoCheck
✓ CPUCheck
✓ DiskCheck
✓ MemoryCheck
✓ PortCheck
✓ Existing Kubernetes Cluster Check
✓ Check exec permission on /tmp
✓ Disabling swap and removing swap in fstab

✓ Completed Pre-Requisite Checks successfully

-----------------------------------------------------------------
./pf9ctl prep-node
✓ Loaded Config Successfully
✓ Removal of existing CLI
✓ Existing Platform9 Packages Check
✓ Required OS Packages Check
✓ SudoCheck
✓ CPUCheck
✓ DiskCheck
✓ MemoryCheck
✓ PortCheck
✓ Existing Kubernetes Cluster Check
x Check exec permission on /tmp - /tmp is not having exec permission
✓ Disabling swap and removing swap in fstab

x Required pre-requisite check(s) failed.