### PR TITLE
removing spinner to make stdout automation friendly

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/briandowns/spinner"
 	"github.com/platform9/pf9ctl/pkg/client"
 	"github.com/platform9/pf9ctl/pkg/cmdexec"
 	"github.com/platform9/pf9ctl/pkg/color"
@@ -285,25 +284,28 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("%s pmk-version is not supported", pmkVersion)
 	}
 
-	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-	s.Color("red")
-	s.Start()
-	defer s.Stop()
-	s.Suffix = " Running pre-requisite checks for Bootstrap command"
+	//s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	//s.Color("red")
+	//s.Start()
+	//defer s.Stop()
+	//s.Suffix = " Running pre-requisite checks for Bootstrap command"
+	zap.L().Info("  Running pre-requisite checks for Bootstrap command")
 
 	val, val1, err := pmk.PreReqBootstrap(executor)
 	if err != nil {
 		zap.S().Fatalf("Error running Prerequisite Checks for Bootstrap Command")
 	}
-	s.Stop()
+	//s.Stop()
 	if !val1 && !val { //Both node and cluster are already present
 		zap.S().Fatalf(color.Red("x ") + " Cannot run this command as this node is already attached to a cluster")
 
 	} else if !val && val1 { //Only node is present but not attached to a cluster
 		util.SkipPrepNode = true
-		fmt.Println(color.Green("✓") + " Node is already Onboarded....Skipping Prep-Node")
+		//fmt.Println(color.Green("✓") + " Node is already Onboarded....Skipping Prep-Node")
+		zap.L().Info(color.Green("✓") + " Node is already Onboarded....Skipping Prep-Node")
 	} else { //Both node and cluster are not present
-		fmt.Println(color.Green("✓") + " Node is not onboarded and not attached to any cluster")
+		//fmt.Println(color.Green("✓") + " Node is not onboarded and not attached to any cluster")
+		zap.L().Info(color.Green("✓") + " Node is not onboarded and not attached to any cluster")
 		util.SkipPrepNode = false
 	}
 
@@ -321,12 +323,14 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 		}
 
 		if result == pmk.RequiredFail {
-			zap.S().Fatalf(color.Red("x ")+"Required pre-requisite check(s) failed. See %s or use --verbose for logs \n", log.GetLogLocation(util.Pf9Log))
+			zap.S().Fatalf(color.Red("x ")+"Required pre-requisite check(s) failed. See %s or use --log-level debug for logs \n", log.GetLogLocation(logDirPath))
 			//this is so the exit flag is set to 1
 		} else if result == pmk.OptionalFail {
-			fmt.Printf("\nOptional pre-requisite check(s) failed. See %s or use --verbose for logs \n", log.GetLogLocation(util.Pf9Log))
+			//fmt.Printf("\nOptional pre-requisite check(s) failed. See %s or use --verbose for logs \n", log.GetLogLocation(util.Pf9Log))
+			zap.S().Info("Optional pre-requisite check(s) failed. See %s or use --log-level debug for logs \n", log.GetLogLocation(logDirPath))
 		} else if result == pmk.CleanInstallFail {
-			fmt.Println("\nPrevious Installation Removed")
+			//fmt.Println("\nPrevious Installation Removed")
+			zap.L().Info("Previous Installation Removed")
 		}
 
 		zap.S().Debug("==========Finished running check-node==========")
@@ -339,7 +343,8 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 				zap.S().Fatalf(" Declined to proceed with creating a Kubernetes cluster with the current node as the master node ")
 			}
 		} else {
-			fmt.Println(" Proceeding to create a Kubernetes cluster with current node as master node")
+			//fmt.Println(" Proceeding to create a Kubernetes cluster with current node as master node")
+			zap.L().Info(" Proceeding to create a Kubernetes cluster with current node as master node")
 		}
 
 		zap.S().Debug("========== Running prep-node as a part of bootstrap ==========")
