### PR TITLE
Added Bootstrap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ Node decommissioned successfully
 
  ```sh
 ./pf9ctl bootstrap --help
-Bootstrap a single node Kubernetes cluster with your current node as the master node.
+Bootstrap a single node Kubernetes cluster with current node as the master node.
 
 Usage:
   pf9ctl bootstrap [flags]

--- a/README.md
+++ b/README.md
@@ -546,3 +546,69 @@ Node decommissioned successfully
 
 ✓ Has access
 ```
+
+ **bootstrap**
+
+ ```sh
+./pf9ctl bootstrap --help
+Bootstrap a single node Kubernetes cluster with your current node as the master node.
+
+Usage:
+  pf9ctl bootstrap [flags]
+
+Flags:
+      --allowWorkloadsOnMaster   Taint master nodes ( to enable workloads ) (default true)
+      --appCatalogEnabled        Enable Helm application catalog
+      --containersCidr string    CIDR for container overlay (default "10.20.0.0/16")
+      --externalDnsName string   External DNS for master VIP
+  -h, --help                     help for bootstrap
+  -i, --ip strings               IP address of host to be prepared
+      --masterVip string         IP Address for VIP for master nodes
+      --masterVipIf string       Interface name for master / worker nodes
+      --metallbIpRange string    Ip range for MetalLB
+      --networkPlugin string     Specify network plugin ( Possible values: flannel or calico ) (default "calico")
+  -p, --password string          ssh password for the nodes (use 'single quotes' to pass password)
+      --privileged               Enable privileged mode for K8s API. Default: true (default true)
+      --servicesCidr string      CIDR for services overlay (default "10.21.0.0/16")
+  -s, --ssh-key string           ssh key file for connecting to the nodes
+  -u, --user string              ssh username for the nodes
+
+Global Flags:
+      --no-prompt   disable all user prompts
+      --verbose     print verbose logs
+
+```
+
+```sh
+./pf9ctl bootstrap trial
+✓ Loaded Config Successfully
+✓ Node is not onboarded and not attached to any cluster
+✓ Removal of existing CLI
+✓ Existing Platform9 Packages Check
+✓ Required OS Packages Check
+✓ SudoCheck
+✓ CPUCheck
+✓ DiskCheck
+x MemoryCheck - At least 12 GB of memory is needed on host. Total memory found: 4 GB
+✓ PortCheck
+✓ Existing Kubernetes Cluster Check
+✓ Check lock on dpkg
+✓ Check lock on apt
+✓ Check if system is booted with systemd
+✓ Check time synchronization
+✓ Check if firewalld service is not running
+✓ Disabling swap and removing swap in fstab
+
+✓ Completed Pre-Requisite Checks successfully
+
+Optional pre-requisite check(s) failed. See /home/ubuntu/pf9/log/pf9ctl-20211119.log or use --verbose for logs 
+Prep local node as master node for kubernetes cluster (y/n): y
+✓ Platform9 packages installed successfully
+✓ Initialised host successfully
+✓ Host successfully attached to the Platform9 control-plane
+✓ Cluster created successfully
+✓ Host is connected
+✓ Attached node to the cluster
+2021-11-19T07:06:58.8159Z	INFO	=======Bootstrap successfully finished========
+
+```

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -25,8 +25,8 @@ import (
 // bootstrapCmd represents the bootstrap command
 var bootstrapCmd = &cobra.Command{
 	Use:   "bootstrap",
-	Short: "Create a single node k8s cluster with your current node",
-	Long:  `Bootstrap a single node Kubernetes cluster with your current node as the master node.`,
+	Short: "Create a single node k8s cluster with current node",
+	Long:  `Bootstrap a single node Kubernetes cluster with current node as the master node.`,
 
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -7,12 +7,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/platform9/pf9ctl/pkg/client"
 	"github.com/platform9/pf9ctl/pkg/cmdexec"
+	"github.com/platform9/pf9ctl/pkg/color"
 	"github.com/platform9/pf9ctl/pkg/config"
+	"github.com/platform9/pf9ctl/pkg/log"
 	"github.com/platform9/pf9ctl/pkg/objects"
 	"github.com/platform9/pf9ctl/pkg/pmk"
 	"github.com/platform9/pf9ctl/pkg/qbert"
+	"github.com/platform9/pf9ctl/pkg/supportBundle"
 	"github.com/platform9/pf9ctl/pkg/util"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -22,9 +26,7 @@ import (
 var bootstrapCmd = &cobra.Command{
 	Use:   "bootstrap",
 	Short: "Create a single node k8s cluster with your current node",
-	Long: `Bootstrap a single node Kubernetes cluster with your current
-	host as the Kubernetes node. Read more at
-	http://pf9.io/cli_clbootstrap.`,
+	Long:  `Bootstrap a single node Kubernetes cluster with your current node as the master node.`,
 
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
@@ -33,6 +35,26 @@ var bootstrapCmd = &cobra.Command{
 		return nil
 	},
 	Run: bootstrapCmdRun,
+}
+
+var bootConfig objects.NodeConfig
+
+func init() {
+	bootstrapCmd.Flags().StringVar(&masterVIP, "masterVip", "", "IP Address for VIP for master nodes")
+	bootstrapCmd.Flags().StringVar(&masterVIPIf, "masterVipIf", "", "Interface name for master / worker nodes")
+	bootstrapCmd.Flags().StringVar(&metallbIPRange, "metallbIpRange", "", "Ip range for MetalLB")
+	bootstrapCmd.Flags().StringVar(&containersCIDR, "containersCidr", "10.20.0.0/16", "CIDR for container overlay")
+	bootstrapCmd.Flags().StringVar(&servicesCIDR, "servicesCidr", "10.21.0.0/16", "CIDR for services overlay")
+	bootstrapCmd.Flags().StringVar(&externalDNSName, "externalDnsName", "", "External DNS for master VIP")
+	bootstrapCmd.Flags().BoolVar(&privileged, "privileged", true, "Enable privileged mode for K8s API. Default: true")
+	bootstrapCmd.Flags().BoolVar(&appCatalogEnabled, "appCatalogEnabled", false, "Enable Helm application catalog")
+	bootstrapCmd.Flags().BoolVar(&allowWorkloadsOnMaster, "allowWorkloadsOnMaster", true, "Taint master nodes ( to enable workloads )")
+	bootstrapCmd.Flags().StringVar(&networkPlugin, "networkPlugin", "calico", "Specify network plugin ( Possible values: flannel or calico )")
+	bootstrapCmd.Flags().StringVarP(&bootConfig.User, "user", "u", "", "ssh username for the nodes")
+	bootstrapCmd.Flags().StringVarP(&bootConfig.Password, "password", "p", "", "ssh password for the nodes (use 'single quotes' to pass password)")
+	bootstrapCmd.Flags().StringVarP(&bootConfig.SshKey, "ssh-key", "s", "", "ssh key file for connecting to the nodes")
+	bootstrapCmd.Flags().StringSliceVarP(&bootConfig.IPs, "ip", "i", []string{}, "IP address of host to be prepared")
+	rootCmd.AddCommand(bootstrapCmd)
 }
 
 var (
@@ -51,15 +73,125 @@ var (
 func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 	zap.S().Debug("Received a call to bootstrap the node")
 
-	cfg := &objects.Config{WaitPeriod: time.Duration(60), AllowInsecure: false, MfaToken: nc.MFA}
-	err := config.LoadConfig(util.Pf9DBLoc, cfg, objects.NodeConfig{})
-	if err != nil {
-		zap.S().Fatalf("Unable to load config: %s", err.Error())
+	detachedMode := cmd.Flags().Changed("no-prompt")
+	isRemote := cmdexec.CheckRemote(bootConfig)
+
+	if isRemote {
+		if !config.ValidateNodeConfig(&bootConfig, !detachedMode) {
+			zap.S().Fatal("Invalid remote node config (Username/Password/IP), use 'single quotes' to pass password")
+		}
 	}
 
-	c, err := client.NewClient(cfg.Fqdn, cmdexec.LocalExecutor{}, cfg.AllowInsecure, false)
+	cfg := &objects.Config{WaitPeriod: time.Duration(60), AllowInsecure: false, MfaToken: bootConfig.MFA}
+	var err error
+	if detachedMode {
+		err = config.LoadConfig(util.Pf9DBLoc, cfg, bootConfig)
+	} else {
+		err = config.LoadConfigInteractive(util.Pf9DBLoc, cfg, bootConfig)
+	}
 	if err != nil {
-		zap.S().Fatalf("Unable to load clients: %s", err.Error())
+		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
+	}
+
+	fmt.Println(color.Green("✓ ") + "Loaded Config Successfully")
+
+	var executor cmdexec.Executor
+	if executor, err = cmdexec.GetExecutor(cfg.ProxyURL, bootConfig); err != nil {
+		zap.S().Fatalf("Unable to create executor: %s\n", err.Error())
+	}
+
+	var c client.Client
+	if c, err = client.NewClient(cfg.Fqdn, executor, cfg.AllowInsecure, false); err != nil {
+		zap.S().Fatalf("Unable to create client: %s\n", err.Error())
+	}
+
+	defer c.Segment.Close()
+
+	if isRemote {
+		if err := SudoPasswordCheck(executor, detachedMode, bootConfig.SudoPassword); err != nil {
+			zap.S().Fatal(err.Error())
+		}
+	}
+
+	defer c.Segment.Close()
+
+	// Fetch the keystone token.
+	auth, err := c.Keystone.GetAuth(
+		cfg.Username,
+		cfg.Password,
+		cfg.Tenant,
+		cfg.MfaToken,
+	)
+
+	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	s.Color("red")
+	s.Start()
+	defer s.Stop()
+	s.Suffix = " Running pre-requisite checks for Bootstrap command"
+
+	val, val1, err := pmk.PreReqBootstrap(executor)
+	if err != nil {
+		zap.S().Fatalf("Error running Prerequisite Checks for Bootstrap Command")
+	}
+	s.Stop()
+	if !val1 && !val { //Both node and cluster are already present
+		zap.S().Fatalf(color.Red("x ") + " Cannot run this command as this node is already attached to a cluster")
+
+	} else if !val && val1 { //Only node is present but not attached to a cluster
+		util.SkipPrepNode = true
+		fmt.Println(color.Green("✓") + " Node is already Onboarded....Skipping Prep-Node")
+	} else { //Both node and cluster are not present
+		fmt.Println(color.Green("✓") + " Node is not onboarded and not attached to any cluster")
+		util.SkipPrepNode = false
+	}
+
+	if !util.SkipPrepNode {
+		zap.S().Debug("========== Running check-node as a part of bootstrap ==========")
+
+		result, err := pmk.CheckNode(*cfg, c, auth)
+		if err != nil {
+			// Uploads pf9cli log bundle if checknode fails
+			errbundle := supportBundle.SupportBundleUpload(*cfg, c, isRemote)
+			if errbundle != nil {
+				zap.S().Debugf("Unable to upload supportbundle to s3 bucket %s", errbundle.Error())
+			}
+			zap.S().Fatalf("Unable to perform pre-requisite checks on this node: %s", err.Error())
+		}
+
+		if result == pmk.RequiredFail {
+			zap.S().Fatalf(color.Red("x ")+"Required pre-requisite check(s) failed. See %s or use --verbose for logs \n", log.GetLogLocation(util.Pf9Log))
+			//this is so the exit flag is set to 1
+		} else if result == pmk.OptionalFail {
+			fmt.Printf("\nOptional pre-requisite check(s) failed. See %s or use --verbose for logs \n", log.GetLogLocation(util.Pf9Log))
+		}
+
+		zap.S().Debug("==========Finished running check-node==========")
+
+		zap.S().Debug("Received a call to boostrap the local node")
+
+		if !detachedMode {
+			resp, err := util.AskBool("Prep local node as master node for kubernetes cluster")
+			if err != nil || !resp {
+				zap.S().Fatalf(" Declined to proceed with creating a Kubernetes cluster with the current node as the masternode ")
+			}
+		} else {
+			fmt.Println(" Proceeding to create a Kubernetes cluster with current node as master node")
+		}
+
+		zap.S().Debug("========== Running prep-node as a part of bootstrap ==========")
+		if err := pmk.PrepNode(*cfg, c, auth); err != nil {
+
+			// Uploads pf9cli log bundle if prepnode failed to get prepared
+			errbundle := supportBundle.SupportBundleUpload(*cfg, c, isRemote)
+			if errbundle != nil {
+				zap.S().Debugf("Unable to upload supportbundle to s3 bucket %s", errbundle.Error())
+			}
+
+			zap.S().Debugf("Unable to prep node: %s\n", err.Error())
+			zap.S().Fatalf("\nFailed to prepare node. See %s or use --verbose for logs\n", log.GetLogLocation(util.Pf9Log))
+		}
+
+		zap.S().Debug("==========Finished running prep-node==========")
 	}
 	defer c.Segment.Close()
 
@@ -78,14 +210,6 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 		Privileged:            privileged,
 	}
 
-	// Fetch the keystone token.
-	auth, err := c.Keystone.GetAuth(
-		cfg.Username,
-		cfg.Password,
-		cfg.Tenant,
-		cfg.MfaToken,
-	)
-
 	if err != nil {
 		// Certificate expiration is detected by the http library and
 		// only error object gets populated, which means that the http
@@ -98,28 +222,16 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Unable to obtain keystone credentials: %s", err.Error())
 	}
 
-	err = pmk.Bootstrap(*cfg, c, payload, auth)
-	if err != nil {
-		c.Segment.SendEvent("Bootstrap : Cluster creation failed", err, "FAIL", "")
-		zap.S().Fatalf("Unable to bootstrap the cluster. Error: %s", err.Error())
-	}
+	if err := pmk.Bootstrap(*cfg, c, payload, auth, bootConfig); err != nil {
 
-	if err := c.Segment.SendEvent("Bootstrap : Cluster creation succeeded", payload, "PASS", ""); err != nil {
-		zap.S().Errorf("Unable to send Segment event for Bootstrap. Error: %s", err.Error())
-	}
-}
+		// Uploads pf9cli log bundle if bootstrap command fails
+		errbundle := supportBundle.SupportBundleUpload(*cfg, c, isRemote)
+		if errbundle != nil {
+			zap.S().Debugf("Unable to upload supportbundle to s3 bucket %s", errbundle.Error())
+		}
 
-func init() {
-	bootstrapCmd.Flags().StringVar(&masterVIP, "masterVip", "", "IP Address for VIP for master nodes")
-	bootstrapCmd.Flags().StringVar(&masterVIPIf, "masterVipIf", "", "Interface name for master / worker nodes")
-	bootstrapCmd.Flags().StringVar(&metallbIPRange, "metallbIpRange", "", "Ip range for MetalLB")
-	bootstrapCmd.Flags().StringVar(&containersCIDR, "containersCidr", "10.20.0.0/16", "CIDR for container overlay")
-	bootstrapCmd.Flags().StringVar(&servicesCIDR, "servicesCidr", "10.21.0.0/16", "CIDR for services overlay")
-	bootstrapCmd.Flags().StringVar(&externalDNSName, "externalDnsName", "", "External DNS for master VIP")
-	bootstrapCmd.Flags().BoolVar(&privileged, "privileged", true, "Enable privileged mode for K8's API. Default: true")
-	bootstrapCmd.Flags().BoolVar(&appCatalogEnabled, "appCatalogEnabled", false, "Enable Helm application catalog")
-	bootstrapCmd.Flags().BoolVar(&allowWorkloadsOnMaster, "allowWorkloadsOnMaster", true, "Taint master nodes ( to enable workloads )")
-	bootstrapCmd.Flags().StringVar(&networkPlugin, "networkPlugin", "flannel", "Specify network plugin ( Possible values: flannel or calico )")
-	// This is the bootstrap command to initialize its run and add to root which is not in use for now.
-	//rootCmd.AddCommand(bootstrapCmd)
+		zap.S().Debugf("Unable to bootstrap node: %s\n", err.Error())
+		zap.S().Fatalf("\nFailed to bootstrap node. See %s or use --verbose for logs\n", log.GetLogLocation(util.Pf9Log))
+	}
+	zap.S().Debug("==========Finished running bootstrap==========")
 }

--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -39,7 +39,7 @@ func (c *CentOS) Check() []platform.Check {
 	result, err := c.removePyCli()
 	checks = append(checks, platform.Check{"Removal of existing CLI", false, result, err, util.PyCliErr})
 
-	result, err = c.checkExistingInstallation()
+	result, err = c.CheckExistingInstallation()
 	checks = append(checks, platform.Check{"Existing Platform9 Packages Check", true, result, err, util.ExisitngInstallationErr})
 
 	result, err = c.checkOSPackages()
@@ -60,7 +60,7 @@ func (c *CentOS) Check() []platform.Check {
 	result, err = c.checkPort()
 	checks = append(checks, platform.Check{"PortCheck", true, result, err, fmt.Sprintf("%s", err)})
 
-	result, err = c.checkKubernetesCluster()
+	result, err = c.CheckKubernetesCluster()
 	checks = append(checks, platform.Check{"Existing Kubernetes Cluster Check", true, result, err, fmt.Sprintf("%s", err)})
 
 	result, err = c.checkPIDofSystemd()
@@ -77,7 +77,7 @@ func (c *CentOS) Check() []platform.Check {
 	return checks
 }
 
-func (c *CentOS) checkKubernetesCluster() (bool, error) {
+func (c *CentOS) CheckKubernetesCluster() (bool, error) {
 	for _, proc := range util.ProcessesList {
 		//Checking if kubernetes process is running on the host or not
 		_, err := c.exec.RunWithStdout("bash", "-c", fmt.Sprintf("ps -A | grep -i %s", proc))
@@ -105,7 +105,7 @@ func (c *CentOS) checkDocker() error {
 	return err
 }
 
-func (c *CentOS) checkExistingInstallation() (bool, error) {
+func (c *CentOS) CheckExistingInstallation() (bool, error) {
 
 	var (
 		out string

--- a/pkg/platform/centos/centos_test.go
+++ b/pkg/platform/centos/centos_test.go
@@ -338,7 +338,7 @@ func TestExistingInstallation(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			c := &CentOS{exec: tc.exec}
-			o, err := c.checkExistingInstallation()
+			o, err := c.CheckExistingInstallation()
 
 			if diff := cmp.Diff(tc.want.err, err); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
@@ -504,7 +504,7 @@ func TestCheckKubernetesCluster(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			c := &CentOS{exec: tc.exec}
-			o, err := c.checkKubernetesCluster()
+			o, err := c.CheckKubernetesCluster()
 
 			if diff := cmp.Diff(tc.want.result, o); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -38,7 +38,7 @@ func (d *Debian) Check() []platform.Check {
 	result, err := d.removePyCli()
 	checks = append(checks, platform.Check{"Removal of existing CLI", false, result, err, util.PyCliErr})
 
-	result, err = d.checkExistingInstallation()
+	result, err = d.CheckExistingInstallation()
 	checks = append(checks, platform.Check{"Existing Platform9 Packages Check", true, result, err, util.ExisitngInstallationErr})
 
 	result, err = d.checkOSPackages()
@@ -59,7 +59,7 @@ func (d *Debian) Check() []platform.Check {
 	result, err = d.checkPort()
 	checks = append(checks, platform.Check{"PortCheck", true, result, err, fmt.Sprintf("%s", err)})
 
-	result, err = d.checkKubernetesCluster()
+	result, err = d.CheckKubernetesCluster()
 	checks = append(checks, platform.Check{"Existing Kubernetes Cluster Check", true, result, err, fmt.Sprintf("%s", err)})
 
 	result, err = d.checkIfdpkgISLock()
@@ -84,7 +84,7 @@ func (d *Debian) Check() []platform.Check {
 	return checks
 }
 
-func (d *Debian) checkKubernetesCluster() (bool, error) {
+func (d *Debian) CheckKubernetesCluster() (bool, error) {
 	for _, proc := range util.ProcessesList {
 		//Checking if kubernetes process is running on the host or not
 		_, err := d.exec.RunWithStdout("bash", "-c", fmt.Sprintf("ps -A | grep -i %s", proc))
@@ -112,7 +112,7 @@ func (d *Debian) checkDocker() error {
 	return err
 }
 
-func (d *Debian) checkExistingInstallation() (bool, error) {
+func (d *Debian) CheckExistingInstallation() (bool, error) {
 
 	var (
 		out string

--- a/pkg/platform/debian/debian_test.go
+++ b/pkg/platform/debian/debian_test.go
@@ -335,7 +335,7 @@ func TestExistingInstallation(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			c := &Debian{exec: tc.exec}
-			o, err := c.checkExistingInstallation()
+			o, err := c.CheckExistingInstallation()
 
 			if diff := cmp.Diff(tc.want.err, err); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
@@ -501,7 +501,7 @@ func TestCheckKubernetesCluster(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			c := &Debian{exec: tc.exec}
-			o, err := c.checkKubernetesCluster()
+			o, err := c.CheckKubernetesCluster()
 
 			if diff := cmp.Diff(tc.want.result, o); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -3,4 +3,6 @@ package platform
 type Platform interface {
 	Check() []Check
 	Version() (string, error)
+	CheckExistingInstallation() (bool, error)
+	CheckKubernetesCluster() (bool, error)
 }

--- a/pkg/pmk/cluster.go
+++ b/pkg/pmk/cluster.go
@@ -1,5 +1,3 @@
-// Copyright © 2020 The Platform9 Systems Inc.
-
 package pmk
 
 import (
@@ -7,58 +5,224 @@ import (
 	"strings"
 	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/platform9/pf9ctl/pkg/client"
+	"github.com/platform9/pf9ctl/pkg/cmdexec"
+	"github.com/platform9/pf9ctl/pkg/color"
 	"github.com/platform9/pf9ctl/pkg/keystone"
 	"github.com/platform9/pf9ctl/pkg/objects"
+	"github.com/platform9/pf9ctl/pkg/platform/centos"
+	"github.com/platform9/pf9ctl/pkg/platform/debian"
 	"github.com/platform9/pf9ctl/pkg/qbert"
 	"github.com/platform9/pf9ctl/pkg/util"
 	"go.uber.org/zap"
 )
 
-// Bootstrap simply preps the local node and attach it as master to a newly
-// created cluster.
-func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateRequest, keystoneAuth keystone.KeystoneAuth) error {
-	zap.S().Debug("Received a call to boostrap the local node")
+// Bootstrap simply onboards the local node and attaches it as master to a newly created cluster.
+func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateRequest, keystoneAuth keystone.KeystoneAuth, bootConfig objects.NodeConfig) error {
 
-	resp, err := util.AskBool("Prep local node for kubernetes cluster")
-	if err != nil || !resp {
-		zap.S().Errorf("Couldn't fetch user content")
+	if err1 := c.Segment.SendEvent("Starting Cluster creation(Bootstrap)", keystoneAuth, checkPass, ""); err1 != nil {
+		zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err1.Error())
 	}
 
-	if err := PrepNode(ctx, c, keystoneAuth); err != nil {
-		return fmt.Errorf("Unable to prepnode: %w", err)
-	}
+	token := keystoneAuth.Token
+	clustername := fmt.Sprintf(" Creating a cluster %s", req.Name)
 
-	zap.S().Info("Creating the cluster...")
+	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	s.Color("red")
+	s.Start() // Start the spinner
+	defer s.Stop()
+	s.Suffix = clustername
+
 	clusterID, err := c.Qbert.CreateCluster(
 		req,
 		keystoneAuth.ProjectID,
 		keystoneAuth.Token)
 
+	s.Stop()
+
 	if err != nil {
-		return fmt.Errorf("Unable to create cluster: %w", err)
+		if err = c.Segment.SendEvent("Cluster creation(Bootstrap)", keystoneAuth, checkFail, ""); err != nil {
+			zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
+		}
+		fmt.Println(color.Red("x ") + " Unable to create a Cluster")
+		return fmt.Errorf("Unable to create cluster"+req.Name+": %w", err)
 	}
 
-	cmd := `grep host_id /etc/pf9/host_id.conf | cut -d '=' -f2`
+	fmt.Println(color.Green("✓") + " Cluster created successfully")
+
+	if err = c.Segment.SendEvent("Cluster creation(Bootstrap)", keystoneAuth, checkPass, ""); err != nil {
+		zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
+	}
+
+	s.Color("red")
+	s.Start() // Start the spinner
+	defer s.Stop()
+	s.Suffix = "Checking Host Status"
+
+	cmd := `grep ^host_id /etc/pf9/host_id.conf | cut -d = -f2 | cut -d ' ' -f2`
 	output, err := c.Executor.RunWithStdout("bash", "-c", cmd)
-	output = strings.TrimSpace(output)
 	if err != nil {
 		return fmt.Errorf("Unable to execute command: %w", err)
 	}
 	nodeID := strings.TrimSuffix(string(output), "\n")
 
-	time.Sleep(ctx.WaitPeriod * time.Second)
-	var nodeIDs []string
-	nodeIDs = append(nodeIDs, nodeID)
-	zap.S().Info("Attaching node to the cluster...")
-	err = c.Qbert.AttachNode(
-		clusterID,
-		keystoneAuth.ProjectID, keystoneAuth.Token, nodeIDs, "worker")
-
-	if err != nil {
-		return fmt.Errorf("Unable to attach node: %w", err)
+	LoopVariable := 1
+	for LoopVariable <= util.MaxLoopValue {
+		hostStatus := Host_Status(c.Executor, ctx.Fqdn, token, nodeID, bootConfig)
+		if hostStatus != "true" {
+			zap.S().Debugf("Host is Down...Trying again")
+		} else {
+			util.HostDown = false
+			break
+		}
+		LoopVariable = LoopVariable + 1
 	}
 
-	zap.S().Info("Bootstrap successfully finished")
+	s.Stop()
+
+	if !util.HostDown {
+
+		zap.S().Debugf("Host is Connected...Proceeding to connect node to cluster " + req.Name)
+		fmt.Println(color.Green("✓") + " Host is connected")
+		if err = c.Segment.SendEvent("Host Connected(Bootstrap)", keystoneAuth, checkPass, ""); err != nil {
+			zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
+		}
+	} else {
+		fmt.Println(color.Red("x ") + " Host is disconnected")
+		if err = c.Segment.SendEvent("Host Connected(Bootstrap)", keystoneAuth, checkFail, ""); err != nil {
+			zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
+		}
+		//Deleting the cluster if the host is disconnected
+		err = c.Qbert.DeleteCluster(clusterID, keystoneAuth.ProjectID, token)
+
+		if err != nil {
+			if err = c.Segment.SendEvent("Delete Cluster(Bootstrap)", keystoneAuth, checkFail, ""); err != nil {
+				zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
+			}
+			zap.S().Debugf("Unable to delete the cluster")
+		} else {
+			if err = c.Segment.SendEvent("Delete Cluster(Bootstrap)", keystoneAuth, checkPass, ""); err != nil {
+				zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
+			}
+			zap.S().Debugf("Deleted the cluster successfully")
+		}
+		zap.S().Fatalf("Host is disconnected....Unable to attach this node to the cluster " + req.Name)
+	}
+
+	attachname := fmt.Sprintf(" Attaching node to the cluster %s", req.Name)
+	s.Color("red")
+	s.Start() // Start the spinner
+	defer s.Stop()
+	s.Suffix = attachname
+
+	time.Sleep(30 * time.Second)
+	var nodeIDs []string
+	nodeIDs = append(nodeIDs, nodeID)
+
+	err = c.Qbert.AttachNode(
+		clusterID,
+		keystoneAuth.ProjectID, keystoneAuth.Token, nodeIDs, "master")
+
+	s.Stop() //Stop the Spinner
+
+	if err != nil {
+		fmt.Println(color.Red("x ") + " Unable to attach-node to cluster")
+		if err = c.Segment.SendEvent("Attach-Node(Bootstrap)", keystoneAuth, checkFail, ""); err != nil {
+			zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
+		}
+
+		//Deleting the cluster if the node is not attached to the cluster
+		err = c.Qbert.DeleteCluster(clusterID, keystoneAuth.ProjectID, token)
+
+		if err != nil {
+			if err = c.Segment.SendEvent("Delete Cluster(Bootstrap)", keystoneAuth, checkFail, ""); err != nil {
+				zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
+			}
+			zap.S().Debugf("Unable to delete the cluster")
+		} else {
+			if err = c.Segment.SendEvent("Delete Cluster(Bootstrap)", keystoneAuth, checkPass, ""); err != nil {
+				zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
+			}
+			zap.S().Debugf("Deleted the cluster successfully")
+		}
+		return fmt.Errorf("Unable to attach node to the cluster"+req.Name+": %w", err)
+	}
+
+	fmt.Println(color.Green("✓") + " Attached node to the cluster")
+	if err = c.Segment.SendEvent("Attach-Node(Bootstrap)", keystoneAuth, checkPass, ""); err != nil {
+		zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
+	}
+
+	if err = c.Segment.SendEvent("Bootstrap Completed Successfully", keystoneAuth, checkPass, ""); err != nil {
+		zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
+	}
+	zap.S().Info("=======Bootstrap successfully finished========")
 	return nil
+}
+
+//To check the host status before attaching the node to a cluster
+func Host_Status(exec cmdexec.Executor, fqdn string, token string, hostID string, bootConfig objects.NodeConfig) string {
+	zap.S().Debug("Getting host status")
+	isRemote := cmdexec.CheckRemote(bootConfig)
+
+	tkn := fmt.Sprintf(`"X-Auth-Token: %v"`, token)
+	cmd := fmt.Sprintf(`curl -sH %v -X GET %v/resmgr/v1/hosts/%v | jq .info.responding`, tkn, fqdn, hostID)
+	var status string
+	var err1 error
+
+	if isRemote {
+		cmnd := fmt.Sprintf(`bash %s`, cmd)
+		status, err1 = exec.RunWithStdout(cmnd)
+	} else {
+		status, err1 = exec.RunWithStdout("bash", "-c", cmd)
+	}
+	if err1 != nil {
+		zap.S().Fatalf("Unable to get host status : ", err1)
+	}
+	status = strings.TrimSpace(strings.Trim(status, "\n\""))
+	zap.S().Debug("Host status is : ", status)
+	return status
+}
+
+//Checks Prerequisites for Bootstrap Command
+func PreReqBootstrap(executor cmdexec.Executor) (bool, bool, error) {
+
+	os, err := ValidatePlatform(executor)
+	if err != nil {
+		zap.S().Fatalf("OS version is not supported")
+	}
+
+	if os == "debian" {
+		Instance := debian.NewDebian(executor)
+		val, err := Instance.CheckExistingInstallation()
+		if err != nil {
+			//zap.S().Fatalf("Could not run command Installation")
+			zap.S().Fatalf("Error %s", err)
+		}
+
+		val1, err1 := Instance.CheckKubernetesCluster()
+		if err1 != nil {
+			//zap.S().Fatalf("Could not run command Cluster")
+			zap.S().Fatalf("Error %s", err1)
+		}
+		return val, val1, nil
+	} else if os == "redhat" {
+		Instance := centos.NewCentOS(executor)
+		val, err := Instance.CheckExistingInstallation()
+		if err != nil {
+			//zap.S().Fatalf("Could not run command Installation")
+			zap.S().Fatalf("Error %s", err)
+		}
+
+		val1, err1 := Instance.CheckKubernetesCluster()
+		if err1 != nil {
+			//zap.S().Fatalf("Could not run command Cluster")
+			zap.S().Fatalf("Error %s", err1)
+		}
+		return val, val1, nil
+	} else {
+		zap.S().Infof("OS version is not supported")
+		return false, false, fmt.Errorf("OS version is not supported")
+	}
 }

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -11,7 +11,8 @@ var RequiredPorts []string
 var PortErr string
 var ProcessesList []string //Kubernetes clusters processes list
 var SwapOffDisabled bool   //If this is true the swapOff functionality will be disabled.
-
+var SkipPrepNode bool
+var HostDown bool
 var EBSPermissions []string
 var Route53Permissions []string
 var EC2Permission []string
@@ -35,6 +36,8 @@ const (
 	MinDisk = 30
 	// Disk size in GiBs
 	MinAvailDisk = 15
+	// Counter variable max value
+	MaxLoopValue = 3
 
 	CheckPass       = "PASS"
 	CheckFail       = "FAIL"


### PR DESCRIPTION
- This command bootstraps a single node Kubernetes cluster with the current node as the master node.
- Added Prerequisite checks for Bootstrap command to check whether the host is already attached to the PF9 control plane and is also attached to a cluster.
- Deletes the cluster created in case bootstrap command fails.
- Use Cases 
   - Bootstrap Info 
<img width="840" alt="Bootstrap_Info" src="https://user-images.githubusercontent.com/65108449/142580923-163fe959-3bc4-4595-abf6-7fac370c093f.png">

   - Local Bootstrap(Node and Cluster both are not present)
 
<img width="827" alt="Bootstrap_No_Node_Local" src="https://user-images.githubusercontent.com/65108449/142580994-a6ce0e77-0c89-46b6-96b4-0c2d7b767e92.png">

   - Local Bootstrap(Node and Cluster both are not present) (with --no-prompt flag)
<img width="827" alt="Bootstrap_No_Node_no-prompt_Local" src="https://user-images.githubusercontent.com/65108449/142581063-8a7e814f-6346-481f-ad83-5b0bcb8519dd.png">

  - Remote Bootstrap(Node and Cluster both are not present)
 
<img width="827" alt="Bootstrap_No_Node_Remote" src="https://user-images.githubusercontent.com/65108449/142581375-26becfd0-2a0d-4404-972e-a52ccfe43c3e.png">


  - Remote Bootstrap(Node and Cluster both are not present) (with --no-prompt flag)
   <img width="827" alt="Bootstrap_No_Node_no-prompt_Remote" src="https://user-images.githubusercontent.com/65108449/142581117-e62c7c34-7cd1-4c69-91bc-5115d8db98c7.png">

  - Local(Node is Onboarded but not attached to a cluster)
  
<img width="827" alt="Bootstrap_Node_Local" src="https://user-images.githubusercontent.com/65108449/142581446-71cc7544-b47b-4c9d-8de1-a3623f1df4b3.png">

  - Remote(Node is Onboarded but not attached to a cluster)
  
<img width="827" alt="Bootstrap_Node_Remote" src="https://user-images.githubusercontent.com/65108449/142581519-75357276-f29f-4ef6-9a48-91a65e2aca24.png">

  - Node is Onboarded and attached to a Cluster
<img width="1016" alt="Both_Cluster_Node_Present" src="https://user-images.githubusercontent.com/65108449/142581579-e624bed9-3070-49df-8703-750c258c8e54.png">
 