### PR TITLE
improved os version check for ubuntu

### DIFF
--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -299,11 +299,11 @@ func (d *Debian) Version() (string, error) {
 		"bash",
 		"-c",
 		"cat /etc/*os-release | grep -i pretty_name | cut -d ' ' -f 2")
-	mjrVersion := out[0:2]
+	mjrVersion := out[0:5]
 	if err != nil {
 		return "", fmt.Errorf("Couldn't read the OS configuration file os-release: %s", err.Error())
 	}
-	if strings.Contains(string(mjrVersion), "16") || strings.Contains(string(mjrVersion), "18") || strings.Contains(string(mjrVersion), "20") {
+	if strings.Contains(string(mjrVersion), "16.04") || strings.Contains(string(mjrVersion), "18.04") || strings.Contains(string(mjrVersion), "20.04") {
 		return "debian", nil
 	}
 	return "", fmt.Errorf("Unable to determine OS type: %s", string(out))
@@ -383,9 +383,9 @@ func (d *Debian) checkIfTimesyncServiceRunning() (bool, error) {
 		} else {
 			zap.S().Debug("installed timesync package")
 			version := d.getVersion()
-			mjrVersion := version[0:2]
+			mjrVersion := version[0:5]
 			var err error
-			if strings.Contains(string(mjrVersion), "20") {
+			if strings.Contains(string(mjrVersion), "20.04") {
 				err = d.start("systemd-timesyncd")
 			} else {
 				err = d.start("ntp")
@@ -439,8 +439,8 @@ func (d *Debian) IsPresent(service string) error {
 	zap.S().Debugf("checking if %s is present", service)
 	var cmd string
 	version := d.getVersion()
-	mjrVersion := version[0:2]
-	if strings.Contains(string(mjrVersion), "16") {
+	mjrVersion := version[0:5]
+	if strings.Contains(string(mjrVersion), "16.04") {
 		cmd = fmt.Sprintf(`systemctl status %s | grep 'not-found'`, service)
 		_, err := d.exec.RunWithStdout("bash", "-c", cmd)
 		if err != nil {
@@ -493,9 +493,9 @@ func (d *Debian) start(service string) error {
 func (d *Debian) DownloadAndInstallTimesyncPkg() error {
 	zap.S().Debug("timesync package not found installing timesync package")
 	version := d.getVersion()
-	mjrVersion := version[0:2]
+	mjrVersion := version[0:5]
 	var err error
-	if strings.Contains(string(mjrVersion), "20") {
+	if strings.Contains(string(mjrVersion), "20.04") {
 		err = d.installOSPackages("systemd-timesyncd")
 	} else {
 		err = d.installOSPackages("ntp")


### PR DESCRIPTION
Currently we are comparing version with 16, 18, 20. which will cause check-node. and proceed for version like 20.10 which we dont support.