@@ -352,7 +357,7 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 			}
 
 			zap.S().Debugf("Unable to prep node: %s\n", err.Error())
-			zap.S().Fatalf("\nFailed to prepare node. See %s or use --verbose for logs\n", log.GetLogLocation(util.Pf9Log))
+			zap.S().Fatalf("\nFailed to prepare node. See %s or use --log-level debug for logs\n", log.GetLogLocation(logDirPath))
 		}
 
 		zap.S().Debug("==========Finished running prep-node==========")
@@ -427,7 +432,7 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 		}
 
 		zap.S().Debugf("Unable to bootstrap node: %s\n", err.Error())
-		zap.S().Fatalf("Failed to bootstrap node. See %s or use --verbose for logs\n", log.GetLogLocation(util.Pf9Log))
+		zap.S().Fatalf("Failed to bootstrap node. See %s or use --log-level debug for logs\n", log.GetLogLocation(logDirPath))
 	}
 	zap.S().Debug("==========Finished running bootstrap==========")
 }

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -122,10 +122,10 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 	}
 
 	if result == pmk.RequiredFail {
-		zap.S().Fatalf(color.Red("x ")+"Required pre-requisite check(s) failed. See %s or use --verbose for logs \n", log.GetLogLocation(util.Pf9Log))
+		zap.S().Fatalf(color.Red("x ")+"Required pre-requisite check(s) failed. See %s or use --log-level debug for logs \n", log.GetLogLocation(logDirPath))
 		//this is so the exit flag is set to 1
 	} else if result == pmk.OptionalFail {
-		fmt.Printf("\nOptional pre-requisite check(s) failed. See %s or use --verbose for logs \n", log.GetLogLocation(util.Pf9Log))
+		fmt.Printf("\nOptional pre-requisite check(s) failed. See %s or use --log-level debug for logs \n", log.GetLogLocation(logDirPath))
 	} else if result == pmk.CleanInstallFail {
 		fmt.Println("\nPrevious Installation Removed")
 	}

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -144,7 +144,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 	}
 
 	if result == pmk.RequiredFail {
-		zap.S().Fatalf(color.Red("x ")+"Required pre-requisite check(s) failed. See %s or use --verbose for logs \n", log.GetLogLocation(util.Pf9Log))
+		zap.S().Fatalf(color.Red("x ")+"Required pre-requisite check(s) failed. See %s or use --log-level debug for logs \n", log.GetLogLocation(logDirPath))
 	} else if result == pmk.CleanInstallFail {
 		fmt.Println("\nPrevious Installation Removed")
 	}
@@ -176,7 +176,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 		}
 
 		zap.S().Debugf("Unable to prep node: %s\n", err.Error())
-		zap.S().Fatalf("\nFailed to prepare node. See %s or use --verbose for logs\n", log.GetLogLocation(util.Pf9Log))
+		zap.S().Fatalf("\nFailed to prepare node. See %s or use --log-level debug for logs\n", log.GetLogLocation(logDirPath))
 	}
 
 	zap.S().Debug("==========Finished running prep-node==========")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,7 +52,8 @@ func StoreConfig(cfg *objects.Config, loc string) error {
 	defer f.Close()
 
 	encoder := json.NewEncoder(f)
-	fmt.Println(color.Green("✓ ") + "Stored configuration details successfully")
+	//fmt.Println(color.Green("✓ ") + "Stored configuration details successfully")
+	zap.L().Info(color.Green("✓ ") + "Stored configuration details successfully")
 	return encoder.Encode(cfgCopy)
 }
 

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -5,9 +5,7 @@ package pmk
 import (
 	"fmt"
 	"strings"
-	"time"
 
-	"github.com/briandowns/spinner"
 	"github.com/platform9/pf9ctl/pkg/client"
 	"github.com/platform9/pf9ctl/pkg/color"
 	"github.com/platform9/pf9ctl/pkg/keystone"
@@ -40,8 +38,8 @@ var WarningOptionalChecks bool
 // CheckNode checks the prerequisites for k8s stack
 func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.KeystoneAuth, nc objects.NodeConfig) (CheckNodeResult, error) {
 	// Building our new spinner
-	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-	s.Color("red")
+	//s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	//s.Color("red")
 
 	zap.S().Debug("Received a call to check node.")
 
@@ -68,15 +66,18 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 		zap.S().Debugf("Unable to send Segment event for check node. Error: %s", err.Error())
 	}
 
