### PR TITLE
remote support for authorize/deauthorize commands

### DIFF
--- a/cmd/attachNode.go
+++ b/cmd/attachNode.go
@@ -188,6 +188,7 @@ func hostId(exec cmdexec.Executor, fqdn string, token string, IPs []string) []st
 	tkn := fmt.Sprintf(`"X-Auth-Token: %v"`, token)
 	for _, ip := range IPs {
 		ip = strings.TrimSpace(ip)
+		ip = fmt.Sprintf(`"%v"`, ip)
 		cmd := fmt.Sprintf("curl -sH %v -X GET %v/resmgr/v1/hosts | jq -r '.[] | select(.extensions!=\"\")  | select(.extensions.ip_address.data[]==(%v)) | .id' ", tkn, fqdn, ip)
 		output, err := exec.RunWithStdout("bash", "-c", cmd)
 		if err != nil {

--- a/cmd/authoriseNode.go
+++ b/cmd/authoriseNode.go
@@ -27,9 +27,11 @@ var authNodeCmd = &cobra.Command{
 	},
 	Run: authNodeRun,
 }
+var ipAdd string
 
 func init() {
 	rootCmd.AddCommand(authNodeCmd)
+	authNodeCmd.Flags().StringVarP(&ipAdd, "ip", "i", "", "Ip address of the host to be authorized")
 	authNodeCmd.Flags().StringVar(&attachconfig.MFA, "mfa", "", "MFA token")
 }
 
@@ -71,8 +73,11 @@ func authNodeRun(cmd *cobra.Command, args []string) {
 	}
 
 	var nodeIPs []string
-	nodeIPs = append(nodeIPs, getIp().String())
-
+	if ipAdd != "" {
+		nodeIPs = append(nodeIPs, ipAdd)
+	} else {
+		nodeIPs = append(nodeIPs, getIp().String())
+	}
 	token := auth.Token
 	nodeUuids := hostId(c.Executor, cfg.Fqdn, token, nodeIPs)
 

--- a/cmd/authoriseNode.go
+++ b/cmd/authoriseNode.go
@@ -31,7 +31,7 @@ var ipAdd string
 
 func init() {
 	rootCmd.AddCommand(authNodeCmd)
-	authNodeCmd.Flags().StringVarP(&ipAdd, "ip", "i", "", "Ip address of the host to be authorized")
+	authNodeCmd.Flags().StringVarP(&ipAdd, "ip", "i", "", "IP address of the host to be authorized")
 	authNodeCmd.Flags().StringVar(&attachconfig.MFA, "mfa", "", "MFA token")
 }
 

--- a/cmd/deauthoriseNode.go
+++ b/cmd/deauthoriseNode.go
@@ -31,6 +31,7 @@ var deauthNodeCmd = &cobra.Command{
 
 func init() {
 	deauthNodeCmd.Flags().StringVar(&attachconfig.MFA, "mfa", "", "MFA token")
+	deauthNodeCmd.Flags().StringVarP(&ipAdd, "ip", "i", "", "Ip address of the host to be deauthorized")
 	rootCmd.AddCommand(deauthNodeCmd)
 }
 
@@ -72,7 +73,11 @@ func deauthNodeRun(cmd *cobra.Command, args []string) {
 	}
 
 	var nodeIPs []string
-	nodeIPs = append(nodeIPs, getIp().String())
+	if ipAdd != "" {
+		nodeIPs = append(nodeIPs, ipAdd)
+	} else {
+		nodeIPs = append(nodeIPs, getIp().String())
+	}
 	projectId := auth.ProjectID
 	token := auth.Token
 	nodeUuids := hostId(c.Executor, cfg.Fqdn, token, nodeIPs)

--- a/cmd/deauthoriseNode.go
+++ b/cmd/deauthoriseNode.go
@@ -31,7 +31,7 @@ var deauthNodeCmd = &cobra.Command{
 
 func init() {
 	deauthNodeCmd.Flags().StringVar(&attachconfig.MFA, "mfa", "", "MFA token")
-	deauthNodeCmd.Flags().StringVarP(&ipAdd, "ip", "i", "", "Ip address of the host to be deauthorized")
+	deauthNodeCmd.Flags().StringVarP(&ipAdd, "ip", "i", "", "IP address of the host to be deauthorized")
 	rootCmd.AddCommand(deauthNodeCmd)
 }
 


### PR DESCRIPTION
## ISSUE(S):
<!--- Links to JIRA tickets -->
<!--- [FT-XXXX](link.to/FT-XXXX): Subject of FT-XXXX -->
https://platform9.atlassian.net/browse/FT-344
https://platform9.atlassian.net/browse/FT-349

## SUMMARY
<!--- Describe the change below -->

- Added remote support for authorize-node and deauthorize-node commands
- authorize-node and deauthorize-node was not working because getHost id was broken because of recent merge of ervin. Fixed that as well.

<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## TESTING DONE
#### Manual
<!--- Please list down various use case which were part of manual testing. -->

![Screenshot 2022-02-17 at 12 29 27 PM](https://user-images.githubusercontent.com/76941923/154425052-b60618ce-90e5-4793-b7df-ca76ef5ae288.png)

![Screenshot 2022-02-17 at 12 30 40 PM](https://user-images.githubusercontent.com/76941923/154425102-2e22c27a-a8ba-4673-ab0a-397c2d60a2a3.png)

![Screenshot 2022-02-17 at 12 36 23 PM](https://user-images.githubusercontent.com/76941923/154425130-850ab157-180f-4d64-8278-b156f944b8e9.png)

#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->
/cc @anupbarve @nikhilbandi 