### PR TITLE
Added ldflags to reduce binary size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ container-build:
 	docker run --rm --env XDG_CACHE_HOME=$(XDG_CACHE_HOME) --env SEGMENT_KEY_PRD_PMKFT=$(SEGMENT_KEY_PRD_PMKFT) --env VERSION_OVERRIDE=${VERSION_OVERRIDE} --env GOPATH=/tmp --env GOFLAGS=$(GOFLAGS) --user $(CONT_USER):$(CONT_GRP) --volume $(PWD):$(PACKAGE_GOPATH) $(GIT_STORAGE_MOUNT) --workdir $(PACKAGE_GOPATH) golang:1.17.6 make
 
 $(BIN): test
-	go build -o $(BIN_DIR)/$(BIN) -ldflags "$(LDFLAGS) -X github.com/platform9/pf9ctl/pkg/client.SegmentWriteKey=$(SEGMENT_KEY_PRD_PMKFT)"
+	go build -o $(BIN_DIR)/$(BIN) -ldflags "$(LDFLAGS) -X github.com/platform9/pf9ctl/pkg/client.SegmentWriteKey=$(SEGMENT_KEY_PRD_PMKFT) -s -w"
 
 format:
 	gofmt -w -s *.go


### PR DESCRIPTION
## ISSUE(S):
<!--- Links to JIRA tickets -->
<!--- [FT-XXXX](link.to/FT-XXXX): Subject of FT-XXXX -->
Check around strip, Dwraf sub-flags (-s,-w) with ldflags to further reduce binary size of pf9ctl. 
[FT-338](https://platform9.atlassian.net/browse/FT-338)

## SUMMARY
<!--- Describe the change below -->
Binary size of pf9ctl is 22.43 which is large. Reducing this size without affecting core fictionality or
process in which binary is build

binary size reduced 22.43 to 16.4
~ 26% reduction 
ldflags added
-s : Omit the symbol table and debug information.
-w: Omit the DWARF symbol table.

<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## TESTING DONE
#### Automated
##### previous version
<img width="755" alt="Screenshot 2022-04-25 at 12 00 23 PM" src="https://user-images.githubusercontent.com/35176826/165036488-4ed412b5-5019-4b82-8331-4fb1a381247d.png">

###### with new flags
<img width="778" alt="Screenshot 2022-04-25 at 12 35 23 PM" src="https://user-images.githubusercontent.com/35176826/165037590-66a5ecf8-0d74-4a33-95e4-047715a194dc.png">



#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->
@devidask27 @AnirudhPokala 
