### PR TITLE
Removed skipCheck, using no-prompt, fixed error in detach-node if a node is not attached

### DIFF
--- a/cmd/deauthoriseNode.go
+++ b/cmd/deauthoriseNode.go
@@ -83,7 +83,7 @@ func deauthNodeRun(cmd *cobra.Command, args []string) {
 
 	isMaster := getNode(c.Executor, cfg.Fqdn, token, projectId, nodeUuids[0])
 
-	if detachedMode {
+	if !detachedMode && isMaster.ClusterUuid != "" {
 
 		projectNodes := getAllProjectNodes(c.Executor, cfg.Fqdn, token, projectId)
 

--- a/cmd/deauthoriseNode.go
+++ b/cmd/deauthoriseNode.go
@@ -30,7 +30,6 @@ var deauthNodeCmd = &cobra.Command{
 }
 
 func init() {
-	deauthNodeCmd.Flags().BoolVarP(&skipCheck, "skipCheck", "s", false, "skips node check")
 	deauthNodeCmd.Flags().StringVar(&attachconfig.MFA, "mfa", "", "MFA token")
 	rootCmd.AddCommand(deauthNodeCmd)
 }
@@ -84,7 +83,7 @@ func deauthNodeRun(cmd *cobra.Command, args []string) {
 
 	isMaster := getNode(c.Executor, cfg.Fqdn, token, projectId, nodeUuids[0])
 
-	if !skipCheck {
+	if detachedMode {
 
 		projectNodes := getAllProjectNodes(c.Executor, cfg.Fqdn, token, projectId)
 


### PR DESCRIPTION
One node is attached the other is not
![image](https://user-images.githubusercontent.com/86835683/143201523-ed7a3403-279e-416f-b0e5-bf7b86c53a11.png)

Both nodes attached
![image](https://user-images.githubusercontent.com/86835683/143201562-0e2f8777-dd5a-4581-8f95-7ae6c6ecce43.png)

Both nodes detached (will show the first one that is not attached)
![image](https://user-images.githubusercontent.com/86835683/143201635-a8456485-7400-4a5b-b31d-94e5055c5bf9.png)

Deauthorize with and without -no--prompt
![image](https://user-images.githubusercontent.com/86835683/143218758-a4f5b6e6-fb90-461a-805e-3fea14e65c3c.png)

