### PR TITLE
--no-prompt fix on prep-node re-run

### DIFF
--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -62,6 +62,7 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 	cfg := &objects.Config{WaitPeriod: time.Duration(60), AllowInsecure: false, MfaToken: nc.MFA}
 	var err error
 	if detachedMode {
+		nc.RemoveExistingPkgs = true
 		err = config.LoadConfig(util.Pf9DBLoc, cfg, nc)
 	} else {
 		err = config.LoadConfigInteractive(util.Pf9DBLoc, cfg, nc)

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -85,6 +85,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 	cfg := &objects.Config{WaitPeriod: time.Duration(60), AllowInsecure: false, MfaToken: nodeConfig.MFA}
 	var err error
 	if detachedMode {
+		nodeConfig.RemoveExistingPkgs = true
 		err = config.LoadConfig(util.Pf9DBLoc, cfg, nodeConfig)
 	} else {
 		err = config.LoadConfigInteractive(util.Pf9DBLoc, cfg, nodeConfig)


### PR DESCRIPTION
## ISSUE(S):
<!--- Links to JIRA tickets -->
<!--- [FT-XXXX](link.to/FT-XXXX): Subject of FT-XXXX -->
https://platform9.atlassian.net/browse/FT-368

## SUMMARY
<!--- Describe the change below -->

<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->
prep-node on re-run prompting even when used with --no-prompt option.

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## IMPACTED FEATURES/COMPONENTS:
<!--- List of impacted features/components due to this change -->
<!--- delete section if not relevant -->
check-node/prep-node

## TESTING DONE
#### Manual
<!--- Please list down various use case which were part of manual testing. -->
**prep-node --no-prompt**
<img width="729" alt="Screenshot 2022-03-15 at 8 10 28 PM" src="https://user-images.githubusercontent.com/76941923/158405511-13e46086-3488-491b-bafc-65b21f40660c.png">
<img width="729" alt="Screenshot 2022-03-15 at 8 11 01 PM" src="https://user-images.githubusercontent.com/76941923/158405769-31bbf1e4-061b-441c-9fea-fcfdef38fb0d.png">
<img width="729" alt="Screenshot 2022-03-15 at 8 11 16 PM" src="https://user-images.githubusercontent.com/76941923/158405918-9bcd9237-bb4f-4e9d-ae17-524d4093203b.png">
**check-node --no-prompt**
<img width="729" alt="Screenshot 2022-03-15 at 8 12 40 PM" src="https://user-images.githubusercontent.com/76941923/158406140-68b0e758-c5a8-47ac-8dd6-250dc8b284b7.png">
<img width="729" alt="Screenshot 2022-03-15 at 8 12 55 PM" src="https://user-images.githubusercontent.com/76941923/158406432-d04f280e-c689-42a5-b4af-82a2e279fdf6.png">
<img width="729" alt="Screenshot 2022-03-15 at 8 13 44 PM" src="https://user-images.githubusercontent.com/76941923/158406550-fe4fdc41-e109-4ae0-b937-40c1df9c675e.png">

#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->
