### PR TITLE
Removed the user password as part of CLI logs, and removed config.json as a part of supportbundle

### DIFF
--- a/pkg/cmdexec/executor.go
+++ b/pkg/cmdexec/executor.go
@@ -60,7 +60,7 @@ func (c LocalExecutor) RunWithStdout(name string, args ...string) (string, error
 	for _, arg := range args {
 		command = fmt.Sprintf("%s \"%s\"", command, arg)
 	}
-	// Remove user password if command has passwordflag
+	// Avoid password from getting logged, if the command contains password flag.
 	command = PasswordRemover(command)
 	zap.S().Debug("Ran command sudo", command)
 
@@ -93,7 +93,7 @@ func (r *RemoteExecutor) RunWithStdout(name string, args ...string) (string, err
 	// To fetch the stderr after executing command.
 	StdErrSudoPassword = string(stderr)
 
-	// Remove user password if command has passwordflag
+	// Avoid password from getting logged, if the command contains password flag.
 	command := PasswordRemover(cmd)
 
 	zap.S().Debug("Running command ", command, "stdout:", string(stdout), "stderr:", string(stderr))
@@ -110,7 +110,7 @@ func NewRemoteExecutor(host string, port int, username string, privateKey []byte
 	return re, nil
 }
 
-// To Remove the user Password from commands as part of logs
+// Avoid password from getting logged, if the command contains password flag
 func PasswordRemover(cmd string) string {
 	// To find the command that contains password flag
 	passwordFlag := "--password"

--- a/pkg/supportBundle/supportBundle.go
+++ b/pkg/supportBundle/supportBundle.go
@@ -168,7 +168,7 @@ func GenSupportBundle(exec cmdexec.Executor, timestamp time.Time) (string, error
 
 	//Check whether the source directories exist in remote node.
 	if !RemoteBundle {
-		_, errPf9 := exec.RunWithStdout("bash", "-c", fmt.Sprintf("stat %s", util.Pf9Dir))
+		_, errPf9 := exec.RunWithStdout("bash", "-c", fmt.Sprintf("stat %s", util.Pf9LogDir))
 		if err != nil {
 			zap.S().Debug("Log files directory not Found!!", errPf9)
 		}
@@ -215,7 +215,7 @@ func GenSupportBundle(exec cmdexec.Executor, timestamp time.Time) (string, error
 
 	} else {
 		// Generation of supportBundle in local host case.
-		_, errbundle := exec.RunWithStdout("bash", "-c", fmt.Sprintf("tar czf %s --directory=%s pf9 %s %s",
+		_, errbundle := exec.RunWithStdout("bash", "-c", fmt.Sprintf("tar czf %s --directory=%s pf9/log %s %s",
 			targetfile, util.Pf9DirLoc, util.VarDir, util.EtcDir))
 		if errbundle != nil {
 			zap.S().Debug("Failed to generate complete supportBundle, generated partial bundle", errbundle)

--- a/pkg/supportBundle/supportBundle.go
+++ b/pkg/supportBundle/supportBundle.go
@@ -215,8 +215,8 @@ func GenSupportBundle(exec cmdexec.Executor, timestamp time.Time) (string, error
 
 	} else {
 		// Generation of supportBundle in local host case.
-		_, errbundle := exec.RunWithStdout("bash", "-c", fmt.Sprintf("tar czf %s --directory=%s pf9/log %s %s",
-			targetfile, util.Pf9DirLoc, util.VarDir, util.EtcDir))
+		_, errbundle := exec.RunWithStdout("bash", "-c", fmt.Sprintf("tar czf %s --directory=%s %s %s %s",
+			targetfile, util.Pf9DirLoc, util.Pf9LogLoc, util.VarDir, util.EtcDir))
 		if errbundle != nil {
 			zap.S().Debug("Failed to generate complete supportBundle, generated partial bundle", errbundle)
 			return targetfile, ErrPartialBundle

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -70,6 +70,7 @@ var (
 
 	VarDir    = "/var/log/pf9"
 	EtcDir    = "/etc/pf9"
+	Pf9LogLoc = "pf9/log"
 	Pf9DirLoc = filepath.Join(homeDir, "/")
 )
 


### PR DESCRIPTION
To handle security issues with password being printed in logs, and stored as part of supportbundle,
* Now CLI logs wont print password as part of installer command. 
![Screenshot 2021-08-24 at 6 07 21 PM](https://user-images.githubusercontent.com/77390180/130624418-5334f01f-c0cf-44ee-9a90-f26f015fa13f.png)


* The config.json is removed from supportbundle as part of ~/pf9/db
![Screenshot 2021-08-24 at 6 40 04 PM](https://user-images.githubusercontent.com/77390180/130624378-8f9b4597-8a39-4db3-9645-36a9597f6fb6.png)