-	s.Start() // Start the spinner
-	defer s.Stop()
-	s.Suffix = " Running pre-requisite checks and installing any missing OS packages"
+	//s.Start() // Start the spinner
+	//defer s.Stop()
+	zap.S().Debug("Running pre-requisite checks and installing any missing OS packages")
+	zap.L().Info("  Running pre-requisite checks and installing any missing OS packages")
+	//s.Suffix = " Running pre-requisite checks and installing any missing OS packages"
 	checks := platform.Check()
-	s.Stop()
+	//s.Stop()
 
 	//We will print console if any missing os packages installed
 	if debian.MissingPkgsInstalledDebian || centos.MissingPkgsInstalledCentos {
-		fmt.Printf(color.Green("✓ ") + "Missing package(s) installed successfully\n")
+		//fmt.Printf(color.Green("✓ ") + "Missing package(s) installed successfully\n")
+		zap.L().Info(color.Green("✓ ") + "Missing package(s) installed successfully\n")
 	}
 
 	mandatoryCheck := true
@@ -89,7 +90,9 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 			if err := allClients.Segment.SendEvent(segment_str, auth, checkPass, ""); err != nil {
 				zap.S().Debugf("Unable to send Segment event for check node. Error: %s", err.Error())
 			}
-			fmt.Printf(color.Green("✓ ")+"%s\n", check.Name)
+			//fmt.Printf(color.Green("✓ ")+"%s\n", check.Name)
+			c := fmt.Sprintf("%s", check.Name)
+			zap.L().Info(color.Green("✓ ") + c)
 
 		} else {
 			segment_str := "CheckNode: " + check.Name
@@ -98,9 +101,15 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 			}
 			// To print warning "!", if --skipchecks flag passed and optional checks failed.
 			if WarningOptionalChecks && !check.Mandatory {
-				fmt.Printf(color.Yellow("! ")+"%s - %s\n", check.Name, check.UserErr)
+				//fmt.Printf(color.Yellow("! ")+"%s - %s\n", check.Name, check.UserErr)
+				c := fmt.Sprintf("%s", check.Name)
+				e := fmt.Sprintf("%s", check.UserErr)
+				zap.L().Info(color.Yellow("! ") + c + " - " + e)
 			} else {
-				fmt.Printf(color.Red("x ")+"%s - %s\n", check.Name, check.UserErr)
+				//fmt.Printf(color.Red("x ")+"%s - %s\n", check.Name, check.UserErr)
+				c := fmt.Sprintf("%s", check.Name)
+				e := fmt.Sprintf("%s", check.UserErr)
+				zap.L().Info(color.Red("x ") + c + " - " + e)
 			}
 
 			if check.Mandatory {
@@ -124,7 +133,8 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 	}
 	fmt.Printf("\n")
 	if mandatoryCheck {
-		fmt.Println(color.Green("✓ ") + "Completed Pre-Requisite Checks successfully\n")
+		//fmt.Println(color.Green("✓ ") + "Completed Pre-Requisite Checks successfully\n")
+		zap.L().Info(color.Green("✓ ") + "Completed Pre-Requisite Checks successfully\n")
 	}
 
 	removeCurrentInstallation := ""

--- a/pkg/pmk/cluster.go
+++ b/pkg/pmk/cluster.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/briandowns/spinner"
 	"github.com/platform9/pf9ctl/pkg/client"
 	"github.com/platform9/pf9ctl/pkg/cmdexec"
 	"github.com/platform9/pf9ctl/pkg/color"
