### PR TITLE
Added validation for region during config set/config loading.  

### DIFF
--- a/cmd/attachNode.go
+++ b/cmd/attachNode.go
@@ -70,7 +70,7 @@ func attachNodeRun(cmd *cobra.Command, args []string) {
 		if err := validateUserCredentials(ctx, c); err != nil {
 			clearContext(&pmk.Context)
 			//Check if no or invalid config exists, then bail out if asked for correct config for maxLoop times.
-			err = configValidation(pmk.LoopCounter)
+			err = configValidation(RegionInvalid, pmk.LoopCounter)
 		} else {
 			// We will store the set config if its set for first time using check-node
 			if pmk.IsNewConfig {

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -62,7 +62,7 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 			//Clearing the invalid config entered. So that it will ask for new information again.
 			clearContext(&pmk.Context)
 			//Check if no or invalid config exists, then bail out if asked for correct config for maxLoop times.
-			err = configValidation(pmk.LoopCounter)
+			err = configValidation(RegionInvalid, pmk.LoopCounter)
 		} else {
 			// We will store the set config if its set for first time using check-node
 			if pmk.IsNewConfig {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -193,7 +193,7 @@ func validateUserCredentials(pmk.Config, pmk.Client) error {
 	endpointURL, err1 := pmk.FetchRegionFQDN(ctx, auth)
 	if endpointURL == "" || err1 != nil {
 		RegionInvalid = true
-		zap.S().Debug("Invalid Region entered")
+		zap.S().Debug("Invalid Region")
 		return errors.New("Invalid Region")
 	}
 
@@ -206,11 +206,12 @@ func configValidation(bool, int) error {
 
 		//Check if we are setting config through pf9ctl config set command.
 		if !SetConfig {
-			// If Oldconfig exists and invalid credentials entered
+			// If Oldconfig exists and invalid credentials entered during config prompt
 			if pmk.OldConfigExist {
 				if pmk.InvalidExistingConfig {
+					// If user enters invalid credentials during prompt of config (due to invalid config found after config loading).
 					if RegionInvalid {
-						fmt.Println("\n" + color.Red("x ") + "Invalid credentials entered (Region)")
+						fmt.Println("\n" + color.Red("x ") + "Invalid Region entered")
 						zap.S().Debug("Invalid Region entered")
 					} else {
 						fmt.Println("\n" + color.Red("x ") + "Invalid credentials entered (Platform9 Account URL/Username/Password/Region/Tenant)")
@@ -218,9 +219,10 @@ func configValidation(bool, int) error {
 					}
 
 				} else if pmk.OldConfigExist && pmk.LoopCounter == 0 {
+					// If invalid credentials are found during config loading
 					if RegionInvalid {
-						fmt.Println("\n" + color.Red("x ") + "Invalid credentials found (Region)")
-						zap.S().Debug("Invalid credentials found (Region)")
+						fmt.Println("\n" + color.Red("x ") + "Invalid Region found")
+						zap.S().Debug("Invalid Region found")
 					} else {
 						fmt.Println("\n" + color.Red("x ") + "Invalid credentials found (Platform9 Account URL/Username/Password/Region/Tenant)")
 						zap.S().Debug("Invalid credentials found (Platform9 Account URL/Username/Password/Region/Tenant)")
@@ -228,9 +230,10 @@ func configValidation(bool, int) error {
 				}
 
 			} else {
+				// If user enters invalid credentials during new config promput (due to config not found)
 				if RegionInvalid {
-					fmt.Println("\n" + color.Red("x ") + "Invalid credentials found (Region)")
-					zap.S().Debug("Invalid credentials found (Region)")
+					fmt.Println("\n" + color.Red("x ") + "Invalid Region entered")
+					zap.S().Debug("Invalid Region entered")
 				} else {
 					fmt.Println("\n" + color.Red("x ") + "Invalid credentials entered (Platform9 Account URL/Username/Password/Region/Tenant)")
 					zap.S().Debug("Invalid credentials entered (Platform9 Account URL/Username/Password/Region/Tenant)")
@@ -238,9 +241,10 @@ func configValidation(bool, int) error {
 
 			}
 		} else {
+			// If user enters invalid credentials during config set through "pf9ctl config set"
 			if RegionInvalid {
-				fmt.Println("\n" + color.Red("x ") + "Invalid credentials found (Region)")
-				zap.S().Debug("Invalid credentials found (Region)")
+				fmt.Println("\n" + color.Red("x ") + "Invalid Region entered")
+				zap.S().Debug("Invalid Region entered")
 			} else {
 				fmt.Println("\n" + color.Red("x ") + "Invalid credentials entered (Platform9 Account URL/Username/Password/Region/Tenant)")
 				zap.S().Debug("Invalid credentials entered (Platform9 Account URL/Username/Password/Region/Tenant)")
@@ -259,10 +263,14 @@ func configValidation(bool, int) error {
 
 	// If any invalid credentials extered multiple times in new config prompt then to bail out the recursive loop (thrice)
 	if pmk.LoopCounter >= MaxLoopNoConfig && !(pmk.InvalidExistingConfig) {
-		zap.S().Fatalf("Invalid credentials entered multiple times (Username/Password/Region/Tenant)")
+		zap.S().Fatalf("Invalid credentials entered multiple times (Platform9 Account URL/Username/Password/Region/Tenant)")
 	} else if pmk.LoopCounter >= MaxLoopNoConfig+1 && pmk.InvalidExistingConfig {
-		fmt.Println(color.Red("x ") + "Invalid credentials entered (Username/Password/Region/Tenant)")
-		zap.S().Fatalf("Invalid credentials entered multiple times (Username/Password/Region/Tenant)")
+		if RegionInvalid {
+			fmt.Println(color.Red("x ") + "Invalid Region entered")
+		} else {
+			fmt.Println(color.Red("x ") + "Invalid credentials entered (Platform9 Account URL/Username/Password/Region/Tenant)")
+		}
+		zap.S().Fatalf("Invalid credentials entered multiple times (Platform9 Account URL/Username/Password/Region/Tenant)")
 	}
 	return nil
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -32,6 +33,8 @@ var (
 	// This flag is true when we set config through ./pf9ctl config set
 	SetConfig             bool
 	SetConfigByParameters bool
+	// This flag is set true when only region is found/entered is invalid.
+	RegionInvalid bool
 )
 
 const MaxLoopNoConfig = 3
@@ -77,13 +80,17 @@ func configCmdCreateRun(cmd *cobra.Command, args []string) {
 		if err := validateUserCredentials(ctx, c); err != nil {
 
 			if SetConfigByParameters {
-				zap.S().Fatalf("Invalid credentials entered (Username/Password/Tenant), use 'single quotes' to pass password ")
+				if RegionInvalid {
+					zap.S().Fatalf("Invalid credentials entered (Region)")
+				} else {
+					zap.S().Fatalf("Invalid credentials entered (Platform9 Account URL/Username/Password/Region/Tenant), use 'single quotes' to pass password")
+				}
 				credentialFlag = false
 			} else {
 				//Clearing the invalid config entered. So that it will ask for new information again.
 				clearContext(&pmk.Context)
 				//Check if no or invalid config exists, then bail out if asked for correct config for maxLoop times.
-				err = configValidation(pmk.LoopCounter)
+				err = configValidation(RegionInvalid, pmk.LoopCounter)
 			}
 
 		} else {
@@ -171,15 +178,29 @@ func init() {
 // This function will validate the user credentials entered during config set and bail out if invalid
 func validateUserCredentials(pmk.Config, pmk.Client) error {
 
-	_, err = c.Keystone.GetAuth(
+	auth, err := c.Keystone.GetAuth(
 		ctx.Username,
 		ctx.Password,
 		ctx.Tenant,
 	)
-	return err
+
+	if err != nil {
+		RegionInvalid = false
+		return err
+	}
+
+	// To validate region.
+	endpointURL, err1 := pmk.FetchRegionFQDN(ctx, auth)
+	if endpointURL == "" || err1 != nil {
+		RegionInvalid = true
+		zap.S().Debug("Invalid Region entered")
+		return errors.New("Invalid Region")
+	}
+
+	return nil
 }
 
-func configValidation(int) error {
+func configValidation(bool, int) error {
 
 	if pmk.LoopCounter <= MaxLoopNoConfig-1 {
 
@@ -188,18 +209,43 @@ func configValidation(int) error {
 			// If Oldconfig exists and invalid credentials entered
 			if pmk.OldConfigExist {
 				if pmk.InvalidExistingConfig {
-					fmt.Println("\n" + color.Red("x ") + "Invalid credentials entered (Username/Password/Tenant)")
-					zap.S().Debug("Invalid credentials entered (Username/Password/Tenant)")
+					if RegionInvalid {
+						fmt.Println("\n" + color.Red("x ") + "Invalid credentials entered (Region)")
+						zap.S().Debug("Invalid Region entered")
+					} else {
+						fmt.Println("\n" + color.Red("x ") + "Invalid credentials entered (Platform9 Account URL/Username/Password/Region/Tenant)")
+						zap.S().Debug("Invalid credentials entered (Platform9 Account URL/Username/Password/Region/Tenant)")
+					}
+
 				} else if pmk.OldConfigExist && pmk.LoopCounter == 0 {
-					zap.S().Debug("Invalid credentials found (Username/Password/Tenant)")
+					if RegionInvalid {
+						fmt.Println("\n" + color.Red("x ") + "Invalid credentials found (Region)")
+						zap.S().Debug("Invalid credentials found (Region)")
+					} else {
+						fmt.Println("\n" + color.Red("x ") + "Invalid credentials found (Platform9 Account URL/Username/Password/Region/Tenant)")
+						zap.S().Debug("Invalid credentials found (Platform9 Account URL/Username/Password/Region/Tenant)")
+					}
 				}
+
 			} else {
-				fmt.Println("\n" + color.Red("x ") + "Invalid credentials entered (Username/Password/Tenant)")
-				zap.S().Debug("Invalid credentials entered (Username/Password/Tenant)")
+				if RegionInvalid {
+					fmt.Println("\n" + color.Red("x ") + "Invalid credentials found (Region)")
+					zap.S().Debug("Invalid credentials found (Region)")
+				} else {
+					fmt.Println("\n" + color.Red("x ") + "Invalid credentials entered (Platform9 Account URL/Username/Password/Region/Tenant)")
+					zap.S().Debug("Invalid credentials entered (Platform9 Account URL/Username/Password/Region/Tenant)")
+				}
+
 			}
 		} else {
-			fmt.Println("\n" + color.Red("x ") + "Invalid credentials entered (Username/Password/Tenant)")
-			zap.S().Debug("Invalid credentials entered (Username/Password/Tenant)")
+			if RegionInvalid {
+				fmt.Println("\n" + color.Red("x ") + "Invalid credentials found (Region)")
+				zap.S().Debug("Invalid credentials found (Region)")
+			} else {
+				fmt.Println("\n" + color.Red("x ") + "Invalid credentials entered (Platform9 Account URL/Username/Password/Region/Tenant)")
+				zap.S().Debug("Invalid credentials entered (Platform9 Account URL/Username/Password/Region/Tenant)")
+			}
+
 		}
 	}
 	// If existing initial config is Invalid
@@ -213,10 +259,10 @@ func configValidation(int) error {
 
 	// If any invalid credentials extered multiple times in new config prompt then to bail out the recursive loop (thrice)
 	if pmk.LoopCounter >= MaxLoopNoConfig && !(pmk.InvalidExistingConfig) {
-		zap.S().Fatalf("Invalid credentials entered multiple times (Username/Password/Tenant)")
+		zap.S().Fatalf("Invalid credentials entered multiple times (Username/Password/Region/Tenant)")
 	} else if pmk.LoopCounter >= MaxLoopNoConfig+1 && pmk.InvalidExistingConfig {
-		fmt.Println(color.Red("x ") + "Invalid credentials entered (Username/Password/Tenant)")
-		zap.S().Fatalf("Invalid credentials entered multiple times (Username/Password/Tenant)")
+		fmt.Println(color.Red("x ") + "Invalid credentials entered (Username/Password/Region/Tenant)")
+		zap.S().Fatalf("Invalid credentials entered multiple times (Username/Password/Region/Tenant)")
 	}
 	return nil
 }

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -87,7 +87,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 			//Clearing the invalid config entered. So that it will ask for new information again.
 			clearContext(&pmk.Context)
 			//Check if no or invalid config exists, then bail out if asked for correct config for maxLoop times.
-			err = configValidation(pmk.LoopCounter)
+			err = configValidation(RegionInvalid, pmk.LoopCounter)
 		} else {
 			// We will store the set config if its set for first time using check-node
 			if pmk.IsNewConfig {

--- a/cmd/supportBundle.go
+++ b/cmd/supportBundle.go
@@ -60,7 +60,7 @@ func supportBundleUpload(cmd *cobra.Command, args []string) {
 		if err := validateUserCredentials(ctx, c); err != nil {
 			clearContext(&pmk.Context)
 			//Check if no or invalid config exists, then bail out if asked for correct config for maxLoop times.
-			err = configValidation(pmk.LoopCounter)
+			err = configValidation(RegionInvalid, pmk.LoopCounter)
 		} else {
 			// We will store the set config if its set for first time using check-node
 			if pmk.IsNewConfig {

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -149,7 +149,7 @@ func PrepNode(ctx Config, allClients Client) error {
 	return nil
 }
 
-func FetchRegionFQDN(ctx Config, auth keystone.KeystoneAuth, hostOS string) (string, error) {
+func FetchRegionFQDN(ctx Config, auth keystone.KeystoneAuth) (string, error) {
 
 	// "regionInfo" service will have endpoint information. So fetch it's service ID.
 	regionInfoServiceID, err := keystone.GetServiceID(ctx.Fqdn, auth, "regionInfo")
@@ -170,7 +170,7 @@ func FetchRegionFQDN(ctx Config, auth keystone.KeystoneAuth, hostOS string) (str
 func installHostAgent(ctx Config, auth keystone.KeystoneAuth, hostOS string, exec cmdexec.Executor) error {
 	zap.S().Debug("Downloading Hostagent")
 
-	regionURL, err := FetchRegionFQDN(ctx, auth, hostOS)
+	regionURL, err := FetchRegionFQDN(ctx, auth)
 	if err != nil {
 		return fmt.Errorf("Unable to fetch URL: %w", err)
 	}

--- a/pkg/supportBundle/supportBundle.go
+++ b/pkg/supportBundle/supportBundle.go
@@ -87,15 +87,15 @@ func SupportBundleUpload(ctx pmk.Config, allClients pmk.Client) error {
 	}
 
 	// To get the hostOS.
-	hostOS, err := pmk.ValidatePlatform(allClients.Executor)
+	/*hostOS, err := pmk.ValidatePlatform(allClients.Executor)
 	if err != nil {
 		zap.S().Debug("Error: Invalid host OS. " + err.Error())
 		errStr := "Error: Invalid host OS. " + err.Error()
 		return fmt.Errorf(errStr)
-	}
+	}*/
 
 	// To Fetch FQDN
-	FQDN, err := pmk.FetchRegionFQDN(ctx, auth, hostOS)
+	FQDN, err := pmk.FetchRegionFQDN(ctx, auth)
 	if err != nil {
 		zap.S().Debug("unable to fetch fqdn: %w")
 		return fmt.Errorf("unable to fetch fqdn: %w", err)


### PR DESCRIPTION
* We bail out if user enters invalid region during config set multiple times or prompt if found invalid. 

Cases possible:
1) Only Region invalid during config set. -- "we will return an error saying region is invalid".
2) Multiple credentials invalid during config set. -- 
3) Only Region invalid during config loading  -- "we will return an error saying region is invalid".
4) Multiple credentials invalid during config loading.

If only region is invalid during config loading then the output is 
<img width="1440" alt="Screenshot 2021-06-16 at 12 51 52 PM" src="https://user-images.githubusercontent.com/77390180/122177453-42c30400-cea3-11eb-8735-813017463de4.png">

If region is invalid during config set. 
<img width="1440" alt="Screenshot 2021-06-16 at 12 54 28 PM" src="https://user-images.githubusercontent.com/77390180/122177630-6be39480-cea3-11eb-8cf7-51f6bd279c9f.png">
