### PR TITLE
Proxy

### DIFF
--- a/cmd/attachNode.go
+++ b/cmd/attachNode.go
@@ -55,7 +55,7 @@ func attachNodeRun(cmd *cobra.Command, args []string) {
 			zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
 		}
 
-		executor, err := getExecutor()
+		executor, err := getExecutor(ctx.ProxyURL)
 		if err != nil {
 			zap.S().Debug("Error connecting to host %s", err.Error())
 			zap.S().Fatalf(" Invalid (Username/Password/IP)")

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -46,7 +46,7 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 			zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
 		}
 
-		executor, err := getExecutor()
+		executor, err := getExecutor(ctx.ProxyURL)
 		if err != nil {
 			zap.S().Fatalf(" Invalid (Username/Password/IP), use 'single quotes' to pass password")
 			zap.S().Debug("Error connecting to host %s", err.Error())

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -65,7 +65,7 @@ func configCmdCreateRun(cmd *cobra.Command, args []string) {
 		// invoked the configcreate command from pkg/pmk
 		ctx, _ = pmk.ConfigCmdCreateRun()
 
-		executor, err := getExecutor()
+		executor, err := getExecutor(ctx.ProxyURL)
 		if err != nil {
 			zap.S().Fatalf("Error connecting to host %s", err.Error())
 		}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -60,6 +60,7 @@ func configCmdCreateRun(cmd *cobra.Command, args []string) {
 	pmk.Context.Tenant = tenant
 	pmk.Context.WaitPeriod = time.Duration(60)
 	pmk.Context.AllowInsecure = false
+	pmk.Context.ProxyURL = proxyURL
 
 	for credentialFlag {
 		// invoked the configcreate command from pkg/pmk
@@ -146,7 +147,7 @@ var configCmdSet = &cobra.Command{
 	Long:  `Create a new config that can be used to query Platform9 controller`,
 	Run:   configCmdCreateRun,
 	Args: func(configCmdSet *cobra.Command, args []string) error {
-		if configCmdSet.Flags().Changed("account_url") || configCmdSet.Flags().Changed("username") || configCmdSet.Flags().Changed("password") || configCmdSet.Flags().Changed("region") || configCmdSet.Flags().Changed("tenant") {
+		if configCmdSet.Flags().Changed("account_url") || configCmdSet.Flags().Changed("username") || configCmdSet.Flags().Changed("password") || configCmdSet.Flags().Changed("region") || configCmdSet.Flags().Changed("tenant") || configCmdSet.Flags().Changed("proxyUrl") {
 			SetConfigByParameters = true
 		}
 		return nil
@@ -163,6 +164,7 @@ var (
 	account_url string
 	username    string
 	Password    string
+	proxyURL    string
 	region      string
 	tenant      string
 )
@@ -171,6 +173,7 @@ func init() {
 	configCmdSet.Flags().StringVarP(&account_url, "account_url", "u", "", "sets account_url")
 	configCmdSet.Flags().StringVarP(&username, "username", "e", "", "sets username")
 	configCmdSet.Flags().StringVarP(&Password, "password", "p", "", "sets password (use 'single quotes' to pass password)")
+	configCmdSet.Flags().StringVarP(&proxyURL, "proxy_url", "l", "", "sets proxy URL")
 	configCmdSet.Flags().StringVarP(&region, "region", "r", "", "sets region")
 	configCmdSet.Flags().StringVarP(&tenant, "tenant", "t", "", "sets tenant")
 }

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -71,7 +71,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 			zap.S().Fatalf("Unable to load the config: %s\n", err.Error())
 		}
 
-		executor, err := getExecutor()
+		executor, err := getExecutor(ctx.ProxyURL)
 		if err != nil {
 			zap.S().Debug("Error connecting to host %s", err.Error())
 			zap.S().Fatalf(" Invalid (Username/Password/IP), use 'single quotes' to pass password")
@@ -182,7 +182,7 @@ func checkAndValidateRemote() bool {
 			}
 			FoundRemote = true
 			supportBundle.RemoteBundle = true
-      pmk.IsRemoteExecutor = true
+			pmk.IsRemoteExecutor = true
 			return FoundRemote
 		}
 	}
@@ -191,7 +191,7 @@ func checkAndValidateRemote() bool {
 }
 
 // getExecutor creates the right Executor
-func getExecutor() (cmdexec.Executor, error) {
+func getExecutor(proxyURL string) (cmdexec.Executor, error) {
 	if checkAndValidateRemote() {
 		var pKey []byte
 		var err error
@@ -201,11 +201,10 @@ func getExecutor() (cmdexec.Executor, error) {
 				zap.S().Fatalf("Unable to read the sshKey %s, %s", sshKey, err.Error())
 			}
 		}
-
-		return cmdexec.NewRemoteExecutor(ips[0], 22, user, pKey, password)
+		return cmdexec.NewRemoteExecutor(ips[0], 22, user, pKey, password, proxyURL)
 	}
 	zap.S().Debug("Using local executor")
-	return cmdexec.LocalExecutor{}, nil
+	return cmdexec.LocalExecutor{ProxyUrl: proxyURL}, nil
 }
 
 // To check if Remote Host needs Password to access Sudo and prompt for Sudo Password if exists.

--- a/cmd/prepNode_test.go
+++ b/cmd/prepNode_test.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"testing"
+
 	"github.com/platform9/pf9ctl/pkg/cmdexec"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 //Local executor test case
@@ -12,7 +13,7 @@ func TestGetExecutor(t *testing.T) {
 	var TestErr error = nil
 
 	t.Run("LocalExecutorTest", func(t *testing.T) {
-		executor, err := getExecutor()
+		executor, err := getExecutor("https://www.google.com")
 		if err != nil {
 			t.Errorf("Error occured : %s", err)
 		}

--- a/cmd/prepNode_test.go
+++ b/cmd/prepNode_test.go
@@ -7,13 +7,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var proxy_url = "127.0.0.1:3128"
+
 //Local executor test case
 func TestGetExecutor(t *testing.T) {
-	var exec cmdexec.LocalExecutor
+	exec := cmdexec.LocalExecutor{ProxyUrl: proxy_url}
 	var TestErr error = nil
 
 	t.Run("LocalExecutorTest", func(t *testing.T) {
-		executor, err := getExecutor("https://www.google.com")
+		executor, err := getExecutor(proxy_url)
 		if err != nil {
 			t.Errorf("Error occured : %s", err)
 		}

--- a/cmd/supportBundle.go
+++ b/cmd/supportBundle.go
@@ -45,7 +45,7 @@ func supportBundleUpload(cmd *cobra.Command, args []string) {
 			zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
 		}
 
-		executor, err := getExecutor()
+		executor, err := getExecutor(ctx.ProxyURL)
 		if err != nil {
 			zap.S().Debug("Error connecting to host %s", err.Error())
 			zap.S().Fatalf(" Invalid (Username/Password/IP), use 'single quotes' to pass password")

--- a/pkg/cmdexec/executor.go
+++ b/pkg/cmdexec/executor.go
@@ -37,7 +37,7 @@ func (c LocalExecutor) Run(name string, args ...string) error {
 
 // RunWithStdout runs a command locally returning stdout and err
 func (c LocalExecutor) RunWithStdout(name string, args ...string) (string, error) {
-	args = append([]string{name}, args...)
+	args = append([]string{"-E", name}, args...)
 	cmd := exec.Command("sudo", args...)
 	cmd.Env = append(cmd.Env, httpsProxy+"="+c.ProxyUrl)
 	byt, err := cmd.Output()

--- a/pkg/cmdexec/executor.go
+++ b/pkg/cmdexec/executor.go
@@ -12,6 +12,10 @@ import (
 // To fetch the stderr after executing command
 var StdErrSudoPassword string
 
+const (
+	httpsProxy = "https_proxy"
+)
+
 // Executor interace abstracts us from local or remote execution
 type Executor interface {
 	Run(name string, args ...string) error
@@ -19,19 +23,24 @@ type Executor interface {
 }
 
 // LocalExecutor as the name implies executes commands locally
-type LocalExecutor struct{}
+type LocalExecutor struct {
+	ProxyUrl string
+}
 
 // Run runs a command locally returning just success or failure
 func (c LocalExecutor) Run(name string, args ...string) error {
 	args = append([]string{name}, args...)
 	cmd := exec.Command("sudo", args...)
+	cmd.Env = append(cmd.Env, httpsProxy+"="+c.ProxyUrl)
 	return cmd.Run()
 }
 
 // RunWithStdout runs a command locally returning stdout and err
 func (c LocalExecutor) RunWithStdout(name string, args ...string) (string, error) {
 	args = append([]string{name}, args...)
-	byt, err := exec.Command("sudo", args...).Output()
+	cmd := exec.Command("sudo", args...)
+	cmd.Env = append(cmd.Env, httpsProxy+"="+c.ProxyUrl)
+	byt, err := cmd.Output()
 	stderr := ""
 	if exitError, ok := err.(*exec.ExitError); ok {
 		stderr = string(exitError.Stderr)
@@ -43,7 +52,8 @@ func (c LocalExecutor) RunWithStdout(name string, args ...string) (string, error
 
 // RemoteExecutor as the name implies runs commands usign SSH on remote host
 type RemoteExecutor struct {
-	Client ssh.Client
+	Client   ssh.Client
+	proxyURL string
 }
 
 // Run runs a command locally returning just success or failure
@@ -58,6 +68,9 @@ func (r *RemoteExecutor) RunWithStdout(name string, args ...string) (string, err
 	for _, arg := range args {
 		cmd = fmt.Sprintf("%s \"%s\"", cmd, arg)
 	}
+	if r.proxyURL != "" {
+		cmd = fmt.Sprintf("%s=%s %s", httpsProxy, r.proxyURL, cmd)
+	}
 	stdout, stderr, err := r.Client.RunCommand(cmd)
 	// To fetch the stderr after executing command.
 	StdErrSudoPassword = string(stderr)
@@ -66,11 +79,11 @@ func (r *RemoteExecutor) RunWithStdout(name string, args ...string) (string, err
 }
 
 // NewRemoteExecutor create an Executor interface to execute commands remotely
-func NewRemoteExecutor(host string, port int, username string, privateKey []byte, password string) (Executor, error) {
-	client, err := ssh.NewClient(host, port, username, privateKey, password)
+func NewRemoteExecutor(host string, port int, username string, privateKey []byte, password, proxyURL string) (Executor, error) {
+	client, err := ssh.NewClient(host, port, username, privateKey, password, proxyURL)
 	if err != nil {
 		return nil, err
 	}
-	re := &RemoteExecutor{Client: client}
+	re := &RemoteExecutor{Client: client, proxyURL: proxyURL}
 	return re, nil
 }

--- a/pkg/pmk/config.go
+++ b/pkg/pmk/config.go
@@ -148,6 +148,12 @@ func ConfigCmdCreateRun() (Config, error) {
 		service, _ = reader.ReadString('\n')
 		Context.Tenant = strings.TrimSuffix(service, "\n")
 	}
+	var proxyURL string
+	if Context.ProxyURL == "" {
+		fmt.Print("Proxy URL: ")
+		proxyURL, _ = reader.ReadString('\n')
+		Context.ProxyURL = strings.TrimSuffix(proxyURL, "\n")
+	}
 
 	if Context.Region == "" {
 		Context.Region = "RegionOne"

--- a/pkg/pmk/config.go
+++ b/pkg/pmk/config.go
@@ -4,15 +4,16 @@ import (
 	"bufio"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/platform9/pf9ctl/pkg/color"
+	"github.com/platform9/pf9ctl/pkg/util"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh/terminal"
-	"github.com/platform9/pf9ctl/pkg/util"
 )
 
 var (
@@ -31,6 +32,7 @@ type Config struct {
 	Region        string        `json:"region"`
 	WaitPeriod    time.Duration `json:"wait_period"`
 	AllowInsecure bool          `json:"allow_insecure"`
+	ProxyURL      string        `json:"proxy_url"`
 }
 
 // StoreConfig simply updates the in-memory object
@@ -98,6 +100,13 @@ func LoadConfig(loc string) (Config, error) {
 	ctx.Password = string(decodedBytePassword)
 	//s.Stop()
 	fmt.Println(color.Green("✓ ") + "Loaded Config Successfully")
+
+	if ctx.ProxyURL != "" {
+		if err = os.Setenv("https_proxy", ctx.ProxyURL); err != nil {
+			return Config{}, errors.New("Error setting proxy as environment variable")
+		}
+	}
+
 	return ctx, err
 }
 

--- a/pkg/pmk/config.go
+++ b/pkg/pmk/config.go
@@ -150,7 +150,7 @@ func ConfigCmdCreateRun() (Config, error) {
 	}
 	var proxyURL string
 	if Context.ProxyURL == "" {
-		fmt.Print("Proxy URL: ")
+		fmt.Print("Proxy URL [None]: ")
 		proxyURL, _ = reader.ReadString('\n')
 		Context.ProxyURL = strings.TrimSuffix(proxyURL, "\n")
 	}

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -222,14 +222,19 @@ func installHostAgentCertless(ctx Config, regionURL string, auth keystone.Keysto
 		return err
 	}
 
-	if IsRemoteExecutor {
-		cmd = fmt.Sprintf(`bash /tmp/installer.sh --no-proxy --skip-os-check --no-ntp %s`, installOptions)
-		_, err = exec.RunWithStdout(cmd)
+	if ctx.ProxyURL != "" {
+		cmd = fmt.Sprintf(`/tmp/installer.sh --proxy http://%s --skip-os-check --no-ntp`, ctx.ProxyURL)
 	} else {
-		cmd = fmt.Sprintf(`/tmp/installer.sh --no-proxy --skip-os-check --no-ntp %s`, installOptions)
-		_, err = exec.RunWithStdout("bash", "-c", cmd)
+		cmd = fmt.Sprintf(`/tmp/installer.sh --no-proxy --skip-os-check --no-ntp`)
 	}
 
+	if IsRemoteExecutor {
+		cmd = fmt.Sprintf(`bash %s %s`, cmd, installOptions)
+		_, err = exec.RunWithStdout(cmd)
+	} else {
+		cmd = fmt.Sprintf(`%s %s`, cmd, installOptions)
+		_, err = exec.RunWithStdout("bash", "-c", cmd)
+	}
 	if err != nil {
 		return fmt.Errorf("Unable to run installer script")
 	}
@@ -308,7 +313,12 @@ func installHostAgentLegacy(ctx Config, regionURL string, auth keystone.Keystone
 		return err
 	}
 
-	cmd = fmt.Sprintf(`/tmp/installer.sh --no-proxy --skip-os-check --ntpd %s`, installOptions)
+	if ctx.ProxyURL != "" {
+		cmd = fmt.Sprintf(`/tmp/installer.sh --proxy https://%s --skip-os-check --ntpd %s`, ctx.ProxyURL, installOptions)
+	} else {
+		cmd = fmt.Sprintf(`/tmp/installer.sh --no-proxy --skip-os-check --ntpd %s`, installOptions)
+	}
+
 	_, err = exec.RunWithStdout("bash", "-c", cmd)
 	if err != nil {
 		return err


### PR DESCRIPTION
Allow users to use a proxy for all the network requests made by the CLI and the host-agents to route through the specified proxy.

The proxy URL is stored in config and can be set by the existing command `pf9ctl config set`