@@ -27,23 +26,24 @@ func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateReque
 	}
 
 	token := keystoneAuth.Token
-	clustername := fmt.Sprintf(" Creating a cluster %s", req.Name)
+	clustername := fmt.Sprintf("  Creating a cluster %s", req.Name)
 
-	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-	s.Color("red")
-	s.Start() // Start the spinner
-	defer s.Stop()
-	s.Suffix = clustername
-
+	//s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	//s.Color("red")
+	//s.Start() // Start the spinner
+	//defer s.Stop()
+	//s.Suffix = clustername
+	zap.L().Info(clustername)
 	clusterID, err := c.Qbert.CreateCluster(
 		req,
 		keystoneAuth.ProjectID,
 		keystoneAuth.Token)
 
-	s.Stop()
+	//s.Stop()
 
 	if err != nil {
-		fmt.Println(color.Red("x")+" Unable to create cluster. Error:", err)
+		//fmt.Println(color.Red("x")+" Unable to create cluster. Error:", err)
+		zap.S().Info(color.Red("x")+" Unable to create cluster. Error:", err)
 		zap.S().Debug("Unable to create cluster. Error:", err)
 		if err = c.Segment.SendEvent("Cluster creation(Bootstrap)", keystoneAuth, checkFail, ""); err != nil {
 			zap.S().Debugf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
@@ -51,16 +51,18 @@ func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateReque
 		return fmt.Errorf("Unable to create cluster " + req.Name)
 	}
 
-	fmt.Println(color.Green("✓") + " Cluster creation started")
+	//fmt.Println(color.Green("✓") + " Cluster creation started")
+	zap.L().Info(color.Green("✓") + " Cluster creation started")
 
 	if err = c.Segment.SendEvent("Cluster creation(Bootstrap)", keystoneAuth, checkPass, ""); err != nil {
 		zap.S().Debugf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
 	}
 
-	s.Color("red")
-	s.Start() // Start the spinner
-	defer s.Stop()
-	s.Suffix = " Checking Host Status"
+	//s.Color("red")
+	//s.Start() // Start the spinner
+	//defer s.Stop()
+	//s.Suffix = " Checking Host Status"
+	zap.L().Info("  Checking Host Status")
 
 	cmd := `grep ^host_id /etc/pf9/host_id.conf | cut -d = -f2 | cut -d ' ' -f2`
 	output, err := c.Executor.RunWithStdout("bash", "-c", cmd)
@@ -85,17 +87,19 @@ func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateReque
 		util.HostDown = true
 	}
 
-	s.Stop()
+	//s.Stop()
 
 	if !util.HostDown {
 
 		zap.S().Debugf("Host is Connected...Proceeding to connect node to cluster " + req.Name)
-		fmt.Println(color.Green("✓") + " Host is connected")
+		//fmt.Println(color.Green("✓") + " Host is connected")
+		zap.L().Info(color.Green("✓") + " Host is connected")
 		if err = c.Segment.SendEvent("Host Connected(Bootstrap)", keystoneAuth, checkPass, ""); err != nil {
 			zap.S().Debugf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
 		}
 	} else {
-		fmt.Println(color.Red("x") + " Host is disconnected. Unable to attach this node to the cluster " + req.Name + " Run prep-node/authorize-node and try again")
+		//fmt.Println(color.Red("x") + " Host is disconnected. Unable to attach this node to the cluster " + req.Name + " Run prep-node/authorize-node and try again")
+		zap.S().Info(color.Red("x") + " Host is disconnected. Unable to attach this node to the cluster " + req.Name + " Run prep-node/authorize-node and try again")
 		zap.S().Debug("Host is disconnected. Unable to attach this node to the cluster " + req.Name + " Run prep-node/authorize-node and try again")
 		if err = c.Segment.SendEvent("Host Connected(Bootstrap)", keystoneAuth, checkFail, ""); err != nil {
 			zap.S().Debugf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
@@ -105,11 +109,12 @@ func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateReque
 		return fmt.Errorf("Host is disconnected. Unable to attach this node to the cluster " + req.Name + " Run prep-node/authorize-node and try again")
 	}
 
-	attachname := fmt.Sprintf(" Attaching node to the cluster %s", req.Name)
-	s.Color("red")
-	s.Start() // Start the spinner
-	defer s.Stop()
-	s.Suffix = attachname
+	attachname := fmt.Sprintf("  Attaching node to the cluster %s (this might take a few minutes...)", req.Name)
+	//s.Color("red")
+	//s.Start() // Start the spinner
+	//defer s.Stop()
+	//s.Suffix = attachname
+	zap.L().Info(attachname)
 
 	time.Sleep(30 * time.Second)
 	var nodeIDs []string
@@ -119,10 +124,11 @@ func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateReque
 		clusterID,
 		keystoneAuth.ProjectID, keystoneAuth.Token, nodeIDs, "master")
 
