### PR TITLE
Modified the message to pass password during config set through (-p flag).

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -77,7 +77,7 @@ func configCmdCreateRun(cmd *cobra.Command, args []string) {
 		if err := validateUserCredentials(ctx, c); err != nil {
 
 			if SetConfigByParameters {
-				zap.S().Fatalf("Invalid credentials entered (Username/Password/Tenant)")
+				zap.S().Fatalf("Invalid credentials entered (Username/Password/Tenant), use 'single quotes' to pass password ")
 				credentialFlag = false
 			} else {
 				//Clearing the invalid config entered. So that it will ask for new information again.
@@ -163,7 +163,7 @@ var (
 func init() {
 	configCmdSet.Flags().StringVarP(&account_url, "account_url", "u", "", "sets account_url")
 	configCmdSet.Flags().StringVarP(&username, "username", "e", "", "sets username")
-	configCmdSet.Flags().StringVarP(&Password, "password", "p", "", "sets password")
+	configCmdSet.Flags().StringVarP(&Password, "password", "p", "", "sets password (use 'single quotes' to pass password)")
 	configCmdSet.Flags().StringVarP(&region, "region", "r", "", "sets region")
 	configCmdSet.Flags().StringVarP(&tenant, "tenant", "t", "", "sets tenant")
 }


### PR DESCRIPTION
Config Set fails, if password contains special characters and passed through -p flag during config set. So, we should pass using single quotes. 

<img width="959" alt="Screenshot 2021-05-26 at 3 29 14 PM" src="https://user-images.githubusercontent.com/77390180/119641699-8e036d00-be37-11eb-8eee-dd38598c0e6e.png">
