### PR TITLE
Added segment-event property to differentiate between OVA and non-OVA nodes

### DIFF
--- a/pkg/client/segment.go
+++ b/pkg/client/segment.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/platform9/pf9ctl/pkg/keystone"
+	"github.com/platform9/pf9ctl/pkg/util"
 	"go.uber.org/zap"
 	"gopkg.in/segmentio/analytics-go.v3"
 )
@@ -52,6 +53,15 @@ func NewSegment(fqdn string, noTracking bool) Segment {
 }
 
 func (c SegmentImpl) SendEvent(name string, data interface{}, status string, err string) error {
+	//To differentiate between OVA and non-OVA node
+	var infra string
+	ovfservicepresent := InfraCheck()
+	if ovfservicepresent {
+		infra = "OVA"
+	} else {
+		infra = "CLI"
+	}
+
 	zap.S().Debug("Sending Segment Event: ", name)
 	data_struct, ok := data.(keystone.KeystoneAuth)
 	if ok {
@@ -63,6 +73,7 @@ func (c SegmentImpl) SendEvent(name string, data interface{}, status string, err
 				Set("dufqdn", data_struct.DUFqdn).
 				Set("email", data_struct.Email).
 				Set("status", status).
+				Set("infra", infra).
 				Set("errorMsg", err),
 			Integrations: analytics.NewIntegrations().Set("Amplitude", map[string]interface{}{
 				"session_id": time.Now().Unix(),
@@ -88,6 +99,21 @@ func (c SegmentImpl) SendGroupTraits(name string, data interface{}) error {
 	} else {
 		return fmt.Errorf("Unable to fetch keystone info")
 	}
+}
+
+func InfraCheck() bool {
+	//Checking for OVF Service to determine infrastructure for node onboarding
+	var ovfservice bool
+	_, err1 := os.Stat(util.OVFLoc)
+	if err1 != nil {
+		zap.S().Debugf("OVF Service not present")
+		ovfservice = false
+
+	} else {
+		zap.S().Debugf("Node onboarded through OVA")
+		ovfservice = true
+	}
+	return ovfservice
 }
 
 func (c SegmentImpl) Close() {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -79,6 +79,8 @@ var (
 	// before it starts with the operations.
 	WaitPeriod = time.Duration(60)
 
+	//Location of ovf service file
+	OVFLoc    = "/etc/systemd/system/ovf.service"
 	VarDir    = "/var/log/pf9"
 	EtcDir    = "/etc/pf9"
 	Pf9LogLoc = "pf9/log"


### PR DESCRIPTION
- #### Added segment event property (infra) to differentiate between OVA and non-OVA node on the basis of presence of ovf.service file.

OVA-node Segment Event
<img width="613" alt="141098129-a9a8dfe7-cf32-4a5d-a50a-e5790807a516" src="https://user-images.githubusercontent.com/65108449/141780529-b7ff618a-2911-49ef-9e0b-b057ad685f20.png">

non-OVA node Segment Event
<img width="613" alt="141098008-bce0004f-8c25-4143-b124-2a5cbdb7d6fc" src="https://user-images.githubusercontent.com/65108449/141780590-faf5a745-5322-41a5-83ce-859a3a709636.png">

The Older PR : https://github.com/platform9/pf9ctl/pull/224 was closed as it also contained automation changes