-	s.Stop() //Stop the Spinner
+	//s.Stop() //Stop the Spinner
 
 	if err != nil {
-		fmt.Println(color.Red("x") + " Unable to attach-node to cluster " + req.Name + "Run bootstrap again")
+		//fmt.Println(color.Red("x") + " Unable to attach-node to cluster " + req.Name + "Run bootstrap again")
+		zap.S().Info(color.Red("x") + " Unable to attach-node to cluster " + req.Name + "Run bootstrap again")
 		zap.S().Debug("Unable to attach-node to cluster. Error:", err)
 		if err = c.Segment.SendEvent("Attach-Node(Bootstrap)", keystoneAuth, checkFail, ""); err != nil {
 			zap.S().Debugf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
@@ -133,7 +139,8 @@ func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateReque
 		return fmt.Errorf("Unable to attach node to cluster " + req.Name + "Run bootstrap again")
 	}
 
-	fmt.Println(color.Green("✓") + " Attached node to the cluster")
+	//fmt.Println(color.Green("✓") + " Attached node to the cluster")
+	zap.L().Info(color.Green("✓") + " Attached node to the cluster")
 	if err = c.Segment.SendEvent("Attach-Node(Bootstrap)", keystoneAuth, checkPass, ""); err != nil {
 		zap.S().Debugf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
 	}
@@ -141,8 +148,10 @@ func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateReque
 	if err = c.Segment.SendEvent("Bootstrap Completed Successfully", keystoneAuth, checkPass, ""); err != nil {
 		zap.S().Debugf("Unable to send Segment event for bootstrap node. Error: %s", err.Error())
 	}
-	fmt.Println(color.Green("✓") + " Bootstrap successfully finished")
-	fmt.Println("Cluster creation started....This may take a few minutes....Check the latest status in UI")
+	//fmt.Println(color.Green("✓") + " Bootstrap successfully finished")
+	zap.L().Info(color.Green("✓") + " Bootstrap successfully finished")
+	zap.L().Info("  Cluster creation started....This may take a few minutes....Check the latest status in UI")
+	//fmt.Println("Cluster creation started....This may take a few minutes....Check the latest status in UI")
 	return nil
 }
 

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/briandowns/spinner"
 	"github.com/platform9/pf9ctl/pkg/client"
 	"github.com/platform9/pf9ctl/pkg/cmdexec"
 	"github.com/platform9/pf9ctl/pkg/color"
