### PR TITLE
Changed Host Status Check for Remote Case, changed some messages in bootstrap for the command

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -50,7 +50,6 @@ func init() {
 	bootstrapCmd.Flags().StringVar(&servicesCIDR, "servicesCidr", "10.21.0.0/16", "CIDR for services overlay")
 	bootstrapCmd.Flags().StringVar(&externalDNSName, "externalDnsName", "", "External DNS for master VIP")
 	bootstrapCmd.Flags().BoolVar(&privileged, "privileged", true, "Enable privileged mode for K8s API. Default: true")
-	bootstrapCmd.Flags().BoolVar(&appCatalogEnabled, "appCatalogEnabled", false, "Enable Helm application catalog")
 	bootstrapCmd.Flags().BoolVar(&allowWorkloadsOnMaster, "allowWorkloadsOnMaster", true, "Taint master nodes ( to enable workloads )")
 	bootstrapCmd.Flags().StringVar(&networkPlugin, "networkPlugin", "calico", "Specify network plugin ( Possible values: flannel or calico )")
 	bootstrapCmd.Flags().StringVarP(&bootConfig.User, "user", "u", "", "ssh username for the nodes")
@@ -70,7 +69,6 @@ var (
 	servicesCIDR           string
 	externalDNSName        string
 	privileged             bool
-	appCatalogEnabled      bool
 	allowWorkloadsOnMaster bool
 	networkPlugin          string
 )
@@ -234,7 +232,7 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 		}
 
 		zap.S().Debugf("Unable to bootstrap node: %s\n", err.Error())
-		zap.S().Fatalf("\nFailed to bootstrap node. See %s or use --verbose for logs\n", log.GetLogLocation(util.Pf9Log))
+		zap.S().Fatalf("Failed to bootstrap node. See %s or use --verbose for logs\n", log.GetLogLocation(util.Pf9Log))
 	}
 	zap.S().Debug("==========Finished running bootstrap==========")
 }

