### PR TITLE
Added sudo password for remote host (-e) flag to supportBundlecommand

### DIFF
--- a/cmd/supportBundle.go
+++ b/cmd/supportBundle.go
@@ -36,6 +36,7 @@ func init() {
 	supportBundleCmd.Flags().StringVarP(&bundleConfig.SshKey, "ssh-key", "s", "", "ssh key file for connecting to the nodes")
 	supportBundleCmd.Flags().StringSliceVarP(&bundleConfig.IPs, "ip", "i", []string{}, "IP address of host to be prepared")
 	supportBundleCmd.Flags().StringVar(&bundleConfig.MFA, "mfa", "", "MFA token")
+	supportBundleCmd.Flags().StringVarP(&bundleConfig.SudoPassword, "sudo-pass", "e", "", "sudo password for user on remote host")
 
 	rootCmd.AddCommand(supportBundleCmd)
 }
@@ -75,6 +76,12 @@ func supportBundleUpload(cmd *cobra.Command, args []string) {
 	}
 
 	defer c.Segment.Close()
+
+	if isRemote {
+		if err := SudoPasswordCheck(executor, detachedMode, bundleConfig.SudoPassword); err != nil {
+			zap.S().Fatal("Failed executing commands on remote machine with sudo: ", err.Error())
+		}
+	}
 
 	zap.S().Info("==========Uploading supportBundle to S3 bucket==========")
 	err = supportBundle.SupportBundleUpload(*cfg, c, isRemote)


### PR DESCRIPTION
##### without --no-prompt 
<img width="1413" alt="Screenshot 2021-11-23 at 2 09 22 PM" src="https://user-images.githubusercontent.com/65108449/143014095-b4336409-1fa1-40d0-a042-2f6b18c72e0e.png">

##### with --no-prompt 
<img width="1418" alt="Screenshot 2021-11-23 at 2 09 54 PM" src="https://user-images.githubusercontent.com/65108449/143014100-93014cc7-91f4-4cc4-8b15-d66cc0f157e6.png">

