### PR TITLE
Fixed cluster removing from nodes

### DIFF
--- a/cmd/decomissionNode.go
+++ b/cmd/decomissionNode.go
@@ -37,7 +37,7 @@ func init() {
 	rootCmd.AddCommand(decommissionNodeCmd)
 }
 
-func runCommandWait(command string) {
+func RunCommandWait(command string) {
 	output := exec.Command("/bin/sh", "-c", command)
 	output.Stdout = os.Stdout
 	output.Stdin = os.Stdin
@@ -102,29 +102,37 @@ func decommissionNodeRun(cmd *cobra.Command, args []string) {
 
 	if strings.Contains(string(version), util.Ubuntu) {
 		fmt.Println("Removing packages")
-		runCommandWait("sudo dpkg --remove pf9-comms pf9-kube pf9-hostagent pf9-muster")
+		RunCommandWait("sudo dpkg --remove pf9-comms pf9-kube pf9-hostagent pf9-muster")
 		fmt.Println("Purging packages")
-		runCommandWait("sudo dpkg --purge pf9-comms pf9-kube pf9-hostagent pf9-muster")
+		RunCommandWait("sudo dpkg --purge pf9-comms pf9-kube pf9-hostagent pf9-muster")
 		fmt.Println("Removing /etc/pf9 logs")
-		runCommandWait("sudo rm -rf /etc/pf9")
+		RunCommandWait("sudo rm -rf /etc/pf9")
 		fmt.Println("Removing /opt/pf9 logs")
-		runCommandWait("sudo rm -rf /opt/pf9")
+		RunCommandWait("sudo rm -rf /opt/pf9")
 		fmt.Println("Removing pf9 HOME dir")
-		runCommandWait("sudo rm -rf $HOME/pf9")
+		RunCommandWait("sudo rm -rf $HOME/pf9")
+
+		RunCommandWait("sudo pkill -9 `pidof kubelet`")
+		RunCommandWait("sudo pkill -9 `pidof etcd`")
+		RunCommandWait("sudo pkill -9 `pidof kube_proxy`")
 
 	} else {
 		//command = "sudo yum erase -y pf9-hostagent -y"
 		fmt.Println("Removing packages")
-		runCommandWait("sudo yum erase -y pf9-comms")
-		runCommandWait("sudo yum erase -y pf9-kube")
-		runCommandWait("sudo yum erase -y pf9-hostagent")
-		runCommandWait("sudo yum erase -y pf9-muster")
+		RunCommandWait("sudo yum erase -y pf9-comms")
+		RunCommandWait("sudo yum erase -y pf9-kube")
+		RunCommandWait("sudo yum erase -y pf9-hostagent")
+		RunCommandWait("sudo yum erase -y pf9-muster")
 		fmt.Println("Removing /etc/pf9 logs")
-		runCommandWait("sudo rm -rf /etc/pf9")
+		RunCommandWait("sudo rm -rf /etc/pf9")
 		fmt.Println("Removing /opt/pf9 logs")
-		runCommandWait("sudo rm -rf /opt/pf9")
+		RunCommandWait("sudo rm -rf /opt/pf9")
 		fmt.Println("Removing pf9 HOME dir")
-		runCommandWait("sudo rm -rf $HOME/pf9")
+		RunCommandWait("sudo rm -rf $HOME/pf9")
+
+		RunCommandWait("sudo pkill -9 `pidof kubelet`")
+		RunCommandWait("sudo pkill -9 `pidof etcd`")
+		RunCommandWait("sudo pkill -9 `pidof kube_proxy`")
 
 	}
 

--- a/cmd/deleteCluster.go
+++ b/cmd/deleteCluster.go
@@ -103,7 +103,7 @@ func deleteClusterRun(cmd *cobra.Command, args []string) {
 	if len(localNode) == 1 && localNode[0].ClusterUuid == clusterUuid {
 		RunCommandWait("sudo pkill -9 `pidof kubelet`")
 		RunCommandWait("sudo pkill -9 `pidof etcd`")
-		RunCommandWait("sudo pkill -9 `pidof kube_proxy`")
+		RunCommandWait("sudo pkill -9 `pidof kube-proxy`")
 	}
 
 	err = c.Qbert.DeleteCluster(clusterUuid, projectId, token)

--- a/cmd/deleteCluster.go
+++ b/cmd/deleteCluster.go
@@ -92,6 +92,20 @@ func deleteClusterRun(cmd *cobra.Command, args []string) {
 
 	}
 
+	nodeIPs = append(nodeIPs, getIp().String())
+
+	projectNodes := getAllProjectNodes(c.Executor, cfg.Fqdn, token, projectId)
+
+	nodeUuids, err := hostId(c.Executor, cfg.Fqdn, token, nodeIPs)
+
+	localNode, err := getNodesFromUuids(nodeUuids, projectNodes)
+
+	if len(localNode) == 1 && localNode[0].ClusterUuid == clusterUuid {
+		RunCommandWait("sudo pkill -9 `pidof kubelet`")
+		RunCommandWait("sudo pkill -9 `pidof etcd`")
+		RunCommandWait("sudo pkill -9 `pidof kube_proxy`")
+	}
+
 	err = c.Qbert.DeleteCluster(clusterUuid, projectId, token)
 	if err != nil {
 		zap.S().Fatalf("Error deleting cluster ", err.Error())

--- a/cmd/detachNode.go
+++ b/cmd/detachNode.go
@@ -122,6 +122,14 @@ func detachNodeRun(cmd *cobra.Command, args []string) {
 	}
 
 	for i := range detachNodes {
+
+		isMaster := getNode(c.Executor, cfg.Fqdn, token, projectId, nodeUuids[0])
+		clusterNodes := getAllClusterNodes(projectNodes, []string{isMaster.ClusterUuid})
+
+		if len(clusterNodes) == 1 || isMaster.IsMaster == "1" {
+			fmt.Printf("Node %v is is either the master node or the last node in the cluster\n", isMaster.Uuid)
+		}
+
 		err1 := c.Qbert.DetachNode(detachNodes[i].ClusterUuid, projectId, token, detachNodes[i].Uuid)
 
 		if err1 != nil {


### PR DESCRIPTION
The decommission command was not killing cluster services and thus check-node would read as if the cluster was still on the node.
![Deco1](https://user-images.githubusercontent.com/86835683/144215776-92a93a7d-b013-4d17-8e2d-a61acdccf001.png)
![Deco2](https://user-images.githubusercontent.com/86835683/144215787-0e80b378-d577-4942-be25-fb6fff34998a.png)
![Deco3](https://user-images.githubusercontent.com/86835683/144215793-d8149759-c735-46e3-bbe0-1a846b447038.png)


![Delete1](https://user-images.githubusercontent.com/86835683/144216031-8588dd5d-5137-4f21-abe4-e218f1caad2c.png)
![Delete2](https://user-images.githubusercontent.com/86835683/144216039-6d6be8f2-cb1d-49b9-8784-721cf84e5200.png)

Warns the user if the detached node is the last or a master node of a cluster
![DetachNew](https://user-images.githubusercontent.com/86835683/144218940-ba928480-dcf5-4feb-aecb-cf7682a55a5d.png)

