### PR TITLE
Private/shubhamc/cli dpkg lock check failed ft 336

### DIFF
--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -336,10 +336,15 @@ func (d *Debian) processAcquiredDpkgLock() (string, error) {
 	for _, file := range f {
 
 		output, err := d.exec.RunWithStdout("bash", "-c", fmt.Sprintf("lsof /var/lib/dpkg/%s | grep lib/dpkg/%s ", file, file))
-		if err != nil {
+		if err != nil || output == "" {
 			return "", errors.New("Unable to find pid with dpkg lock")
 		}
-		PID := strings.Fields(output)[1]
+		output_slice := strings.Fields(output)
+		if len(output_slice) < 2 {
+			return "", errors.New("Unable to find pid with dpkg lock")
+		}
+
+		PID := output_slice[1]
 		output, err = d.exec.RunWithStdout("bash", "-c", fmt.Sprintf("ps -p %s -o command=", PID))
 		if err != nil {
 			return "", errors.New("Unable to find process with dpkg lock")

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -62,7 +62,7 @@ func (d *Debian) Check() []platform.Check {
 	result, err = d.CheckKubernetesCluster()
 	checks = append(checks, platform.Check{"Existing Kubernetes Cluster Check", true, result, err, fmt.Sprintf("%s", err)})
 
-	result, err = d.checkIfdpkgISLock()
+	result, err = d.CheckIfdpkgISLock()
 	checks = append(checks, platform.Check{"Check lock on dpkg", true, result, err, fmt.Sprintf("%s", err)})
 
 	result, err = d.checkIfaptISLock()
@@ -331,8 +331,7 @@ func (d *Debian) disableSwap() (bool, error) {
 	}
 }
 
-func (d *Debian) checkIfdpkgISLock() (bool, error) {
-
+func (d *Debian) CheckIfdpkgISLock() (bool, error) {
 	var f = []string{"lock", "lock-frontend"}
 	for _, file := range f {
 		_, err := d.exec.RunWithStdout("bash", "-c", fmt.Sprintf("lsof /var/lib/dpkg/%s", file))

--- a/pkg/platform/debian/debian_test.go
+++ b/pkg/platform/debian/debian_test.go
@@ -646,7 +646,7 @@ func TestDpkgLockCheck(t *testing.T) {
 			},
 			want: want{
 				result: false,
-				err:    fmt.Errorf("Unable to acquire the dpkg"),
+				err:    fmt.Errorf("Unable to acquire the dpkg - "),
 			},
 		},
 	}

--- a/pkg/platform/debian/debian_test.go
+++ b/pkg/platform/debian/debian_test.go
@@ -654,7 +654,7 @@ func TestDpkgLockCheck(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			d := &Debian{exec: tc.exec}
-			result, err := d.checkIfdpkgISLock()
+			result, err := d.CheckIfdpkgISLock()
 			assert.Equal(t, tc.result, result)
 			assert.Equal(t, tc.err, err)
 		})

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -170,7 +170,7 @@ func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.Keysto
 
 func StatusUnattendedUpdates(allClients client.Client) bool {
 	zap.S().Debug("Checking Status of unattended-upgrades")
-	output, err := allClients.Executor.RunWithStdout("bash", "-c", "systemctl status unattended-upgrades | grep -i Active")
+	output, err := allClients.Executor.RunWithStdout("bash", "-c", "systemctl is-active unattended-upgrades")
 	if err != nil {
 		zap.S().Debugf("Failed to check unattended-upgrades : %s", err)
 	}

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -75,10 +75,11 @@ func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.Keysto
 		return fmt.Errorf(errStr)
 	}
 
-	platform := debian.NewDebian(allClients.Executor)
-	result, _ := platform.CheckIfdpkgISLock()
-
 	if hostOS == "debian" {
+
+		platform := debian.NewDebian(allClients.Executor)
+		result, _ := platform.CheckIfdpkgISLock()
+
 		if StatusUnattendedUpdates(allClients) {
 			// stop unattended-upgrades
 			// this do not stop them if they are already running


### PR DESCRIPTION
## ISSUE(S):
<!--- Links to JIRA tickets -->
<!--- [FT-XXXX](link.to/FT-XXXX): Subject of FT-XXXX -->

CLI dpkg lock check failed. Because  of unattended-upgrades
[FT-366](https://platform9.atlassian.net/browse/FT-366)

## SUMMARY
<!--- Describe the change below -->

If unattended-upgrades start after dpkg lock check in check-node.
dpkg would go under lock and we would unable to install hostagent.


<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->
Added additional dpkg lock check after stoping unattended-upgrades.
Also add check if unattended-upgrades is disabled by default.

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## IMPACTED FEATURES/COMPONENTS:
<!--- List of impacted features/components due to this change -->
<!--- delete section if not relevant -->
changed debian.checkIfdpkgISLock to debian.CheckIfdpkgISLock to use outside debian package



## TESTING DONE
<!--- Please give link to teamcity build if there are any automated tests -->
<!--- that gets executed as a part of build.-->
#### Manual
<!--- Please list down various use case which were part of manual testing. -->

#### If unattended-upgrades starts running before check-node
<img width="1440" alt="Screenshot 2022-04-11 at 2 50 28 PM" src="https://user-images.githubusercontent.com/35176826/163370311-db26ec05-9dc2-4951-bfc2-4b3ce1935b98.png">


#### If unattended-upgrades starts running after check-node
<img width="1349" alt="Screenshot 2022-04-11 at 3 59 42 PM" src="https://user-images.githubusercontent.com/35176826/163752688-b1f14de1-33c3-4124-95a8-cc7348270f63.png">

#### If unattended-upgrades active but not running yet
<img width="1349" alt="Screenshot 2022-04-14 at 12 18 36 PM" src="https://user-images.githubusercontent.com/35176826/163752728-b1c1dcca-3bca-4dbf-855d-19177238fcbf.png">

#### Reviewers
@devidask27 @AnirudhPokala @anupbarve @yogeshj83 
<!--- Add reviewers by appending their github usernames after "/cc" -->
