### PR TITLE
changed the decommission steps as per documentation

### DIFF
--- a/pkg/pmk/decomissionNode.go
+++ b/pkg/pmk/decomissionNode.go
@@ -8,6 +8,7 @@ import (
 	"github.com/platform9/pf9ctl/pkg/client"
 	"github.com/platform9/pf9ctl/pkg/cmdexec"
 	"github.com/platform9/pf9ctl/pkg/objects"
+	"github.com/platform9/pf9ctl/pkg/qbert"
 	"github.com/platform9/pf9ctl/pkg/util"
 	"go.uber.org/zap"
 )
@@ -24,7 +25,46 @@ func removePf9Instation(c client.Client) {
 	c.Executor.RunCommandWait(cmd)
 }
 
+func removeHostagent(c client.Client, hostOS string) {
+
+	fmt.Println("Removing pf9-hostagent (this might take a few minutes...)")
+	var services = []string{"pf9-hostagent", "pf9-nodeletd", "pf9-kubelet"}
+	//stop hostagent
+	for _, service := range services {
+		cmd := fmt.Sprintf("sudo systemctl stop %s", service)
+		_, err := c.Executor.RunWithStdout("bash", "-c", cmd)
+		if err != nil {
+			zap.S().Debugf("Could not execute command %v", err)
+		}
+	}
+	//remove hostagent
+	var err error
+	if hostOS == "debian" {
+		_, err = c.Executor.RunWithStdout("bash", "-c", "sudo apt-get purge pf9-hostagent -y")
+	} else {
+		_, err = c.Executor.RunWithStdout("bash", "-c", "sudo yum remove pf9-hostagent -y")
+	}
+	if err != nil {
+		zap.S().Debugf("Could not execute command %v", err)
+	} else {
+		fmt.Println("Removed hostagent")
+	}
+	fmt.Println("Removing logs...")
+	for _, file := range util.Files {
+		cmd := fmt.Sprintf("rm -rf %s", file)
+		c.Executor.RunCommandWait(cmd)
+	}
+}
+
 func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool) {
+	//Doc decommission steps
+	//detach-node from cluster
+	//deauthorize-node from controle plane
+	//stop pf9-hostagent
+	//stop pf9-nodeletd
+	//stop pf9-kublet
+	//purge pf9-hostagent
+	//clean up logs
 
 	var executor cmdexec.Executor
 	var err error
@@ -47,60 +87,77 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 	if err != nil {
 		zap.S().Fatalf("ERROR : unable to get host ip")
 	}
-	var nodeIPs []string
-	nodeIPs = append(nodeIPs, ip)
-	token := auth.Token
-	nodeUuid := c.Resmgr.GetHostId(token, nodeIPs)
-	if len(nodeUuid) == 0 {
-		zap.S().Fatalf("Could not remove the node from the UI, check if the host agent is installed.")
-	}
-
-	version, err := OpenOSReleaseFile(executor)
-
+	hostOS, err := ValidatePlatform(c.Executor)
 	if err != nil {
 		zap.S().Fatalf("Error getting OS version")
 	}
-
-	fmt.Println("Removing packages...")
-	if strings.Contains(string(version), util.Ubuntu) {
-		out := c.Executor.RunCommandWait("dpkg --remove pf9-comms pf9-kube pf9-hostagent pf9-muster")
-		fmt.Println(out)
-		fmt.Println("Purging packages")
-		out = c.Executor.RunCommandWait("dpkg --purge pf9-comms pf9-kube pf9-hostagent pf9-muster")
-		fmt.Println(out)
-
+	var nodeIPs []string
+	nodeIPs = append(nodeIPs, ip)
+	hostID := c.Resmgr.GetHostId(auth.Token, nodeIPs)
+	//check if hostagent is installed on host
+	if hostOS == "debian" {
+		_, err = c.Executor.RunWithStdout("bash", "-c", "dpkg -l | grep hostagent")
 	} else {
-		for _, p := range util.Pf9Packages {
-			cmd := fmt.Sprintf("yum erase -y %s", p)
-			out := c.Executor.RunCommandWait(cmd)
-			fmt.Println(out)
+		_, err = c.Executor.RunWithStdout("bash", "-c", "yum list installed | grep hostagent")
+	}
+	if err == nil {
+		//check if node is connected to any cluster
+		var nodeInfo qbert.Node
+		var nodeConnectedToDU bool
+		if len(hostID) != 0 {
+			nodeConnectedToDU = true
+			nodeInfo = c.Qbert.GetNodeInfo(auth.Token, auth.ProjectID, hostID[0])
 		}
+
+		if nodeInfo.ClusterName == "" {
+			fmt.Println("Node is not connected to any cluster")
+			if nodeConnectedToDU {
+				err = c.Qbert.DeauthoriseNode(hostID[0], auth.Token)
+				if err != nil {
+					zap.S().Fatalf("Failed to deauthorize node")
+				} else {
+					fmt.Println("Deauthorized node from UI")
+				}
+				removeHostagent(c, hostOS)
+			} else {
+				//case where node is not connected to DU but hostagent is installed partially
+				removeHostagent(c, hostOS)
+			}
+			//remove pf9 dir
+			if removePf9 {
+				removePf9Instation(c)
+			}
+			fmt.Println("Node decommissioning started....This may take a few minutes....Check the latest status in UI")
+			time.Sleep(50 * time.Second)
+		} else {
+			//detach node from cluster
+			fmt.Printf("Node is connected to %s cluster\n", nodeInfo.ClusterName)
+			fmt.Println("Detaching node from cluster...")
+			err = c.Qbert.DetachNode(nodeInfo.ClusterUuid, auth.ProjectID, auth.Token, hostID[0])
+			if err != nil {
+				zap.S().Fatalf("Failed to detach host from cluster")
+			} else {
+				fmt.Println("Detached node from cluster")
+			}
+
+			//deauthorize host from UI
+			fmt.Println("Deauthorizing node from UI...")
+			err = c.Qbert.DeauthoriseNode(hostID[0], auth.Token)
+			if err != nil {
+				zap.S().Fatalf("Failed to deauthorize node")
+			} else {
+				fmt.Println("Deauthorized node from UI")
+			}
+			//stop host agent and remove it
+			removeHostagent(c, hostOS)
+			//remove pf9 dir
+			if removePf9 {
+				removePf9Instation(c)
+			}
+			fmt.Println("Node decommissioning started....This may take a few minutes....Check the latest status in UI")
+			time.Sleep(50 * time.Second)
+		}
+	} else {
+		fmt.Println("Host is not connected to Platform9 Management Plane")
 	}
-
-	if removePf9 {
-		removePf9Instation(c)
-	}
-
-	for _, service := range util.ProcessesList {
-		cmd := fmt.Sprintf("pkill %s", service)
-		c.Executor.RunCommandWait(cmd)
-	}
-
-	for _, file := range util.Files {
-		cmd := fmt.Sprintf("rm -rf %s", file)
-		c.Executor.RunCommandWait(cmd)
-	}
-
-	err = c.Qbert.DeauthoriseNode(nodeUuid[0], token)
-
-	if err != nil {
-		zap.S().Fatalf("Error removing the node from the UI ", err.Error())
-	}
-	fmt.Println("Removed the node from the UI")
-
-	fmt.Println("Node decommissioning started....This may take a few minutes....Check the latest status in UI")
-	// Wating for ports to close
-	// Some ports taking time to close even after killing the process
-	time.Sleep(50 * time.Second)
-
 }

--- a/pkg/pmk/decomissionNode.go
+++ b/pkg/pmk/decomissionNode.go
@@ -13,7 +13,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func removePf9Instation(c client.Client) {
+func removePf9Installation(c client.Client) {
 	fmt.Println("Removing /etc/pf9 logs")
 	cmd := fmt.Sprintf("rm -rf %s", util.EtcDir)
 	c.Executor.RunCommandWait(cmd)
@@ -96,9 +96,9 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 	hostID := c.Resmgr.GetHostId(auth.Token, nodeIPs)
 	//check if hostagent is installed on host
 	if hostOS == "debian" {
-		_, err = c.Executor.RunWithStdout("bash", "-c", "dpkg -l | grep hostagent")
+		_, err = c.Executor.RunWithStdout("bash", "-c", "dpkg -s pf9-hostagent")
 	} else {
-		_, err = c.Executor.RunWithStdout("bash", "-c", "yum list installed | grep hostagent")
+		_, err = c.Executor.RunWithStdout("bash", "-c", "yum list installed pf9-hostagent")
 	}
 	if err == nil {
 		//check if node is connected to any cluster
@@ -125,7 +125,7 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 			}
 			//remove pf9 dir
 			if removePf9 {
-				removePf9Instation(c)
+				removePf9Installation(c)
 			}
 			fmt.Println("Node decommissioning started....This may take a few minutes....Check the latest status in UI")
 			time.Sleep(50 * time.Second)
@@ -152,7 +152,7 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 			removeHostagent(c, hostOS)
 			//remove pf9 dir
 			if removePf9 {
-				removePf9Instation(c)
+				removePf9Installation(c)
 			}
 			fmt.Println("Node decommissioning started....This may take a few minutes....Check the latest status in UI")
 			time.Sleep(50 * time.Second)


### PR DESCRIPTION
## ISSUE(S):
<!--- Links to JIRA tickets -->
<!--- [FT-XXXX](link.to/FT-XXXX): Subject of FT-XXXX -->
https://platform9.atlassian.net/browse/FT-374
## SUMMARY
<!--- Describe the change below -->

<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->

- Decommission node steps was not as per the documentation so changed it as per documentation.
- Fixed bug where packages was not getting removed in case of partially onboarded node
- Cleaned up decommissioned node command output

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## IMPACTED FEATURES/COMPONENTS:
<!--- List of impacted features/components due to this change -->
<!--- delete section if not relevant -->
Impacted command
decommission-node

## RELATED ISSUE(S):
<!--- Links to Related issues/Jira tickets if any -->
<!--- delete section if not relevant -->
https://platform9.atlassian.net/browse/FT-364


## TESTING DONE

#### Manual
<!--- Please list down various use case which were part of manual testing. -->
**decommission on ubuntu local**
<img width="727" alt="Screenshot 2022-04-05 at 5 55 00 PM" src="https://user-images.githubusercontent.com/76941923/161897717-f35dcff0-4066-42bc-b35b-786f6be25f4a.png">
**decommission on centos local**
<img width="727" alt="Screenshot 2022-04-05 at 6 03 50 PM" src="https://user-images.githubusercontent.com/76941923/161897820-4818989c-5df0-4c2e-9806-4ff7ce345ef6.png">
**decommission on centos remote**
<img width="727" alt="Screenshot 2022-04-05 at 5 37 32 PM" src="https://user-images.githubusercontent.com/76941923/161898044-8fa91170-c128-43b3-ad88-f09ebfa1fc9e.png">
**decommission on ubuntu remote**
<img width="727" alt="Screenshot 2022-04-05 at 4 00 00 PM" src="https://user-images.githubusercontent.com/76941923/161898181-bdaa7d15-3c06-4889-8876-9a4ee4212bd2.png">
**decommission on node which is connected to cluster**
<img width="727" alt="Screenshot 2022-04-05 at 5 48 34 PM" src="https://user-images.githubusercontent.com/76941923/161898264-445efa9c-7b73-4ff8-a7de-dca0c2e05b81.png">
**decommission on node which is not connected to DU but host agent is installed (partial)**
<img width="727" alt="Screenshot 2022-04-05 at 6 08 54 PM" src="https://user-images.githubusercontent.com/76941923/161898475-e6c961b3-58f9-4ed1-bf5a-08bff62e898e.png">
**prep-node on node which is partially onboarded (not connected to DU but hostagent is installed)**
<img width="673" alt="Screenshot 2022-04-06 at 10 00 44 AM" src="https://user-images.githubusercontent.com/76941923/161898663-50b2233c-726f-4c39-9515-076d86126230.png">
**decommission on fresh vm ubuntu**
<img width="727" alt="Screenshot 2022-04-05 at 6 10 15 PM" src="https://user-images.githubusercontent.com/76941923/161898763-e0753a52-065f-4aa2-a1b9-1e360c6a485e.png">
**decommission on fresh vm centos**
<img width="727" alt="Screenshot 2022-04-05 at 6 11 20 PM" src="https://user-images.githubusercontent.com/76941923/161898824-bdc51e83-e8be-4d65-b233-740cce6cb2fa.png">

#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->
/cc @anupbarve @nikhilbandi 