### PR TITLE
Adding the insecure flag for airgap installation.

### DIFF
--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -294,6 +294,9 @@ func installHostAgentCertless(ctx objects.Config, regionURL string, auth keyston
 	} else {
 		installOptions = fmt.Sprintf(`--no-project --controller=%s --username=%s --password='%s'`, regionURL, ctx.Username, ctx.Password)
 	}
+	if ctx.AllowInsecure {
+		installOptions = fmt.Sprintf("%s --insecure", installOptions)
+	}
 
 	changePermission := fmt.Sprintf("chmod +x %s/pf9/installer.sh", homeDir)
 	_, err = exec.RunWithStdout("bash", "-c", changePermission)


### PR DESCRIPTION
## ISSUE(S):
[AIR-729](https://platform9.atlassian.net/browse/AIR-729)

## SUMMARY
The configure-hosts option for airgap was failing with the below error. It needed the --insecure flag. 

```
/ Downloading the Hostagent (this might take a few minutes...) 2023-01-23T08:56:44.576-0500	debug	Error 	{"stdout": "\nExtracting Platform9 installer\n\nNo TTY available. Skipping all prompts...\nNo TTY available. Skipping all prompts...\nSkipping operating system compatibility questions\nStarting with proxy_routine\nproxy_routine executed successfully\nStarting with get_keystone_routine\n", "stderr": "Failed to authenticate with the keystone server on airctl-1.pf9.localnet, response:\n\n"}
2023-01-23T08:56:44.576-0500	debug	Running command bash "-c" "/root/pf9/installer.sh --no-proxy --skip-os-check --no-ntp --no-project --controller=airctl-1.pf9.localnet --username=admin@airctl.localnet --password='*****']stdout:

Error : 
2023-01-23T08:56:44.718-0500	debug	Error:
|     HOST     | SUCCESS |                                             MESSAGE                                             |
|--------------|---------|-------------------------------------------------------------------------------------------------|
| 10.128.145.0 | false   | error preparing node Error: Unable to install hostagent. error while running installer script:  |
```

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## IMPACTED FEATURES/COMPONENTS:
pf9ctl 
airctl

## RELATED ISSUE(S):
[AIR-729](https://platform9.atlassian.net/browse/AIR-729)

## TESTING DONE
#### Manual
Tested manually by adding the --insecure flag to the command and was able to configure the host. 


[AIR-729]: https://platform9.atlassian.net/browse/AIR-729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIR-729]: https://platform9.atlassian.net/browse/AIR-729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