### PR TITLE
Added DUFqdn as part of segment events

### DIFF
--- a/pkg/keystone/keystone.go
+++ b/pkg/keystone/keystone.go
@@ -12,11 +12,11 @@ import (
 )
 
 type KeystoneAuth struct {
+	DUFqdn    string
 	Token     string
 	UserID    string
 	ProjectID string
 	Email     string
-
 }
 
 type Keystone interface {
@@ -80,8 +80,8 @@ func (k KeystoneImpl) GetAuth(
 	project := t["project"].(map[string]interface{})
 	user := t["user"].(map[string]interface{})
 	token := resp.Header["X-Subject-Token"][0]
-
 	return KeystoneAuth{
+		DUFqdn:    k.fqdn,
 		Token:     token,
 		UserID:    user["id"].(string),
 		ProjectID: project["id"].(string),

--- a/pkg/pmk/segment.go
+++ b/pkg/pmk/segment.go
@@ -60,6 +60,7 @@ func (c SegmentImpl) SendEvent(name string, data interface{}, status string, err
 			Event:  name,
 			Properties: analytics.NewProperties().
 				Set("keystoneData", data).
+				Set("dufqdn", data_struct.DUFqdn).
 				Set("email", data_struct.Email).
 				Set("status", status).
 				Set("errorMsg", err),


### PR DESCRIPTION

* For few of the users in Amplitude we are not able to find the DU FQDN, even though they ran Successfully Prep-node and Check-node. So, we have added DUFqdn as a part of Segment events we send. 

After Adding DUFqdn:

**1. Segment Events:**

![Screenshot 2021-07-29 at 1 37 57 PM](https://user-images.githubusercontent.com/77390180/127455800-09c6f023-e5ca-4427-bd2c-0f8cb042c1d0.png)

**2. Amplitude Events:**

![Screenshot 2021-07-29 at 1 38 19 PM](https://user-images.githubusercontent.com/77390180/127455817-7525ba67-e1a6-4b7a-8701-df61d6a978a5.png)
