### PR TITLE
Create remote directory during UploadFile

### DIFF
--- a/pkg/ssh/sshclient.go
+++ b/pkg/ssh/sshclient.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/sftp"
 	"go.uber.org/zap"
@@ -144,6 +145,13 @@ func (c *client) UploadFile(localFile string, remoteFilePath string, mode os.Fil
 	localFileReader := bufio.NewReader(localFp)
 	// create a progrssReader that will call the callback function after each read
 	progressReader := newProgressCBReader(fInfo.Size(), localFileReader, cb)
+
+	dir, _ := filepath.Split(remoteFilePath)
+	if dir != "" {
+		if err := c.sftpClient.MkdirAll(dir); err != nil {
+			return fmt.Errorf("Could not create remote dir %s: %s", dir, err)
+		}
+	}
 
 	remoteFile, err := c.sftpClient.Create(remoteFilePath)
 	if err != nil {


### PR DESCRIPTION
While trying new change for creating Comms registry.json file, it works on upgrade. But failing on new DU with fresh hosts. The /etc/pf9/comms/ dir does not exist. So UploadFile is failing. Might need changes in pf9ctl to have the sftpClient do a MkdirAll on the filepath's dir, before it does the remote .Create: