### PR TITLE
Add option to skip node auth in prep-node

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -356,7 +356,7 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 		}
 
 		zap.S().Debug("========== Running prep-node as a part of bootstrap ==========")
-		if err := pmk.PrepNode(*cfg, c, auth, false); err != nil {
+		if err := pmk.PrepNode(*cfg, c, auth); err != nil {
 
 			// Uploads pf9cli log bundle if prepnode failed to get prepared
 			errbundle := supportBundle.SupportBundleUpload(*cfg, c, isRemote)

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -356,7 +356,7 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 		}
 
 		zap.S().Debug("========== Running prep-node as a part of bootstrap ==========")
-		if err := pmk.PrepNode(*cfg, c, auth); err != nil {
+		if err := pmk.PrepNode(*cfg, c, auth, false); err != nil {
 
 			// Uploads pf9cli log bundle if prepnode failed to get prepared
 			errbundle := supportBundle.SupportBundleUpload(*cfg, c, isRemote)

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -63,7 +63,7 @@ func init() {
 	prepNodeCmd.Flags().StringVar(&nodeConfig.MFA, "mfa", "", "MFA token")
 	prepNodeCmd.Flags().StringVarP(&nodeConfig.SudoPassword, "sudo-pass", "e", "", "sudo password for user on remote host")
 	prepNodeCmd.Flags().BoolVarP(&nodeConfig.RemoveExistingPkgs, "remove-existing-pkgs", "r", false, "Will remove previous installation if found (default false)")
-	prepNodeCmd.Flags().BoolVarP(&skipKube, "skip-kube", "", false, "Skip installing pf9-kube/nodelet on this host")
+	prepNodeCmd.Flags().BoolVarP(&util.SkipKube, "skip-kube", "", false, "Skip installing pf9-kube/nodelet on this host")
 	prepNodeCmd.Flags().MarkHidden("skip-kube")
 
 	rootCmd.AddCommand(prepNodeCmd)
@@ -170,7 +170,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	if err := pmk.PrepNode(*cfg, c, auth, skipKube); err != nil {
+	if err := pmk.PrepNode(*cfg, c, auth); err != nil {
 
 		// Uploads pf9cli log bundle if prepnode failed to get prepared
 		errbundle := supportBundle.SupportBundleUpload(*cfg, c, isRemote)

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -47,6 +47,7 @@ var (
 	ips            []string
 	skipChecks     bool
 	disableSwapOff bool
+	skipKube       bool = false
 )
 
 var nodeConfig objects.NodeConfig
@@ -58,10 +59,12 @@ func init() {
 	prepNodeCmd.Flags().StringSliceVarP(&nodeConfig.IPs, "ip", "i", []string{}, "IP address of host to be prepared")
 	prepNodeCmd.Flags().BoolVarP(&skipChecks, "skip-checks", "c", false, "Will skip optional checks if true")
 	prepNodeCmd.Flags().BoolVarP(&disableSwapOff, "disable-swapoff", "d", false, "Will skip swapoff")
-	prepNodeCmd.Flags().StringVar(&nodeConfig.MFA, "mfa", "", "MFA token")
 	prepNodeCmd.Flags().MarkHidden("disable-swapoff")
+	prepNodeCmd.Flags().StringVar(&nodeConfig.MFA, "mfa", "", "MFA token")
 	prepNodeCmd.Flags().StringVarP(&nodeConfig.SudoPassword, "sudo-pass", "e", "", "sudo password for user on remote host")
 	prepNodeCmd.Flags().BoolVarP(&nodeConfig.RemoveExistingPkgs, "remove-existing-pkgs", "r", false, "Will remove previous installation if found (default false)")
+	prepNodeCmd.Flags().BoolVarP(&skipKube, "skip-kube", "", false, "Skip installing pf9-kube/nodelet on this host")
+	prepNodeCmd.Flags().MarkHidden("skip-kube")
 
 	rootCmd.AddCommand(prepNodeCmd)
 }
@@ -167,7 +170,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	if err := pmk.PrepNode(*cfg, c, auth); err != nil {
+	if err := pmk.PrepNode(*cfg, c, auth, skipKube); err != nil {
 
 		// Uploads pf9cli log bundle if prepnode failed to get prepared
 		errbundle := supportBundle.SupportBundleUpload(*cfg, c, isRemote)

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -47,7 +47,6 @@ var (
 	ips            []string
 	skipChecks     bool
 	disableSwapOff bool
-	skipKube       bool = false
 )
 
 var nodeConfig objects.NodeConfig
@@ -63,7 +62,7 @@ func init() {
 	prepNodeCmd.Flags().StringVar(&nodeConfig.MFA, "mfa", "", "MFA token")
 	prepNodeCmd.Flags().StringVarP(&nodeConfig.SudoPassword, "sudo-pass", "e", "", "sudo password for user on remote host")
 	prepNodeCmd.Flags().BoolVarP(&nodeConfig.RemoveExistingPkgs, "remove-existing-pkgs", "r", false, "Will remove previous installation if found (default false)")
-	prepNodeCmd.Flags().BoolVarP(&util.SkipKube, "skip-kube", "", false, "Skip installing pf9-kube/nodelet on this host")
+	prepNodeCmd.Flags().BoolVar(&util.SkipKube, "skip-kube", false, "Skip installing pf9-kube/nodelet on this host")
 	prepNodeCmd.Flags().MarkHidden("skip-kube")
 
 	rootCmd.AddCommand(prepNodeCmd)

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -57,7 +57,7 @@ func sendSegmentEvent(allClients client.Client, eventStr string, auth keystone.K
 }
 
 // PrepNode sets up prerequisites for k8s stack
-func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.KeystoneAuth, skipKube bool) error {
+func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.KeystoneAuth) error {
 	// Building our new spinner
 	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 	s.Color("red")
@@ -145,7 +145,7 @@ func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.Keysto
 	s.Stop()
 	fmt.Println(color.Green("✓ ") + "Initialised host successfully")
 	zap.S().Debug("Initialised host successfully")
-	if skipKube {
+	if util.SkipKube {
 		zap.S().Debug("Skip authorizing host as --skip-kube flag is true")
 		sendSegmentEvent(allClients, "Successful", auth, false)
 		return nil

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -57,7 +57,7 @@ func sendSegmentEvent(allClients client.Client, eventStr string, auth keystone.K
 }
 
 // PrepNode sets up prerequisites for k8s stack
-func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.KeystoneAuth) error {
+func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.KeystoneAuth, skipKube bool) error {
 	// Building our new spinner
 	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 	s.Color("red")
@@ -145,13 +145,18 @@ func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.Keysto
 	s.Stop()
 	fmt.Println(color.Green("✓ ") + "Initialised host successfully")
 	zap.S().Debug("Initialised host successfully")
+	if skipKube {
+		zap.S().Debug("Skip authorizing host as --skip-kube flag is true")
+		sendSegmentEvent(allClients, "Successful", auth, false)
+		return nil
+	}
+
 	s.Restart()
 	s.Suffix = " Authorising host"
 	zap.S().Debug("Authorising host")
 	hostID := strings.TrimSuffix(output, "\n")
 	time.Sleep(ctx.WaitPeriod * time.Second)
 
-	sendSegmentEvent(allClients, "Authorising host - 4", auth, false)
 	if err := allClients.Resmgr.AuthorizeHost(hostID, auth.Token); err != nil {
 		errStr := "Error: Unable to authorise host. " + err.Error()
 		sendSegmentEvent(allClients, errStr, auth, true)

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -13,6 +13,7 @@ var PortErr string
 var ProcessesList []string //Kubernetes clusters processes list
 var SwapOffDisabled bool   //If this is true the swapOff functionality will be disabled.
 var SkipPrepNode bool
+var SkipKube bool = false // Skip authorizing kube role during prep-node. Not applicable to bootstrap command.
 var HostDown bool
 var EBSPermissions []string
 var Route53Permissions []string

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -10,10 +10,12 @@ var Files []string
 var Pf9Packages []string
 var RequiredPorts []string
 var PortErr string
-var ProcessesList []string //Kubernetes clusters processes list
-var SwapOffDisabled bool   //If this is true the swapOff functionality will be disabled.
+var ProcessesList []string // Kubernetes clusters processes list
+var SwapOffDisabled bool   // If this is true the swapOff functionality will be disabled.
 var SkipPrepNode bool
-var SkipKube bool = false // Skip authorizing kube role during prep-node. Not applicable to bootstrap command.
+
+// SkipKube skips authorizing kube role during prep-node. Not applicable to bootstrap command
+var SkipKube bool
 var HostDown bool
 var EBSPermissions []string
 var Route53Permissions []string


### PR DESCRIPTION
## ISSUE(S):
<!--- Links to JIRA tickets -->
<!--- [FT-XXXX](link.to/FT-XXXX): Subject of FT-XXXX -->

## SUMMARY
<!--- Describe the change below -->
PMK CAPI uses `pf9ctl prep-node` command in boot script of all instances. However pf9ctl always pushes the latest version to a node. This conflicts with the version being pushed by controller-manager. Although eventually the version pushed by controller-manager is one installed on the host, this process is delayed because pf9-kube package is downloaded, installed and removed at least couple of times.

This commits adds a new hidden option to NOT install pf9-kube role as part of the prep-node command. This hidden option will be used in the PMK CAPI project to remove the race condition since only one component i.e. controller-manager will push/remove the pf9-kube role from the host in case it is CAPI-managed.

<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## IMPACTED FEATURES/COMPONENTS:
<!--- List of impacted features/components due to this change -->
<!--- delete section if not relevant -->

## RELATED ISSUE(S):
<!--- Links to Related issues/Jira tickets if any -->
<!--- delete section if not relevant -->
https://github.com/platform9/pf9-cluster-api/pull/137
https://github.com/platform9/pf9-qbert/pull/1348

## DEPENDS ON:
<!--- Links to related PRs if any -->
<!--- delete section if not relevant -->

## TESTING DONE
#### Automated
<!--- Please give link to teamcity build if there are any automated tests -->
<!--- that gets executed as a part of build.-->
#### Manual
<!--- Please list down various use case which were part of manual testing. -->

#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->
