### PR TITLE
even if ntp is installed systemd-timesyncd was removing ntp

### DIFF
--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -434,7 +434,8 @@ func (d *Debian) checkIfAnyTimeSyncServiceIsRunning() error {
 			if err != nil {
 				err = d.start(service)
 				if err != nil {
-					return err
+					zap.S().Debugf("Failed to start service %s", service)
+					zap.S().Debug("Checking next service")
 				} else {
 					return nil
 				}


### PR DESCRIPTION
## ISSUE(S):
<!--- Links to JIRA tickets -->
<!--- [FT-XXXX](link.to/FT-XXXX): Subject of FT-XXXX -->
https://platform9.atlassian.net/browse/FT-391
## SUMMARY
<!--- Describe the change below -->
<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->
Before installing any timesync package CLI first checks if "systemd-timesyncd.service", "ntp.service", "chrony.service" are present on host, and if no package is installed it installs systemd-timesyncd. But even if ntp is installed on host the systemd-timesyncd.service package was getting installed which was removing ntp completely. 

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTING DONE
#### Manual
<!--- Please list down various use case which were part of manual testing. -->
**Before**
![Screenshot 2022-06-15 at 5 30 04 PM](https://user-images.githubusercontent.com/76941923/173822263-e5e5b0a6-e68e-4112-a074-1cc390361dca.png)

**Now**
![Screenshot 2022-06-15 at 5 17 17 PM](https://user-images.githubusercontent.com/76941923/173821563-e615b100-ab3e-4cc3-b007-8bf0034581de.png)

![Screenshot 2022-06-15 at 5 14 32 PM](https://user-images.githubusercontent.com/76941923/173821569-5cd1d55b-7b0c-4999-8cfd-d7f63675eb61.png)

#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->
/cc @anupbarve 