### PR TITLE
Added pre-check to check if system is booted with systemd as a init

### DIFF
--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -66,6 +66,9 @@ func (c *CentOS) Check() []platform.Check {
 	result, err = c.checkNoexecPermission()
 	checks = append(checks, platform.Check{"Check exec permission on /tmp", true, result, err, fmt.Sprintf("%s", err)})
 
+	result, err = c.checkPIDofSystemd()
+	checks = append(checks, platform.Check{"Check if system booted with systemd", true, result, err, fmt.Sprintf("%s", err)})
+
 	if !util.SwapOffDisabled {
 		result, err = c.disableSwap()
 		checks = append(checks, platform.Check{"Disabling swap and removing swap in fstab", true, result, err, fmt.Sprintf("%s", err)})
@@ -311,5 +314,14 @@ func (c *CentOS) checkNoexecPermission() (bool, error) {
 		return true, nil
 	} else {
 		return false, errors.New("/tmp is not having exec permission")
+	}
+}
+
+func (c *CentOS) checkPIDofSystemd() (bool, error) {
+	_, err := c.exec.RunWithStdout("bash", "-c", "ps -p 1 -o comm= | grep systemd")
+	if err != nil {
+		return false, errors.New("System is not booted with systemd")
+	} else {
+		return true, nil
 	}
 }

--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -67,7 +67,7 @@ func (c *CentOS) Check() []platform.Check {
 	checks = append(checks, platform.Check{"Check exec permission on /tmp", true, result, err, fmt.Sprintf("%s", err)})
 
 	result, err = c.checkPIDofSystemd()
-	checks = append(checks, platform.Check{"Check if system booted with systemd", true, result, err, fmt.Sprintf("%s", err)})
+	checks = append(checks, platform.Check{"Check if system is booted with systemd", true, result, err, fmt.Sprintf("%s", err)})
 
 	if !util.SwapOffDisabled {
 		result, err = c.disableSwap()

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -72,7 +72,7 @@ func (d *Debian) Check() []platform.Check {
 	checks = append(checks, platform.Check{"Check lock on apt", true, result, err, fmt.Sprintf("%s", err)})
 
 	result, err = d.checkPIDofSystemd()
-	checks = append(checks, platform.Check{"Check if system booted with systemd", true, result, err, fmt.Sprintf("%s", err)})
+	checks = append(checks, platform.Check{"Check if system is booted with systemd", true, result, err, fmt.Sprintf("%s", err)})
 
 	if !util.SwapOffDisabled {
 		result, err = d.disableSwap()

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -71,6 +71,9 @@ func (d *Debian) Check() []platform.Check {
 	result, err = d.checkIfaptISLock()
 	checks = append(checks, platform.Check{"Check lock on apt", true, result, err, fmt.Sprintf("%s", err)})
 
+	result, err = d.checkPIDofSystemd()
+	checks = append(checks, platform.Check{"Check if system booted with systemd", true, result, err, fmt.Sprintf("%s", err)})
+
 	if !util.SwapOffDisabled {
 		result, err = d.disableSwap()
 		checks = append(checks, platform.Check{"Disabling swap and removing swap in fstab", true, result, err, fmt.Sprintf("%s", err)})
@@ -342,5 +345,14 @@ func (d *Debian) checkIfaptISLock() (bool, error) {
 		return true, nil
 	} else {
 		return false, errors.New("apt is locked")
+	}
+}
+
+func (d *Debian) checkPIDofSystemd() (bool, error) {
+	_, err := d.exec.RunWithStdout("bash", "-c", "ps -p 1 -o comm= | grep systemd")
+	if err != nil {
+		return false, errors.New("System is not booted with systemd")
+	} else {
+		return true, nil
 	}
 }

--- a/pkg/platform/debian/debian_test.go
+++ b/pkg/platform/debian/debian_test.go
@@ -760,3 +760,53 @@ func TestAptLockCheck(t *testing.T) {
 		})
 	}
 }
+
+func TestPIDofSystemdCheck(t *testing.T) {
+	type want struct {
+		result bool
+		err    error
+	}
+
+	cases := map[string]struct {
+		args
+		want
+	}{
+		//Success case. if system is booted with systemd then its pid will be 1.
+		"CheckPass": {
+			args: args{
+				exec: &cmdexec.MockExecutor{
+					MockRunWithStdout: func(name string, args ...string) (string, error) {
+						return "0", nil
+					},
+				},
+			},
+			want: want{
+				result: true,
+				err:    nil,
+			},
+		},
+		//Failure case. if PID of systemd is not 1 then check will return error.
+		"CheckFail": {
+			args: args{
+				exec: &cmdexec.MockExecutor{
+					MockRunWithStdout: func(name string, args ...string) (string, error) {
+						return "1", fmt.Errorf("ERROR")
+					},
+				},
+			},
+			want: want{
+				result: false,
+				err:    errors.New("System is not booted with systemd"),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := &Debian{exec: tc.exec}
+			result, err := d.checkPIDofSystemd()
+			assert.Equal(t, tc.result, result)
+			assert.Equal(t, tc.err, err)
+		})
+	}
+}


### PR DESCRIPTION
systemctl command was failing because if system was not booted with systemd. So added pre-requisite check to check if system is booted with systemd.