### PR TITLE
FT-335 pick up the product integrated support bundle(drop auth.log) when the pf9ctl CLI operations fail.

### DIFF
--- a/pkg/supportBundle/supportBundle.go
+++ b/pkg/supportBundle/supportBundle.go
@@ -240,7 +240,7 @@ func GenSupportBundle(exec cmdexec.Executor, timestamp time.Time, isRemote bool)
 
 	if isRemote {
 		// Generate supportBundle if any of Etc / var logs are present or both
-		if errEtc == nil || errVar == nil {
+		if errEtc == nil || errVar == nil || errOpt == nil {
 			// Generation of supportBundle in remote host case.
 			_, errbundle := exec.RunWithStdout("bash", "-c", fmt.Sprintf("tar -czf %s %s %s %s %s %s %s",
 				targetfile, util.VarDir, util.EtcDir, util.DmesgLog, msgfile, lockfile, util.OptDir))

--- a/pkg/supportBundle/supportBundle.go
+++ b/pkg/supportBundle/supportBundle.go
@@ -28,7 +28,6 @@ var (
 	fileloc     string
 	err         error
 	S3_Location string
-	authfile    string
 	msgfile     string
 	lockfile    string
 	hostOS      string
@@ -206,18 +205,11 @@ func GenSupportBundle(exec cmdexec.Executor, timestamp time.Time, isRemote bool)
 
 	//Assign specific files according to the platform
 	if hostOS == "debian" {
-		authfile = util.AuthDeb
 		msgfile = util.MsgDeb
 		lockfile = util.LockDeb
 	} else {
-		authfile = util.AuthRed
 		msgfile = util.MsgRed
 		lockfile = util.LockRed
-	}
-
-	_, errAuth := exec.RunWithStdout("bash", "-c", fmt.Sprintf("stat %s", authfile))
-	if errEtc != nil {
-		zap.S().Debug("Auth files not Found!! ", errAuth)
 	}
 
 	_, errMsg := exec.RunWithStdout("bash", "-c", fmt.Sprintf("stat %s", msgfile))
@@ -245,8 +237,8 @@ func GenSupportBundle(exec cmdexec.Executor, timestamp time.Time, isRemote bool)
 		// Generate supportBundle if any of Etc / var logs are present or both
 		if errEtc == nil || errVar == nil {
 			// Generation of supportBundle in remote host case.
-			_, errbundle := exec.RunWithStdout("bash", "-c", fmt.Sprintf("tar -czf %s %s %s %s %s %s %s",
-				targetfile, util.VarDir, util.EtcDir, util.DmesgLog, authfile, msgfile, lockfile))
+			_, errbundle := exec.RunWithStdout("bash", "-c", fmt.Sprintf("tar -czf %s %s %s %s %s %s",
+				targetfile, util.VarDir, util.EtcDir, util.DmesgLog, msgfile, lockfile))
 			if errbundle != nil {
 				zap.S().Debug("Failed to generate complete supportBundle, generated partial bundle (Remote Host)", errbundle)
 			}
@@ -261,8 +253,8 @@ func GenSupportBundle(exec cmdexec.Executor, timestamp time.Time, isRemote bool)
 
 	} else {
 		// Generation of supportBundle in local host case.
-		_, errbundle := exec.RunWithStdout("bash", "-c", fmt.Sprintf("tar czf %s --directory=%s %s %s %s %s %s %s %s",
-			targetfile, util.Pf9DirLoc, util.Pf9LogLoc, util.VarDir, util.EtcDir, util.DmesgLog, authfile, msgfile, lockfile))
+		_, errbundle := exec.RunWithStdout("bash", "-c", fmt.Sprintf("tar czf %s --directory=%s %s %s %s %s %s %s",
+			targetfile, util.Pf9DirLoc, util.Pf9LogLoc, util.VarDir, util.EtcDir, util.DmesgLog, msgfile, lockfile))
 		if errbundle != nil {
 			zap.S().Debug("Failed to generate complete supportBundle, generated partial bundle", errbundle)
 			return targetfile, ErrPartialBundle

--- a/pkg/supportBundle/supportBundle.go
+++ b/pkg/supportBundle/supportBundle.go
@@ -203,6 +203,11 @@ func GenSupportBundle(exec cmdexec.Executor, timestamp time.Time, isRemote bool)
 		zap.S().Debug("Dmesg files not Found!! ", errDmesg)
 	}
 
+	_, errOpt := exec.RunWithStdout("bash", "-c", fmt.Sprintf("stat %s", util.OptDir))
+	if errOpt != nil {
+		zap.S().Debug(fmt.Sprintf("%s directory not found!!", util.OptDir))
+	}
+
 	//Assign specific files according to the platform
 	if hostOS == "debian" {
 		msgfile = util.MsgDeb
@@ -237,8 +242,8 @@ func GenSupportBundle(exec cmdexec.Executor, timestamp time.Time, isRemote bool)
 		// Generate supportBundle if any of Etc / var logs are present or both
 		if errEtc == nil || errVar == nil {
 			// Generation of supportBundle in remote host case.
-			_, errbundle := exec.RunWithStdout("bash", "-c", fmt.Sprintf("tar -czf %s %s %s %s %s %s",
-				targetfile, util.VarDir, util.EtcDir, util.DmesgLog, msgfile, lockfile))
+			_, errbundle := exec.RunWithStdout("bash", "-c", fmt.Sprintf("tar -czf %s %s %s %s %s %s %s",
+				targetfile, util.VarDir, util.EtcDir, util.DmesgLog, msgfile, lockfile, util.OptDir))
 			if errbundle != nil {
 				zap.S().Debug("Failed to generate complete supportBundle, generated partial bundle (Remote Host)", errbundle)
 			}
@@ -253,8 +258,8 @@ func GenSupportBundle(exec cmdexec.Executor, timestamp time.Time, isRemote bool)
 
 	} else {
 		// Generation of supportBundle in local host case.
-		_, errbundle := exec.RunWithStdout("bash", "-c", fmt.Sprintf("tar czf %s --directory=%s %s %s %s %s %s %s",
-			targetfile, util.Pf9DirLoc, util.Pf9LogLoc, util.VarDir, util.EtcDir, util.DmesgLog, msgfile, lockfile))
+		_, errbundle := exec.RunWithStdout("bash", "-c", fmt.Sprintf("tar czf %s --directory=%s %s %s %s %s %s %s %s",
+			targetfile, util.Pf9DirLoc, util.Pf9LogLoc, util.VarDir, util.EtcDir, util.DmesgLog, msgfile, lockfile, util.OptDir))
 		if errbundle != nil {
 			zap.S().Debug("Failed to generate complete supportBundle, generated partial bundle", errbundle)
 			return targetfile, ErrPartialBundle

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -93,10 +93,8 @@ var (
 
 	//Auth,Dmesg,dpkg/yum files for Debian/Redhat
 	DmesgLog = "/var/log/dmesg"
-	AuthDeb  = "/var/log/auth.log"
 	MsgDeb   = "/var/log/syslog"
 	LockDeb  = "/var/log/dpkg.log"
-	AuthRed  = "/var/log/secure"
 	MsgRed   = "/var/log/messages"
 	LockRed  = "/var/log/yum.log"
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -84,6 +84,8 @@ var (
 	// before it starts with the operations.
 	WaitPeriod = time.Duration(60)
 
+	OptDir = "/var/opt/pf9"
+
 	//Location of ovf service file
 	OVFLoc    = "/etc/systemd/system/ovf.service"
 	VarDir    = "/var/log/pf9"


### PR DESCRIPTION
- dropping `auth.log` from support bundle.
- collecting files in `/var/opt/pf9` as in `express-cli`.
TeamCity build link: https://teamcity.platform9.horse/viewLog.html?buildId=1823945&buildTypeId=Pf9project_Platform9Components_Pf9ctl&tab=buildLog&_focus=1720#_state=125,1712,1720

Diffs for the current release(left) vs the changed(right)
![Screenshot 2022-01-31 at 10 25 23_long](https://user-images.githubusercontent.com/39493074/151743508-6b42c88d-ee1b-4202-9403-73e18d957b12.png)
Diffs for changed(left) vs express-cli(right)
![Screenshot 2022-01-31 at 11 21 47_long](https://user-images.githubusercontent.com/39493074/151746883-ce266a1e-3086-4b1b-b074-15a563bea24f.png)