### PR TITLE
don't error out if update fails

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -90,8 +90,10 @@ func getLatestVersion() (bool, error) {
 	}
 	hashString := hex.EncodeToString(hash.Sum(nil))
 	eTag := getEtag()
+	if eTag == "" {
+		return false, nil
+	}
 	return !strings.Contains(eTag, hashString), nil
-
 }
 
 func getEtag() string {
@@ -105,8 +107,10 @@ func getEtag() string {
 		Key:    aws.String(util.AWSBucketKey),
 	}
 	result, err := svc.GetObject(input)
-	if err != nil {
-		fmt.Errorf("Error while getting the latest version " + err.Error())
+	if err != nil || result == nil || result.ETag == nil {
+		fmt.Print("Could not check the latest CLI version")
+		zap.S().Errorf("Could not check the latest CLI version", err.Error())
+		return ""
 	}
 	return *result.ETag
 }


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>

The CLI checks for a new version at all executions - this involves a call to AWS S3. 
The current code panics if the call to S3 fails. This PR removes the panic scenario and adds a proper error message as shown below

![image](https://user-images.githubusercontent.com/17122340/144562116-f3c0c6e7-38f9-470d-b7be-743450e325ba.png)
