### PR TITLE
Added pf9ctl version while executing a command.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.14
 require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/briandowns/spinner v1.12.0
-	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/fatih/color v1.10.0
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/google/go-cmp v0.2.0
@@ -14,7 +13,6 @@ require (
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/mholt/archiver/v3 v3.5.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/nwaples/rardecode v1.1.0 // indirect
 	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
 	github.com/pkg/sftp v1.12.0
 	github.com/plus3it/gorecurcopy v0.0.1
@@ -24,7 +22,6 @@ require (
 	github.com/spf13/viper v1.6.3
 	github.com/stretchr/testify v1.6.1
 	github.com/ulikunitz/xz v0.5.10 // indirect
-	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a

--- a/pkg/pmk/config.go
+++ b/pkg/pmk/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/platform9/pf9ctl/pkg/color"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh/terminal"
+	"github.com/platform9/pf9ctl/pkg/util"
 )
 
 var (
@@ -54,7 +55,7 @@ func StoreConfig(ctx Config, loc string) error {
 // LoadConfig returns the information for communication with PF9 controller.
 func LoadConfig(loc string) (Config, error) {
 
-	zap.S().Debug("Loading configuration details")
+	zap.S().Debug("Loading configuration details. pf9ctl version: ", util.Version)
 
 	f, err := os.Open(loc)
 	// We will execute it if no config found or if config found but have invalid credentials


### PR DESCRIPTION
Messages in the log:
{"level":"debug","ts":"2021-06-24T06:13:33.4038Z","caller":"cobra@v1.0.0/command.go:846","msg":"==========Running check-node=========="}
 {"level":"debug","ts":"2021-06-24T06:13:33.4042Z","caller":"cmd/checkNode.go:44","msg":"Loading configuration details. pf9ctl version: pf9ctl version: v1.4"}
 {"level":"debug","ts":"2021-06-24T06:13:33.407Z","caller":"cmd/prepNode.go:187","msg":"Using local executor"}
 {"level":"debug","ts":"2021-06-24T06:13:33.4071Z","caller":"cmd/checkNode.go:49","msg":"Using local executor"}
 {"level":"debug","ts":"2021-06-24T06:13:33.4072Z","caller":"cmd/config.go:181","msg":"Received a call to fetch keystone authentication for fqdn: https://du-test-kplane-anup-3833.platform9.horse and user: anup@platform9.com and tenant: service\n"}
 {"level":"debug","ts":"2021-06-24T06:13:33.4372Z","caller":"cmd/checkNode.go:65","msg":"Invalid credentials found (Platform9 Account URL/Username/Password/Region/Tenant)"}
 {"level":"debug","ts":"2021-06-24T06:13:33.4373Z","caller":"cmd/checkNode.go:44","msg":"Loading configuration details. pf9ctl version: pf9ctl version: v1.4"}