### PR TITLE
added flag to pass log-location and also logged the console messages into log file

### DIFF
--- a/cmd/attachNode.go
+++ b/cmd/attachNode.go
@@ -78,7 +78,7 @@ func attachNodeRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
 	}
 	fmt.Println(color.Green("✓ ") + "Loaded Config Successfully")
-
+	zap.S().Debug("Loaded Config Successfully")
 	var executor cmdexec.Executor
 	if executor, err = cmdexec.GetExecutor(cfg.ProxyURL, nc); err != nil {
 		zap.S().Fatalf("Unable to create executor: %s\n", err.Error())

--- a/cmd/authoriseNode.go
+++ b/cmd/authoriseNode.go
@@ -57,7 +57,7 @@ func authNodeRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
 	}
 	fmt.Println(color.Green("✓ ") + "Loaded Config Successfully")
-
+	zap.S().Debug("Loaded Config Successfully")
 	var executor cmdexec.Executor
 	if executor, err = cmdexec.GetExecutor(cfg.ProxyURL, nc); err != nil {
 		zap.S().Fatalf("Unable to create executor: %s\n", err.Error())
@@ -93,5 +93,5 @@ func authNodeRun(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Println("Node authorization started....This may take a few minutes....Check the latest status in UI")
-
+	zap.S().Debug("Node authorization started....This may take a few minutes....Check the latest status in UI")
 }

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -216,7 +216,7 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Println(color.Green("✓ ") + "Loaded Config Successfully")
-
+	zap.S().Debug("Loaded Config Successfully")
 	var executor cmdexec.Executor
 	if executor, err = cmdexec.GetExecutor(cfg.ProxyURL, bootConfig); err != nil {
 		zap.S().Fatalf("Unable to create executor: %s\n", err.Error())
@@ -289,6 +289,7 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 	s.Color("red")
 	s.Start()
 	defer s.Stop()
+	zap.S().Debug("Running pre-requisite checks for Bootstrap command")
 	s.Suffix = " Running pre-requisite checks for Bootstrap command"
 
 	val, val1, err := pmk.PreReqBootstrap(executor)

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -72,7 +72,7 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Println(color.Green("✓ ") + "Loaded Config Successfully")
-
+	zap.S().Debug("Loaded Config Successfully")
 	var executor cmdexec.Executor
 	if executor, err = cmdexec.GetExecutor(cfg.ProxyURL, nc); err != nil {
 		zap.S().Fatalf("Unable to create executor: %s\n", err.Error())

--- a/cmd/deauthoriseNode.go
+++ b/cmd/deauthoriseNode.go
@@ -56,7 +56,7 @@ func deauthNodeRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
 	}
 	fmt.Println(color.Green("✓ ") + "Loaded Config Successfully")
-
+	zap.S().Debug("Loaded Config Successfully")
 	var executor cmdexec.Executor
 	if executor, err = cmdexec.GetExecutor(cfg.ProxyURL, nc); err != nil {
 		zap.S().Fatalf("Unable to create executor: %s\n", err.Error())
@@ -115,5 +115,5 @@ func deauthNodeRun(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Println("Node deauthorization started....This may take a few minutes....Check the latest status in UI")
-
+	zap.S().Debug("Node deauthorization started....This may take a few minutes....Check the latest status in UI")
 }

--- a/cmd/decomissionNode.go
+++ b/cmd/decomissionNode.go
@@ -58,7 +58,7 @@ func decommissionNodeRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
 	}
 	fmt.Println(color.Green("✓ ") + "Loaded Config Successfully")
-
+	zap.S().Debug("Loaded Config Successfully")
 	pmk.DecommissionNode(cfg, nc, true)
 
 }

--- a/cmd/deleteCluster.go
+++ b/cmd/deleteCluster.go
@@ -65,7 +65,7 @@ func deleteClusterRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
 	}
 	fmt.Println(color.Green("✓ ") + "Loaded Config Successfully")
-
+	zap.S().Debug("Loaded Config Successfully")
 	var executor cmdexec.Executor
 	if executor, err = cmdexec.GetExecutor(cfg.ProxyURL, nc); err != nil {
 		zap.S().Fatalf("Unable to create executor: %s\n", err.Error())
@@ -110,5 +110,5 @@ func deleteClusterRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Error deleting cluster ", err.Error())
 	}
 	fmt.Println("Cluster deletion started....This may take a few minutes.")
-
+	zap.S().Debug("Cluster deletion started....This may take a few minutes.")
 }

