### PR TITLE
fix SudoPasswordCheck to consider user passed sudo password

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -109,7 +109,7 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 
 	if isRemote {
 		if err := SudoPasswordCheck(executor, detachedMode, bootConfig.SudoPassword); err != nil {
-			zap.S().Fatal(err.Error())
+			zap.S().Fatal("Failed executing commands on remote machine with sudo: ", err.Error())
 		}
 	}
 

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -105,7 +105,7 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 
 	if isRemote {
 		if err := SudoPasswordCheck(executor, detachedMode, nc.SudoPassword); err != nil {
-			zap.S().Fatal("Failed to check sudo password for remote machine:", err.Error())
+			zap.S().Fatal("Failed executing commands on remote machine with sudo: ", err.Error())
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>

The method `SudoPasswordCheck` is broken - in that it doesn't consider the sudo password passed through `-e` by certain commands and prompts for it. Also, it causes wrong error message shown when passing wrong password with `--no-prompt`

```
./pf9ctl bundle -i 10.128.133.33 -u ubuntu -e "ubuntu" -p "ubuntu" 
Error checking versions open /usr/bin/pf9ctl: no such file or directory
✓ Loaded Config Successfully
2021-11-23T10:46:11.7675Z	INFO	==========Uploading supportBundle to S3 bucket==========
✓ Succesfully uploaded pf9ctl supportBundle to loguploads.platform9.com bucket at https://s3-us-west-2.amazonaws.com/loguploads.platform9.com/pmkft-1634051428-31555.platform9.io/10.128.133.33/ location
./pf9ctl bundle -i 10.128.133.33 -u ubuntu -e "ubuntu1" -p "ubuntu" 
Error checking versions open /usr/bin/pf9ctl: no such file or directory
✓ Loaded Config Successfully
x Invalid Sudo Password provided of Remote Host
Enter Sudo password for Remote Host: 
x Invalid Sudo Password provided of Remote Host
Enter Sudo password for Remote Host: 
x Invalid Sudo Password provided of Remote Host
Enter Sudo password for Remote Host: 2021-11-23T10:47:48.1523Z	FATAL	
x Invalid Sudo Password entered multiple times
```
```
./pf9ctl bundle -i 10.128.133.33 -u ubuntu -p "ubuntu" -e "ubuntu" --no-prompt
Error checking versions open /usr/bin/pf9ctl: no such file or directory
✓ Loaded Config Successfully
2021-11-23T10:51:32.5447Z	INFO	==========Uploading supportBundle to S3 bucket==========
✓ Succesfully uploaded pf9ctl supportBundle to loguploads.platform9.com bucket at https://s3-us-west-2.amazonaws.com/loguploads.platform9.com/pmkft-1634051428-31555.platform9.io/10.128.133.33/ location
```

```
./pf9ctl bundle -i 10.128.133.33 -u ubuntu -p "ubuntu" -e "ubuntu1" --no-prompt
Error checking versions open /usr/bin/pf9ctl: no such file or directory
✓ Loaded Config Successfully
2021-11-23T10:51:52.1176Z	FATAL	Failed executing commands on remote machine with sudo: Invalid password for user on remote host
```