### PR TITLE
Add --kube-version hidden flag to prep node

### DIFF
--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -64,6 +64,9 @@ func init() {
 	prepNodeCmd.Flags().BoolVarP(&nodeConfig.RemoveExistingPkgs, "remove-existing-pkgs", "r", false, "Will remove previous installation if found (default false)")
 	prepNodeCmd.Flags().BoolVar(&util.SkipKube, "skip-kube", false, "Skip installing pf9-kube/nodelet on this host")
 	prepNodeCmd.Flags().MarkHidden("skip-kube")
+	// At the moment prep-node command only install the kube role. If this changes in future, this option can be changed to something more generic.
+	prepNodeCmd.Flags().StringVar(&util.KubeVersion, "kube-version", "", "Specific version of pf9-kube to install")
+	prepNodeCmd.Flags().MarkHidden("kube-version")
 	prepNodeCmd.Flags().BoolVar(&util.CheckIfOnboarded, "skip-connected", false, "If the node is already connected to the PMK control plane, prep-node will be skipped")
 
 	rootCmd.AddCommand(prepNodeCmd)

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -157,7 +157,7 @@ func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.Keysto
 	hostID := strings.TrimSuffix(output, "\n")
 	time.Sleep(ctx.WaitPeriod * time.Second)
 
-	if err := allClients.Resmgr.AuthorizeHost(hostID, auth.Token); err != nil {
+	if err := allClients.Resmgr.AuthorizeHost(hostID, auth.Token, util.KubeVersion); err != nil {
 		errStr := "Error: Unable to authorise host. " + err.Error()
 		sendSegmentEvent(allClients, errStr, auth, true)
 		return fmt.Errorf(errStr)

--- a/pkg/resmgr/resmgr.go
+++ b/pkg/resmgr/resmgr.go
@@ -59,7 +59,7 @@ func (c *ResmgrImpl) AuthorizeHost(hostID string, token string, version string) 
 	url := fmt.Sprintf("%s/resmgr/v1/hosts/%s/roles/pf9-kube", c.fqdn, hostID)
 	if len(version) != 0 {
 		// Only resmgr v2 APIs support specifying a specific version of the role to install
-		url = fmt.Sprintf("%s/resmgr/v2/hosts/%s/roles/pf9-kube/?version=%s", c.fqdn, hostID, version)
+		url = fmt.Sprintf("%s/resmgr/v2/hosts/%s/roles/pf9-kube/versions/%s", c.fqdn, hostID, version)
 	}
 	req, err := rhttp.NewRequest("PUT", url, nil)
 	if err != nil {

--- a/pkg/resmgr/resmgr.go
+++ b/pkg/resmgr/resmgr.go
@@ -58,8 +58,7 @@ func (c *ResmgrImpl) AuthorizeHost(hostID string, token string, version string) 
 
 	url := fmt.Sprintf("%s/resmgr/v1/hosts/%s/roles/pf9-kube", c.fqdn, hostID)
 	if len(version) != 0 {
-		// Only resmgr v2 APIs support specifying a specific version of the role to install
-		url = fmt.Sprintf("%s/resmgr/v2/hosts/%s/roles/pf9-kube/versions/%s", c.fqdn, hostID, version)
+		url = fmt.Sprintf("%s/resmgr/v1/hosts/%s/roles/pf9-kube/versions/%s", c.fqdn, hostID, version)
 	}
 	req, err := rhttp.NewRequest("PUT", url, nil)
 	if err != nil {

--- a/pkg/resmgr/resmgr.go
+++ b/pkg/resmgr/resmgr.go
@@ -16,7 +16,7 @@ import (
 )
 
 type Resmgr interface {
-	AuthorizeHost(hostID, token string) error
+	AuthorizeHost(hostID, token string, version string) error
 	GetHostId(token string, hostIP []string) []string
 	HostSatus(token string, hostID string) bool
 }
@@ -44,7 +44,7 @@ func NewResmgr(fqdn string, maxHttpRetry int, minWait, maxWait time.Duration, al
 }
 
 // AuthorizeHost registers the host with hostID to the resmgr.
-func (c *ResmgrImpl) AuthorizeHost(hostID string, token string) error {
+func (c *ResmgrImpl) AuthorizeHost(hostID string, token string, version string) error {
 	zap.S().Debugf("Authorizing the host: %s with DU: %s", hostID, c.fqdn)
 
 	client := rhttp.NewClient()
@@ -57,6 +57,10 @@ func (c *ResmgrImpl) AuthorizeHost(hostID string, token string) error {
 	client.Logger = &util.ZapWrapper{}
 
 	url := fmt.Sprintf("%s/resmgr/v1/hosts/%s/roles/pf9-kube", c.fqdn, hostID)
+	if len(version) != 0 {
+		// Only resmgr v2 APIs support specifying a specific version of the role to install
+		url = fmt.Sprintf("%s/resmgr/v2/hosts/%s/roles/pf9-kube/?version=%s", c.fqdn, hostID, version)
+	}
 	req, err := rhttp.NewRequest("PUT", url, nil)
 	if err != nil {
 		return fmt.Errorf("Unable to create a new request: %w", err)

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -17,6 +17,10 @@ var CheckIfOnboarded bool
 
 // SkipKube skips authorizing kube role during prep-node. Not applicable to bootstrap command
 var SkipKube bool
+
+// KubeVersion allows specifying a role version when running prep-node command
+var KubeVersion string = ""
+
 var HostDown bool
 var EBSPermissions []string
 var Route53Permissions []string


### PR DESCRIPTION
This commit adds a --kube-version arg to prep node command. This will be used in CAPI boot scripts to simplifying and improve the onboarding process. Currently marking this as a hidden flag but if this turns out to be useful it can be made visible to the users as well.

## ISSUE(S):
<!--- Links to JIRA tickets -->
[PMK-5344](https://platform9.atlassian.net/browse/PMK-5244): Support running prep-node with an explicit kubeversion in pf9ctl

## SUMMARY
<!--- Describe the change below -->

<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## IMPACTED FEATURES/COMPONENTS:
<!--- List of impacted features/components due to this change -->
<!--- delete section if not relevant -->

## RELATED ISSUE(S):
<!--- Links to Related issues/Jira tickets if any -->
<!--- delete section if not relevant -->

## DEPENDS ON:
<!--- Links to related PRs if any -->
<!--- delete section if not relevant -->

## TESTING DONE
#### Automated
<!--- Please give link to teamcity build if there are any automated tests -->
<!--- that gets executed as a part of build.-->
#### Manual

In-progress

<!--- Please list down various use case which were part of manual testing. -->

#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->
