### PR TITLE
Modified /tmp noexec command execution

### DIFF
--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -309,7 +309,7 @@ func (c *CentOS) disableSwap() (bool, error) {
 }
 
 func (c *CentOS) checkNoexecPermission() (bool, error) {
-	_, err := c.exec.RunWithStdout("bash", "-c", "mount | grep /tmp | grep noexec")
+	_, err := c.exec.RunWithStdout("bash", "-c", `mount | grep " /tmp " | grep noexec`)
 	if err != nil {
 		return true, nil
 	} else {

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -316,7 +316,7 @@ func (d *Debian) disableSwap() (bool, error) {
 }
 
 func (d *Debian) checkNoexecPermission() (bool, error) {
-	_, err := d.exec.RunWithStdout("bash", "-c", "mount | grep /tmp | grep noexec")
+	_, err := d.exec.RunWithStdout("bash", "-c", `mount | grep " /tmp " | grep noexec`)
 	if err != nil {
 		return true, nil
 	} else {


### PR DESCRIPTION
* To check the noexec permission of only /tmp we had modified the command. 
 
<img width="656" alt="Screenshot 2021-06-30 at 5 25 10 PM" src="https://user-images.githubusercontent.com/77390180/123958243-6ec5a580-d9ca-11eb-99b8-b1354994fc53.png">

<img width="656" alt="Screenshot 2021-06-30 at 5 29 47 PM" src="https://user-images.githubusercontent.com/77390180/123958140-548bc780-d9ca-11eb-8d2b-093dda85f4ee.png">
<img width="656" alt="Screenshot 2021-06-30 at 5 37 31 PM" src="https://user-images.githubusercontent.com/77390180/123958165-59e91200-d9ca-11eb-80e4-f790fc6cbf10.png">
