### PR TITLE
Missed adding RHEL 8.7 to error message

### DIFF
--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -65,7 +65,7 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 	case "redhat":
 		platform = centos.NewCentOS(allClients.Executor)
 	default:
-		return RequiredFail, fmt.Errorf("This OS is not supported. Supported operating systems are: Ubuntu (18.04, 20.04), CentOS 7.[3-9], RHEL 7.[3-9] & RHEL 8.[5-6]")
+		return RequiredFail, fmt.Errorf("This OS is not supported. Supported operating systems are: Ubuntu (18.04, 20.04), CentOS 7.[3-9], RHEL 7.[3-9] & RHEL 8.[5-7]")
 	}
 
 	if err = allClients.Segment.SendEvent("Starting CheckNode", auth, checkPass, ""); err != nil {


### PR DESCRIPTION
RHEL 8.7 is part of supported OS now.

Needed for PMK-5430
