### PR TITLE
tmp permission check in remote case fixed

### DIFF
--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -309,7 +309,7 @@ func (c *CentOS) disableSwap() (bool, error) {
 }
 
 func (c *CentOS) checkNoexecPermission() (bool, error) {
-	_, err := c.exec.RunWithStdout("bash", "-c", `mount | grep " /tmp " | grep noexec`)
+	_, err := c.exec.RunWithStdout("bash", "-c", `mount | grep ' /tmp ' | grep 'noexec'`)
 	if err != nil {
 		return true, nil
 	} else {

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -316,7 +316,7 @@ func (d *Debian) disableSwap() (bool, error) {
 }
 
 func (d *Debian) checkNoexecPermission() (bool, error) {
-	_, err := d.exec.RunWithStdout("bash", "-c", `mount | grep " /tmp " | grep noexec`)
+	_, err := d.exec.RunWithStdout("bash", "-c", `mount | grep ' /tmp ' | grep 'noexec'`)
 	if err != nil {
 		return true, nil
 	} else {


### PR DESCRIPTION
Command was failing in remote case
fixed now
ubuntu@devidas-dev-vm:~/testgocli$ ./pf9ctl check-node -i 10.128.241.165 -u ubuntu -s /home/ubuntu/.ssh/mykey
✓ Loaded Config Successfully
✓ Removal of existing CLI
x Existing Platform9 Packages Check - Platform9 packages already exist. These must be uninstalled.
✓ Required OS Packages Check
✓ SudoCheck
✓ CPUCheck
✓ DiskCheck
✓ MemoryCheck
x PortCheck - Following port(s) should not be in use: 3306
✓ Existing Kubernetes Cluster Check
x Check exec permission on /tmp - /tmp is not having exec permission
✓ Check lock on dpkg
✓ Check lock on apt
✓ Check if system is booted with systemd
✓ Disabling swap and removing swap in fstab

x Required pre-requisite check(s) failed. See /home/ubuntu/pf9/log/pf9ctl-20210709.log or use --verbose for logs 
ubuntu@devidas-dev-vm:~/testgocli$ scp -i ~

---------------------------------------
Local case

ubuntu@devidas-ub-20-04:~$ ./pf9ctl check-node
✓ Loaded Config Successfully
✓ Removal of existing CLI
x Existing Platform9 Packages Check - Platform9 packages already exist. These must be uninstalled.
✓ Required OS Packages Check
✓ SudoCheck
✓ CPUCheck
✓ DiskCheck
✓ MemoryCheck
x PortCheck - Following port(s) should not be in use: 3306
✓ Existing Kubernetes Cluster Check
x Check exec permission on /tmp - /tmp is not having exec permission
✓ Check lock on dpkg
✓ Check lock on apt
✓ Check if system is booted with systemd
✓ Disabling swap and removing swap in fstab

x Required pre-requisite check(s) failed. See /home/ubuntu/pf9/log/pf9ctl-20210709.log or use --verbose for logs 

