### PR TITLE
skipping prep-node if node is already onboarded

### DIFF
--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -64,6 +64,7 @@ func init() {
 	prepNodeCmd.Flags().BoolVarP(&nodeConfig.RemoveExistingPkgs, "remove-existing-pkgs", "r", false, "Will remove previous installation if found (default false)")
 	prepNodeCmd.Flags().BoolVar(&util.SkipKube, "skip-kube", false, "Skip installing pf9-kube/nodelet on this host")
 	prepNodeCmd.Flags().MarkHidden("skip-kube")
+	prepNodeCmd.Flags().BoolVar(&util.CheckIfOnboarded, "skip-connected", false, "If the node is already connected to the PMK control plane, prep-node will be skipped")
 
 	rootCmd.AddCommand(prepNodeCmd)
 }

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -108,17 +108,8 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 						os.Exit(0)
 					} else {
 						//case where hostagent is installed but host is in disconnected sate
-						zap.S().Debug("Hostagent is installed but host is not connected to DU, Trying to authorize")
-						if id[0] != "" {
-							err := allClients.Resmgr.AuthorizeHost(id[0], auth.Token)
-							if err != nil {
-								zap.S().Debug("Failed to authorize node, installing hostagent again")
-								nc.RemoveExistingPkgs = true
-							} else {
-								zap.S().Info(color.Green("✓ ") + "Node is already connected\n")
-								os.Exit(0)
-							}
-						}
+						zap.S().Debug("Hostagent is installed but host is not connected to DU. Installing hostagent again")
+						nc.RemoveExistingPkgs = true
 					}
 				} else {
 					zap.S().Debug("Node is not connected installing hostagent")

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -94,14 +94,13 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 					ip = strings.TrimSpace(ip)
 					var add = []string{ip}
 					id := allClients.Resmgr.GetHostId(auth.Token, add)
-					//If node is already to connected then resmgr will return hostID
+					//If node is already connected then resmgr will return hostID
 					//If hostID is empty then host could be connected to other DU
 					var connected bool
 					if len(id) != 0 {
 						connected = allClients.Resmgr.HostSatus(auth.Token, id[0])
 					} else {
-						zap.S().Infof("Hostagent is installed on this host, but this host is not part of the DU %s specified in the config", ctx.Fqdn)
-						os.Exit(0)
+						zap.S().Fatalf("Hostagent is installed on this host, but this host is not part of the DU %s specified in the config", ctx.Fqdn)
 					}
 					if connected {
 						zap.S().Debug("Node is already connected")

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -13,6 +13,7 @@ var PortErr string
 var ProcessesList []string // Kubernetes clusters processes list
 var SwapOffDisabled bool   // If this is true the swapOff functionality will be disabled.
 var SkipPrepNode bool
+var CheckIfOnboarded bool
 
 // SkipKube skips authorizing kube role during prep-node. Not applicable to bootstrap command
 var SkipKube bool
@@ -298,7 +299,7 @@ func init() {
 
 }
 
-//These are the constants needed for everything version related
+// These are the constants needed for everything version related
 const (
 	Version         string = "pf9ctl version: v1.16"
 	AWSBucketName   string = "pmkft-assets"


### PR DESCRIPTION
## ISSUE(S):
<!--- Links to JIRA tickets -->
<!--- [FT-XXXX](link.to/FT-XXXX): Subject of FT-XXXX -->

## SUMMARY
<!--- Describe the change below -->
<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->
Introduced new flag for prep-node command to skip prep-node if node is already connected to DU
## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## IMPACTED FEATURES/COMPONENTS:
<!--- List of impacted features/components due to this change -->
<!--- delete section if not relevant -->
prep-node

## TESTING DONE
#### Manual
<!--- Please list down various use case which were part of manual testing. -->
![Screenshot 2022-08-30 at 5 10 22 PM](https://user-images.githubusercontent.com/76941923/187428332-2034258e-a5cb-4fc3-a586-e88a49a394d5.png)

#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->
/cc @pshanbhag  @anmolsachan 