@@ -59,15 +58,15 @@ func sendSegmentEvent(allClients client.Client, eventStr string, auth keystone.K
 // PrepNode sets up prerequisites for k8s stack
 func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.KeystoneAuth) error {
 	// Building our new spinner
-	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-	s.Color("red")
+	//s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	//s.Color("red")
 
 	zap.S().Debug("Received a call to start preparing node(s).")
-	s.Start() // Start the spinner
-	defer s.Stop()
+	//s.Start() // Start the spinner
+	//defer s.Stop()
 	sendSegmentEvent(allClients, "Starting prep-node", auth, false)
-	s.Suffix = " Starting prep-node"
-
+	//s.Suffix = " Starting prep-node"
+	zap.L().Info("  Starting prep-node")
 	hostOS, err := ValidatePlatform(allClients.Executor)
 	if err != nil {
 		errStr := "Error: Invalid host OS. " + err.Error()
@@ -91,28 +90,32 @@ func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.Keysto
 	}
 
 	sendSegmentEvent(allClients, "Installing hostagent - 2", auth, false)
-	s.Suffix = " Downloading the Hostagent (this might take a few minutes...)"
+	//s.Suffix = " Downloading the Hostagent (this might take a few minutes...)"
+	zap.L().Info("  Downloading the Hostagent (this might take a few minutes...)")
 	if err := installHostAgent(ctx, auth, hostOS, allClients.Executor); err != nil {
 		errStr := "Error: Unable to install hostagent. " + err.Error()
 		sendSegmentEvent(allClients, errStr, auth, true)
 		return fmt.Errorf(errStr)
 	}
 
-	s.Suffix = " Platform9 packages installed successfully"
+	//s.Suffix = " Platform9 packages installed successfully"
 
 	if HostAgent == HostAgentCertless {
-		s.Suffix = " Platform9 packages installed successfully"
-		s.Stop()
-		fmt.Println(color.Green("✓ ") + "Platform9 packages installed successfully")
+		//s.Suffix = " Platform9 packages installed successfully"
+		//s.Stop()
+		//fmt.Println(color.Green("✓ ") + "Platform9 packages installed successfully")
+		zap.L().Info(color.Green("✓ ") + "Platform9 packages installed successfully")
 	} else if HostAgent == HostAgentLegacy {
-		s.Suffix = " Hostagent installed successfully"
-		s.Stop()
-		fmt.Println(color.Green("✓ ") + "Hostagent installed successfully")
+		//s.Suffix = " Hostagent installed successfully"
+		//s.Stop()
+		//fmt.Println(color.Green("✓ ") + "Hostagent installed successfully")
+		zap.L().Info(color.Green("✓ ") + "Hostagent installed successfully")
 	}
-	s.Restart()
+	//s.Restart()
 
 	sendSegmentEvent(allClients, "Initialising host - 3", auth, false)
-	s.Suffix = " Initialising host"
+	//s.Suffix = " Initialising host"
+	zap.L().Info("  Initialising host...")
 	zap.S().Debug("Initialising host")
 	zap.S().Debug("Identifying the hostID from conf")
 	cmd := `grep host_id /etc/pf9/host_id.conf | cut -d '=' -f2`
@@ -124,10 +127,12 @@ func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.Keysto
 		return fmt.Errorf(errStr)
 	}
 
-	s.Stop()
-	fmt.Println(color.Green("✓ ") + "Initialised host successfully")
-	s.Restart()
-	s.Suffix = " Authorising host"
+	//s.Stop()
+	//fmt.Println(color.Green("✓ ") + "Initialised host successfully")
+	zap.L().Info(color.Green("✓ ") + "Initialised host successfully")
+	//s.Restart()
+	//s.Suffix = " Authorising host"
+	zap.L().Info("  Authorising host (this might take a few minutes...)")
 	hostID := strings.TrimSuffix(output, "\n")
 	time.Sleep(ctx.WaitPeriod * time.Second)
 
@@ -139,12 +144,12 @@ func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.Keysto
 	}
 
 	zap.S().Debug("Host successfully attached to the Platform9 control-plane")
-	s.Suffix = " Host successfully attached to the Platform9 control-plane"
+	//s.Suffix = " Host successfully attached to the Platform9 control-plane"
 	sendSegmentEvent(allClients, "Successful", auth, false)
-	s.Stop()
+	//s.Stop()
 
