### PR TITLE
Fixed some command exit codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin
 build
 .vscode
 .env
+pf9ctl

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -48,8 +48,9 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 
 		executor, err := getExecutor(ctx.ProxyURL)
 		if err != nil {
-			zap.S().Fatalf(" Invalid (Username/Password/IP), use 'single quotes' to pass password")
+			//debug first since Fatalf calls os.Exit
 			zap.S().Debug("Error connecting to host %s", err.Error())
+			zap.S().Fatalf(" Invalid (Username/Password/IP), use 'single quotes' to pass password")
 		}
 
 		c, err = pmk.NewClient(ctx.Fqdn, executor, ctx.AllowInsecure, false)
@@ -94,10 +95,11 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 	}
 
 	if result == pmk.RequiredFail {
-		fmt.Printf(color.Red("x ")+"Required pre-requisite check(s) failed. See %s or use --verbose for logs \n", log.GetLogLocation(util.Pf9Log))
+		zap.S().Fatalf(color.Red("x ")+"Required pre-requisite check(s) failed. See %s or use --verbose for logs \n", log.GetLogLocation(util.Pf9Log))
+		//this is so the exit flag is set to 1
 	} else if result == pmk.OptionalFail {
 		fmt.Printf("\nOptional pre-requisite check(s) failed. See %s or use --verbose for logs \n", log.GetLogLocation(util.Pf9Log))
 	}
-
 	zap.S().Debug("==========Finished running check-node==========")
+
 }

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -120,21 +120,19 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 	}
 
 	if result == pmk.RequiredFail {
-		fmt.Println(color.Red("x ") + "Required pre-requisite check(s) failed.")
-		return
+		zap.S().Fatalf(color.Red("x ") + "Required pre-requisite check(s) failed.")
 	} else if !skipChecks {
 		if result == pmk.OptionalFail {
 			fmt.Print("\nOptional pre-requisite check(s) failed. Do you want to continue? (y/n) ")
 			reader := bufio.NewReader(os.Stdin)
 			char, _, _ := reader.ReadRune()
 			if char != 'y' {
-				return
+				os.Exit(0)
 			}
 		}
 	}
 
 	if err := pmk.PrepNode(ctx, c); err != nil {
-		fmt.Printf("\nFailed to prepare node. See %s or use --verbose for logs\n", log.GetLogLocation(util.Pf9Log))
 
 		// Uploads pf9cli log bundle if prepnode failed to get prepared
 		errbundle := supportBundle.SupportBundleUpload(ctx, c)
@@ -143,6 +141,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 		}
 
 		zap.S().Debugf("Unable to prep node: %s\n", err.Error())
+		zap.S().Fatalf("\nFailed to prepare node. See %s or use --verbose for logs\n", log.GetLogLocation(util.Pf9Log))
 	}
 
 	zap.S().Debug("==========Finished running prep-node==========")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,8 +36,8 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := initializeBaseDirs(); err != nil {
-		fmt.Printf("Base directory initialization failed: %s\n", err.Error())
-		os.Exit(1)
+		// Fatalf does the same as Printf and os.Exit
+		zap.S().Fatalf("Base directory initialization failed: %s\n", err.Error())
 	}
 
 	if err := rootCmd.Execute(); err != nil {


### PR DESCRIPTION
Fixed a couple of commands not changing the exit code when they are stopped or when they finish unsuccessfully.

Prep node:
![ExitCodeEg1](https://user-images.githubusercontent.com/86835683/136033094-fc4f0fd3-a7f4-4a9c-b51c-fcf8091d2e43.png)

Check node:
![ExitCodeEg2](https://user-images.githubusercontent.com/86835683/136033101-8f03fe78-e451-4718-abb7-72064fbb6328.png)

Other commands seam to send the correct exit code, only the check-node and prep-node commands had an issue.