--- a/pkg/pmk/cluster.go
+++ b/pkg/pmk/cluster.go
@@ -96,7 +96,7 @@ func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateReque
 		}
 	} else {
 		fmt.Println(color.Red("x") + " Host is disconnected. Unable to attach this node to the cluster " + req.Name + " Run prep-node/authorize-node and try again")
-		zap.S().Debug("Host is disconnected")
+		zap.S().Debug("Host is disconnected. Unable to attach this node to the cluster " + req.Name + " Run prep-node/authorize-node and try again")
 		if err = c.Segment.SendEvent("Host Connected(Bootstrap)", keystoneAuth, checkFail, ""); err != nil {
 			zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
 		}

--- a/pkg/pmk/cluster.go
+++ b/pkg/pmk/cluster.go
@@ -43,7 +43,7 @@ func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateReque
 	s.Stop()
 
 	if err != nil {
-		fmt.Println(color.Red("x") + " Unable to create cluster")
+		fmt.Println(color.Red("x")+" Unable to create cluster. Error:", err)
 		zap.S().Debug("Unable to create cluster. Error:", err)
 		if err = c.Segment.SendEvent("Cluster creation(Bootstrap)", keystoneAuth, checkFail, ""); err != nil {
 			zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
@@ -60,7 +60,7 @@ func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateReque
 	s.Color("red")
 	s.Start() // Start the spinner
 	defer s.Stop()
-	s.Suffix = "Checking Host Status"
+	s.Suffix = " Checking Host Status"
 
 	cmd := `grep ^host_id /etc/pf9/host_id.conf | cut -d = -f2 | cut -d ' ' -f2`
 	output, err := c.Executor.RunWithStdout("bash", "-c", cmd)
@@ -81,6 +81,10 @@ func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateReque
 		LoopVariable = LoopVariable + 1
 	}
 
+	if LoopVariable > util.MaxLoopValue {
+		util.HostDown = true
+	}
+
 	s.Stop()
 
 	if !util.HostDown {
@@ -91,14 +95,14 @@ func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateReque
 			zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
 		}
 	} else {
-		fmt.Println(color.Red("x") + " Host is disconnected")
-		zap.S().Errorf("Host is disconnected")
+		fmt.Println(color.Red("x") + " Host is disconnected. Unable to attach this node to the cluster " + req.Name + " Run prep-node/authorize-node and try again")
+		zap.S().Debug("Host is disconnected")
 		if err = c.Segment.SendEvent("Host Connected(Bootstrap)", keystoneAuth, checkFail, ""); err != nil {
 			zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
 		}
 		//Deleting the cluster if the host is disconnected
 		DeleteClusterBootstrap(clusterID, c, keystoneAuth, token)
-		zap.S().Fatalf("Host is disconnected....Unable to attach this node to the cluster " + req.Name)
+		return fmt.Errorf("Host is disconnected. Unable to attach this node to the cluster " + req.Name + " Run prep-node/authorize-node and try again")
 	}
 
 	attachname := fmt.Sprintf(" Attaching node to the cluster %s", req.Name)
@@ -118,7 +122,7 @@ func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateReque
 	s.Stop() //Stop the Spinner
 
 	if err != nil {
-		fmt.Println(color.Red("x ") + " Unable to attach-node to cluster")
+		fmt.Println(color.Red("x") + " Unable to attach-node to cluster " + req.Name + "Run bootstrap again")
 		zap.S().Debug("Unable to attach-node to cluster. Error:", err)
 		if err = c.Segment.SendEvent("Attach-Node(Bootstrap)", keystoneAuth, checkFail, ""); err != nil {
 			zap.S().Errorf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
@@ -126,7 +130,7 @@ func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateReque
 
 		//Deleting the cluster if the node is not attached to the cluster
 		DeleteClusterBootstrap(clusterID, c, keystoneAuth, token)
-		return fmt.Errorf("Unable to attach node to cluster " + req.Name)
+		return fmt.Errorf("Unable to attach node to cluster " + req.Name + "Run bootstrap again")
 	}
 
 	fmt.Println(color.Green("✓") + " Attached node to the cluster")
@@ -153,7 +157,7 @@ func Host_Status(exec cmdexec.Executor, fqdn string, token string, hostID string
 	var err1 error
 
 	if isRemote {
-		cmnd := fmt.Sprintf(`bash %s`, cmd)
+		cmnd := fmt.Sprintf(`%s`, cmd)
 		status, err1 = exec.RunWithStdout(cmnd)
 	} else {
 		status, err1 = exec.RunWithStdout("bash", "-c", cmd)

--- a/pkg/qbert/qbert.go
+++ b/pkg/qbert/qbert.go
@@ -148,6 +148,7 @@ func (c QbertImpl) AttachNode(clusterID, projectID, token string, nodeIDs []stri
 	for LoopVariable <= util.MaxRetryValue {
 		if resp.StatusCode != 200 {
 			time.Sleep(30 * time.Second)
+			zap.S().Debug("Trying to attach-node to cluster")
 			resp, err = Attach_Status(attachEndpoint, token, byt)
 			if err != nil {
 				return err
@@ -391,6 +392,7 @@ func Attach_Status(attachEndpoint string, token string, byt []byte) (*http.Respo
 	client := http.Client{}
 	req, err := http.NewRequest("POST", attachEndpoint, strings.NewReader(string(byt)))
 	if err != nil {
+		zap.S().Debugf("Unable to create a request: ", err)
 		return nil, fmt.Errorf("Unable to create a request: %w", err)
 	}
 	req.Header.Set("X-Auth-Token", token)
@@ -398,6 +400,7 @@ func Attach_Status(attachEndpoint string, token string, byt []byte) (*http.Respo
 
 	resp, err := client.Do(req)
 	if err != nil {
+		zap.S().Debugf("Unable to POST request through client: ", err)
 		return resp, fmt.Errorf("Unable to POST request through client: %w", err)
 	}
 


### PR DESCRIPTION
- Host Status Check is working for Local/Remote Case .
Fixed : https://platform9.atlassian.net/jira/software/projects/FT/boards/113?assignee=5ff0c8746420890141da9669&selectedIssue=FT-294
   
    Local

 <img width="1133" alt="Screenshot 2021-12-01 at 11 32 16 AM" src="https://user-images.githubusercontent.com/65108449/144202110-4b1b693c-b10d-418f-84cc-13ffa1144c37.png">
     
     Remote
     
<img width="1133" alt="Screenshot 2021-12-01 at 11 32 26 AM" src="https://user-images.githubusercontent.com/65108449/144202121-7a194dc5-a688-4bf6-9bca-70c1a5fea3f9.png">

<img width="612" alt="Screenshot 2021-12-01 at 11 32 52 AM" src="https://user-images.githubusercontent.com/65108449/144202127-b8f022a1-c181-4584-916c-476ada722955.png">

<img width="624" alt="Screenshot 2021-12-01 at 11 34 27 AM" src="https://user-images.githubusercontent.com/65108449/144202134-1debb596-0196-44a7-b3d8-ed2105f8d4fd.png">

- Added messages in logs and console to display error if cluster-create/attach-node/host-status fails in bootstrap
- Removed appCatalogEnabled flag from bootstrap command