-	fmt.Println(color.Green("✓ ") + "Host successfully attached to the Platform9 control-plane")
-
+	//fmt.Println(color.Green("✓ ") + "Host successfully attached to the Platform9 control-plane")
+	zap.L().Info(color.Green("✓ ") + "Host successfully attached to the Platform9 control-plane")
 	return nil
 }
 


### PR DESCRIPTION
## ISSUE(S):
<!--- Links to JIRA tickets -->
<!--- [FT-XXXX](link.to/FT-XXXX): Subject of FT-XXXX -->
https://platform9.atlassian.net/browse/FT-262

## SUMMARY
<!--- Describe the change below -->

<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->
Current CLI commands output was not automation friendly because of spinner, as mentioned in jira it was difficult to debug logs because of spinner, so removed the spinner and also added the flag to pass path to save log and flag to set log level

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## IMPACTED FEATURES/COMPONENTS:
<!--- List of impacted features/components due to this change -->
<!--- delete section if not relevant -->
impacted commands(output)
check-node
prep-node
bootstrap

## RELATED ISSUE(S):
<!--- Links to Related issues/Jira tickets if any -->
<!--- delete section if not relevant -->
https://platform9.atlassian.net/browse/FT-361

## TESTING DONE
#### Manual
<!--- Please list down various use case which were part of manual testing. -->
**Flags to set log-level and log-dir**
<img width="980" alt="Screenshot 2022-03-23 at 1 40 44 PM" src="https://user-images.githubusercontent.com/76941923/159665289-f6cdf953-0f47-4928-98b0-902692b0820d.png">
**Storing log to user defined location**
<img width="984" alt="Screenshot 2022-03-23 at 1 44 32 PM" src="https://user-images.githubusercontent.com/76941923/159665501-7374deb5-fe5d-4510-af4f-b8448a8a8971.png">
**debug level logs**
<img width="1431" alt="Screenshot 2022-03-23 at 2 51 36 PM" src="https://user-images.githubusercontent.com/76941923/159666191-c8f7e403-9875-4334-95c2-33182f11ae1d.png">
**prep-node**
<img width="984" alt="Screenshot 2022-03-23 at 1 47 35 PM" src="https://user-images.githubusercontent.com/76941923/159666407-a9b7e4f4-4aa0-422d-9bdb-2cee565460a8.png">
**prep-node failure pointing to user defined log location**
<img width="995" alt="Screenshot 2022-03-23 at 2 12 41 PM" src="https://user-images.githubusercontent.com/76941923/159666706-20b857ff-af91-49b3-8c0c-7af076ab6a90.png">
**prep-node failure pointing to default log location**
<img width="995" alt="Screenshot 2022-03-23 at 2 14 13 PM" src="https://user-images.githubusercontent.com/76941923/159666974-88e53dda-d5ac-4c26-ab32-2310496e4a18.png">
**bootstrap**
<img width="1181" alt="Screenshot 2022-03-23 at 2 21 25 PM" src="https://user-images.githubusercontent.com/76941923/159667275-9ba912e5-c849-4429-ae1f-a636d7ed6f31.png">
**bootstrap failure**
<img width="1429" alt="Screenshot 2022-03-23 at 2 16 25 PM" src="https://user-images.githubusercontent.com/76941923/159667469-861501d6-0d7d-41a1-ae9b-4ebe7864e21c.png">
**check-node failure pointing to default log location**
<img width="1431" alt="Screenshot 2022-03-23 at 2 26 32 PM" src="https://user-images.githubusercontent.com/76941923/159667766-d627c50c-15da-42a4-97f2-69c852bfb506.png">
**check-node failure pointing to user defined log location**
<img width="1431" alt="Screenshot 2022-03-23 at 2 27 24 PM" src="https://user-images.githubusercontent.com/76941923/159668116-9ad9ff7b-6de8-4364-9230-cbbbdd6d5399.png">


#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->
/cc @anupbarve @nikhilbandi @anmolsachan 