### PR TITLE
Fix for empty extensions in database

### DIFF
--- a/cmd/attachNode.go
+++ b/cmd/attachNode.go
@@ -164,7 +164,7 @@ func hostId(exec cmdexec.Executor, fqdn string, token string, IPs []string) ([]s
 	tkn := fmt.Sprintf(`"X-Auth-Token: %v"`, token)
 	for _, ip := range IPs {
 		ip = fmt.Sprintf(`"%v"`, ip)
-		cmd := fmt.Sprintf("curl -sH %v -X GET %v/resmgr/v1/hosts | jq -r '.[]  | select(.extensions.ip_address.data[]==(%v)) | .id' ", tkn, fqdn, ip)
+		cmd := fmt.Sprintf("curl -sH %v -X GET %v/resmgr/v1/hosts | jq -r '.[] | select(.extensions!=\"\")  | select(.extensions.ip_address.data[]==(%v)) | .id' ", tkn, fqdn, ip)
 		hostid, _ := exec.RunWithStdout("bash", "-c", cmd)
 		hostid = strings.TrimSpace(strings.Trim(hostid, "\n"))
 		if len(hostid) == 0 {


### PR DESCRIPTION
Fixed an error where if a user had an empty extensions string in databse it fetching node uid would not work.
![image](https://user-images.githubusercontent.com/86835683/143582610-47625e1f-c8b9-4e60-b2ae-c05b3d6b2a46.png)

![image](https://user-images.githubusercontent.com/86835683/143582724-794cfa1e-a6f1-4c37-965c-ca13d5441a2d.png)

