### PR TITLE
Parameterised path to download installer when tmp don't have exec permission

### DIFF
--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -16,11 +16,10 @@ import (
 )
 
 var (
-	packages                         = []string{"ntp", "curl", "policycoreutils", "policycoreutils-python", "selinux-policy", "selinux-policy-targeted", "libselinux-utils", "net-tools", "epel-release", "jq"}
-	packageInstallError              = "Packages not found and could not be installed"
-	MissingPkgsInstalledCentos       bool
-	k8sPresentError                  = errors.New("A Kubernetes cluster is already running on node")
-	IStmpDirectoryHaveExecPermission bool
+	packages                   = []string{"ntp", "curl", "policycoreutils", "policycoreutils-python", "selinux-policy", "selinux-policy-targeted", "libselinux-utils", "net-tools", "epel-release", "jq"}
+	packageInstallError        = "Packages not found and could not be installed"
+	MissingPkgsInstalledCentos bool
+	k8sPresentError            = errors.New("A Kubernetes cluster is already running on node")
 )
 
 // CentOS reprents centos based host machine
@@ -63,9 +62,6 @@ func (c *CentOS) Check() []platform.Check {
 
 	result, err = c.checkKubernetesCluster()
 	checks = append(checks, platform.Check{"Existing Kubernetes Cluster Check", true, result, err, fmt.Sprintf("%s", err)})
-
-	result, err = c.checkNoexecPermission()
-	checks = append(checks, platform.Check{"Check exec permission on /tmp", false, result, err, fmt.Sprintf("%s", err)})
 
 	result, err = c.checkPIDofSystemd()
 	checks = append(checks, platform.Check{"Check if system is booted with systemd", true, result, err, fmt.Sprintf("%s", err)})
@@ -306,17 +302,6 @@ func (c *CentOS) disableSwap() (bool, error) {
 		return false, errors.New("error occured while disabling swap")
 	} else {
 		return true, nil
-	}
-}
-
-func (c *CentOS) checkNoexecPermission() (bool, error) {
-	_, err := c.exec.RunWithStdout("bash", "-c", `mount | grep ' /tmp ' | grep 'noexec'`)
-	if err != nil {
-		IStmpDirectoryHaveExecPermission = true
-		return true, nil
-	} else {
-		IStmpDirectoryHaveExecPermission = false
-		return false, errors.New("/tmp is not having exec permission using pf9 directory to download installer")
 	}
 }
 

--- a/pkg/platform/centos/centos_test.go
+++ b/pkg/platform/centos/centos_test.go
@@ -614,56 +614,6 @@ func TestDisableSwap(t *testing.T) {
 	}
 }
 
-func TestNoexecPermissionCheck(t *testing.T) {
-	type want struct {
-		result bool
-		err    error
-	}
-
-	cases := map[string]struct {
-		args
-		want
-	}{
-		//Success case. successful execution of grep command returns error.
-		"CheckPass": {
-			args: args{
-				exec: &cmdexec.MockExecutor{
-					MockRunWithStdout: func(name string, args ...string) (string, error) {
-						return "0", nil
-					},
-				},
-			},
-			want: want{
-				result: false,
-				err:    errors.New("/tmp is not having exec permission using pf9 directory to download installer"),
-			},
-		},
-		//Failure case. if output of grep command is empty then it returns nil error.
-		"CheckFail": {
-			args: args{
-				exec: &cmdexec.MockExecutor{
-					MockRunWithStdout: func(name string, args ...string) (string, error) {
-						return "1", errors.New("ERROR")
-					},
-				},
-			},
-			want: want{
-				result: true,
-				err:    nil,
-			},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			c := &CentOS{exec: tc.exec}
-			result, err := c.checkNoexecPermission()
-			assert.Equal(t, tc.result, result)
-			assert.Equal(t, tc.err, err)
-		})
-	}
-}
-
 func TestPIDofSystemdCheck(t *testing.T) {
 	type want struct {
 		result bool

--- a/pkg/platform/centos/centos_test.go
+++ b/pkg/platform/centos/centos_test.go
@@ -635,7 +635,7 @@ func TestNoexecPermissionCheck(t *testing.T) {
 			},
 			want: want{
 				result: false,
-				err:    errors.New("/tmp is not having exec permission"),
+				err:    errors.New("/tmp is not having exec permission using pf9 directory to download installer"),
 			},
 		},
 		//Failure case. if output of grep command is empty then it returns nil error.

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -15,11 +15,10 @@ import (
 )
 
 var (
-	packages                         = []string{"curl", "uuid-runtime", "net-tools", "jq"}
-	packageInstallError              = "Packages not found and could not be installed"
-	MissingPkgsInstalledDebian       bool
-	k8sPresentError                  = errors.New("A Kubernetes cluster is already running on node")
-	IStmpDirectoryHaveExecPermission bool
+	packages                   = []string{"curl", "uuid-runtime", "net-tools", "jq"}
+	packageInstallError        = "Packages not found and could not be installed"
+	MissingPkgsInstalledDebian bool
+	k8sPresentError            = errors.New("A Kubernetes cluster is already running on node")
 )
 
 // Debian represents debian based host machine
@@ -62,9 +61,6 @@ func (d *Debian) Check() []platform.Check {
 
 	result, err = d.checkKubernetesCluster()
 	checks = append(checks, platform.Check{"Existing Kubernetes Cluster Check", true, result, err, fmt.Sprintf("%s", err)})
-
-	result, err = d.checkNoexecPermission()
-	checks = append(checks, platform.Check{"Check exec permission on /tmp", false, result, err, fmt.Sprintf("%s", err)})
 
 	result, err = d.checkIfdpkgISLock()
 	checks = append(checks, platform.Check{"Check lock on dpkg", true, result, err, fmt.Sprintf("%s", err)})
@@ -315,17 +311,6 @@ func (d *Debian) disableSwap() (bool, error) {
 		return false, errors.New("error occured while disabling swap")
 	} else {
 		return true, nil
-	}
-}
-
-func (d *Debian) checkNoexecPermission() (bool, error) {
-	_, err := d.exec.RunWithStdout("bash", "-c", `mount | grep ' /tmp ' | grep 'noexec'`)
-	if err != nil {
-		IStmpDirectoryHaveExecPermission = true
-		return true, nil
-	} else {
-		IStmpDirectoryHaveExecPermission = false
-		return false, errors.New("/tmp is not having exec permission using pf9 directory to download installer")
 	}
 }
 

--- a/pkg/platform/debian/debian_test.go
+++ b/pkg/platform/debian/debian_test.go
@@ -632,7 +632,7 @@ func TestNoexecPermissionCheck(t *testing.T) {
 			},
 			want: want{
 				result: false,
-				err:    errors.New("/tmp is not having exec permission"),
+				err:    errors.New("/tmp is not having exec permission using pf9 directory to download installer"),
 			},
 		},
 		//Failure case. if output of grep command is empty then it returns nil error.

