### PR TITLE
fixed prep-node successful segment event

### DIFF
--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -104,7 +104,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 	if c, err = client.NewClient(cfg.Fqdn, executor, cfg.AllowInsecure, false); err != nil {
 		zap.S().Fatalf("Unable to create client: %s\n", err.Error())
 	}
-
+	defer c.Segment.Close()
 	// Fetch the keystone token.
 	auth, err := c.Keystone.GetAuth(
 		cfg.Username,


### PR DESCRIPTION
All events were getting send to segment except two events authorising host and prep-node successful events.

Before

<img width="1147" alt="Screenshot 2022-01-06 at 1 47 55 PM" src="https://user-images.githubusercontent.com/76941923/148351567-c8f4ecc8-8c5f-4357-a698-8b284c81b600.png">

After

<img width="1147" alt="Screenshot 2022-01-06 at 1 30 16 PM" src="https://user-images.githubusercontent.com/76941923/148351657-e4fcc4b3-2146-4d35-b50c-84c5e8a17a1e.png">