--- a/cmd/detachNode.go
+++ b/cmd/detachNode.go
@@ -61,7 +61,7 @@ func detachNodeRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
 	}
 	fmt.Println(color.Green("✓ ") + "Loaded Config Successfully")
-
+	zap.S().Debug("Loaded Config Successfully")
 	var executor cmdexec.Executor
 	if executor, err = cmdexec.GetExecutor(cfg.ProxyURL, nc); err != nil {
 		zap.S().Fatalf("Unable to create executor: %s\n", err.Error())

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -96,7 +96,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Println(color.Green("✓ ") + "Loaded Config Successfully")
-
+	zap.S().Debug("Loaded Config Successfully")
 	var executor cmdexec.Executor
 	if executor, err = cmdexec.GetExecutor(cfg.ProxyURL, nodeConfig); err != nil {
 		zap.S().Fatalf("Unable to create executor: %s\n", err.Error())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,14 @@ func initConfig() {
 	}*/
 
 	if rootCmd.Flags().Changed("log-dir") {
+		logDirPath = filepath.Join(logDirPath)
+		if _, err := os.Stat(logDirPath); os.IsNotExist(err) {
+			zap.S().Debugf("%s dir is not preset creating it", logDirPath)
+			err = os.MkdirAll(logDirPath, 0700)
+			if err != nil {
+				zap.S().Fatalf("error creating %s dir, please make sure dir is present")
+			}
+		}
 		util.Pf9Log = filepath.Join(logDirPath, "pf9ctl.log")
 		util.Pf9LogLoc = logDirPath
 	} else {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,7 +89,7 @@ func initConfig() {
 		util.Pf9Log = filepath.Join(logDirPath, "pf9ctl.log")
 		util.Pf9LogLoc = logDirPath
 	} else {
-		util.Pf9LogLoc = "pf9/log"
+		util.Pf9LogLoc = util.DefaultPf9LogLoc
 	}
 
 	// Read in environment variables that match

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,6 +87,9 @@ func initConfig() {
 
 	if rootCmd.Flags().Changed("log-dir") {
 		util.Pf9Log = filepath.Join(logDirPath, "pf9ctl.log")
+		util.Pf9LogLoc = logDirPath
+	} else {
+		util.Pf9LogLoc = "pf9/log"
 	}
 
 	// Read in environment variables that match

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	//homedir "github.com/mitchellh/go-homedir"
 	"github.com/platform9/pf9ctl/pkg/log"
@@ -17,6 +18,7 @@ import (
 var cfgFile string
 var verbosity bool
 var detach bool
+var logDirPath string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -64,6 +66,7 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolVar(&verbosity, "verbose", false, "print verbose logs")
 	rootCmd.PersistentFlags().BoolVar(&detach, "no-prompt", false, "disable all user prompts")
+	rootCmd.PersistentFlags().StringVar(&logDirPath, "log-dir", "", "path to save logs")
 	//rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.pf9ctl.yaml)")
 	//rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
@@ -81,6 +84,10 @@ func initConfig() {
 		viper.AddConfigPath(home)
 		viper.SetConfigName(".pf9ctl")
 	}*/
+
+	if rootCmd.Flags().Changed("log-dir") {
+		util.Pf9Log = filepath.Join(logDirPath, "pf9ctl.log")
+	}
 
 	// Read in environment variables that match
 	viper.AutomaticEnv()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,7 +88,7 @@ func initConfig() {
 	if rootCmd.Flags().Changed("log-dir") {
 		logDirPath = filepath.Join(logDirPath)
 		if _, err := os.Stat(logDirPath); os.IsNotExist(err) {
-			zap.S().Debugf("%s dir is not preset creating it", logDirPath)
+			zap.S().Debugf("%s dir is not present creating it", logDirPath)
 			err = os.MkdirAll(logDirPath, 0700)
 			if err != nil {
 				zap.S().Fatalf("error creating %s dir, please make sure dir is present")

--- a/cmd/supportBundle.go
+++ b/cmd/supportBundle.go
@@ -64,7 +64,7 @@ func supportBundleUpload(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Unable to load the context: %s\n", err.Error())
 	}
 	fmt.Println(color.Green("✓ ") + "Loaded Config Successfully")
-
+	zap.S().Debug("Loaded Config Successfully")
 	var executor cmdexec.Executor
 	if executor, err = cmdexec.GetExecutor(cfg.ProxyURL, bundleConfig); err != nil {
 		zap.S().Fatalf("Unable to create executor: %s\n", err.Error())

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -70,6 +70,7 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 
 	s.Start() // Start the spinner
 	defer s.Stop()
+	zap.S().Debug("Running pre-requisite checks and installing any missing OS packages")
 	s.Suffix = " Running pre-requisite checks and installing any missing OS packages"
 	checks := platform.Check()
 	s.Stop()
@@ -125,6 +126,7 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 	fmt.Printf("\n")
 	if mandatoryCheck {
 		fmt.Println(color.Green("✓ ") + "Completed Pre-Requisite Checks successfully\n")
+		zap.S().Debug("Completed Pre-Requisite Checks successfully")
 	}
 
 	removeCurrentInstallation := ""

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -126,8 +126,10 @@ func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.Keysto
 
 	s.Stop()
 	fmt.Println(color.Green("✓ ") + "Initialised host successfully")
+	zap.S().Debug("Initialised host successfully")
 	s.Restart()
 	s.Suffix = " Authorising host"
+	zap.S().Debug("Authorising host")
 	hostID := strings.TrimSuffix(output, "\n")
 	time.Sleep(ctx.WaitPeriod * time.Second)
 
@@ -169,7 +171,7 @@ func EnableUnattendedUpdates(allClients client.Client) {
 }
 
 func installHostAgent(ctx objects.Config, auth keystone.KeystoneAuth, hostOS string, exec cmdexec.Executor) error {
-	zap.S().Debug("Downloading Hostagent")
+	zap.S().Debug("Downloading the Hostagent (this might take a few minutes...)")
 
 	regionURL, err := keystone.FetchRegionFQDN(ctx.Fqdn, ctx.Region, auth)
 	if err != nil {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -92,11 +92,12 @@ var (
 	OptDir = "/var/opt/pf9"
 
 	//Location of ovf service file
-	OVFLoc    = "/etc/systemd/system/ovf.service"
-	VarDir    = "/var/log/pf9"
-	EtcDir    = "/etc/pf9"
-	Pf9LogLoc string
-	Pf9DirLoc = filepath.Join(HomeDir, "/")
+	OVFLoc           = "/etc/systemd/system/ovf.service"
+	VarDir           = "/var/log/pf9"
+	EtcDir           = "/etc/pf9"
+	DefaultPf9LogLoc = "pf9/log"
+	Pf9LogLoc        string
+	Pf9DirLoc        = filepath.Join(HomeDir, "/")
 
 	//Auth,Dmesg,dpkg/yum files for Debian/Redhat
 	DmesgLog = "/var/log/dmesg"

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -95,7 +95,7 @@ var (
 	OVFLoc    = "/etc/systemd/system/ovf.service"
 	VarDir    = "/var/log/pf9"
 	EtcDir    = "/etc/pf9"
-	Pf9LogLoc = "pf9/log"
+	Pf9LogLoc string
 	Pf9DirLoc = filepath.Join(HomeDir, "/")
 
 	//Auth,Dmesg,dpkg/yum files for Debian/Redhat


### PR DESCRIPTION

## ISSUE(S):
<!--- Links to JIRA tickets -->
<!--- [FT-XXXX](link.to/FT-XXXX): Subject of FT-XXXX -->
https://platform9.atlassian.net/browse/FT-262

## SUMMARY
<!--- Describe the change below -->

<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->
Added new flag to pass location to save logs, and also logged the console messages into logfile

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## RELATED ISSUE(S):
<!--- Links to Related issues/Jira tickets if any -->
<!--- delete section if not relevant -->
https://platform9.atlassian.net/browse/FT-361


## TESTING DONE
#### Manual
<!--- Please list down various use case which were part of manual testing. -->
**Flag to pass log location**
<img width="811" alt="Screenshot 2022-03-28 at 12 57 48 PM" src="https://user-images.githubusercontent.com/76941923/160350445-3b6f8ba0-02ce-4c43-9485-628ebabb22bc.png">
**User defined log location to save logs**
<img width="1365" alt="Screenshot 2022-03-28 at 12 59 21 PM" src="https://user-images.githubusercontent.com/76941923/160350550-bf5eb850-3793-47b0-a926-9b911fffba03.png">
**Default log location**
<img width="1373" alt="Screenshot 2022-03-28 at 1 02 07 PM" src="https://user-images.githubusercontent.com/76941923/160350659-452a76d2-8013-4e33-8313-25c95fe3350c.png">

#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->
/cc @anupbarve @nikhilbandi 