--- a/pkg/platform/debian/debian_test.go
+++ b/pkg/platform/debian/debian_test.go
@@ -611,56 +611,6 @@ func TestDisableSwap(t *testing.T) {
 	}
 }
 
-func TestNoexecPermissionCheck(t *testing.T) {
-	type want struct {
-		result bool
-		err    error
-	}
-
-	cases := map[string]struct {
-		args
-		want
-	}{
-		//Success case. successful execution of grep command returns error.
-		"CheckPass": {
-			args: args{
-				exec: &cmdexec.MockExecutor{
-					MockRunWithStdout: func(name string, args ...string) (string, error) {
-						return "0", nil
-					},
-				},
-			},
-			want: want{
-				result: false,
-				err:    errors.New("/tmp is not having exec permission using pf9 directory to download installer"),
-			},
-		},
-		//Failure case. if output of grep command is empty then it returns nil error.
-		"CheckFail": {
-			args: args{
-				exec: &cmdexec.MockExecutor{
-					MockRunWithStdout: func(name string, args ...string) (string, error) {
-						return "1", errors.New("ERROR")
-					},
-				},
-			},
-			want: want{
-				result: true,
-				err:    nil,
-			},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			d := &Debian{exec: tc.exec}
-			result, err := d.checkNoexecPermission()
-			assert.Equal(t, tc.result, result)
-			assert.Equal(t, tc.err, err)
-		})
-	}
-}
-
 func TestDpkgLockCheck(t *testing.T) {
 	type want struct {
 		result bool

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -239,6 +239,13 @@ func installHostAgentCertless(ctx Config, regionURL string, auth keystone.Keysto
 		cmd = fmt.Sprintf(`%s %s`, cmd, installOptions)
 		_, err = exec.RunWithStdout("bash", "-c", cmd)
 	}
+
+	zap.S().Debug("Removing temporary directory created to extract installer")
+	_, err = exec.RunWithStdout("bash", "-c", "rm -rf pf9-install-*")
+	if err != nil {
+		zap.S().Debug("error removing temporary directory")
+	}
+
 	if err != nil {
 		return fmt.Errorf("Unable to run installer script")
 	}

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -209,11 +209,8 @@ func installHostAgentCertless(ctx Config, regionURL string, auth keystone.Keysto
 	if ctx.AllowInsecure {
 		insecureDownload = "-k"
 	}
-	if debian.IStmpDirectoryHaveExecPermission || centos.IStmpDirectoryHaveExecPermission {
-		downloadPath = "/tmp"
-	} else {
-		downloadPath = "pf9"
-	}
+
+	downloadPath = "pf9"
 
 	cmd := fmt.Sprintf(`curl %s --silent --show-error  %s -o  %s/installer.sh`, insecureDownload, url, downloadPath)
 	_, err := exec.RunWithStdout("bash", "-c", cmd)


### PR DESCRIPTION
Prep-node was failing when /tmp directory do not have exec permission. So Parameterised path to download installer script when /tmp don't have exec permission.