### PR TITLE
PMK-5721 Adding support for Ubuntu 22.04

### DIFF
--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -301,7 +301,10 @@ func (d *Debian) Version() (string, error) {
 		isVersionMatch = true
 	} else if strings.Contains(string(majorVersion), "20") && strings.Contains(string(minorVersion), "04") {
 		isVersionMatch = true
+	} else if strings.Contains(string(majorVersion), "22") && strings.Contains(string(minorVersion), "04") {
+		isVersionMatch = true
 	}
+
 	if isVersionMatch {
 		return "debian", nil
 	}
@@ -405,7 +408,7 @@ func (d *Debian) checkIfTimesyncServiceRunning() (bool, error) {
 				zap.S().Debugf("Couldn't read the OS configuration file os-release: %s", err1.Error())
 			}
 			var err error
-			if strings.Contains(string(majorVersion), "20") && strings.Contains(string(minorVersion), "04") {
+			if (strings.Contains(string(majorVersion), "20") || strings.Contains(string(majorVersion), "22")) && strings.Contains(string(minorVersion), "04") {
 				err = d.start("systemd-timesyncd")
 			} else {
 				err = d.start("ntp")
@@ -516,7 +519,7 @@ func (d *Debian) DownloadAndInstallTimesyncPkg() error {
 		zap.S().Debugf("Couldn't read the OS configuration file os-release: %s", err1.Error())
 	}
 	var err error
-	if strings.Contains(string(majorVersion), "20") && strings.Contains(string(minorVersion), "04") {
+	if (strings.Contains(string(majorVersion), "20") || strings.Contains(string(majorVersion), "22")) && strings.Contains(string(minorVersion), "04") {
 		err = d.installOSPackages("systemd-timesyncd")
 	} else {
 		err = d.installOSPackages("ntp")

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -65,7 +65,7 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 	case "redhat":
 		platform = centos.NewCentOS(allClients.Executor)
 	default:
-		return RequiredFail, fmt.Errorf("This OS is not supported. Supported operating systems are: Ubuntu (18.04, 20.04), CentOS 7.[3-9], RHEL 7.[3-9] & RHEL 8.[5-7]")
+		return RequiredFail, fmt.Errorf("This OS is not supported. Supported operating systems are: Ubuntu (18.04, 20.04, 22.04), CentOS 7.[3-9], RHEL 7.[3-9] & RHEL 8.[5-7]")
 	}
 
 	if err = allClients.Segment.SendEvent("Starting CheckNode", auth, checkPass, ""); err != nil {


### PR DESCRIPTION
## ISSUE(S):
[PMK-5721](https://platform9.atlassian.net/browse/PMK-5721?search_id=3a1ea541-a40b-4922-8394-92a84e67c539)

## SUMMARY
Added support for Ubuntu 22.04


## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## IMPACTED FEATURES/COMPONENTS:
pf9ctl

## TESTING DONE
#### Manual
BareOS testing:
Created a 5.8 DU with a custom DDU chart that included the hostagent installer code changes needed for Ubuntu 22.04 support. Created a Ubuntu 22.04 node and used the pf9ctl binary with these changes to onboard the node using pf9ctl `prep-node` command

O/P:
```
✓ Stored configuration details successfully
root@manasa-ubuntu-02:~# ./pf9ctl prep-node
Error checking versions  open /usr/bin/pf9ctl: no such file or directory
✓ Loaded Config Successfully
✓ Missing package(s) installed successfully
✓ Removal of existing CLI
✓ Existing Platform9 Packages Check
✓ Required OS Packages Check
✓ SudoCheck
✓ CPUCheck
✓ DiskCheck
x MemoryCheck - At least 12 GB of memory is needed on host. Total memory found: 4 GB
✓ PortCheck
✓ Existing Kubernetes Cluster Check
✓ Check lock on dpkg
✓ Check lock on apt
✓ Check if system is booted with systemd
✓ Check time synchronization
✓ Check if firewalld service is not running
✓ Disabling swap and removing swap in fstab

✓ Completed Pre-Requisite Checks successfully


Optional pre-requisite check(s) failed. Do you want to continue? (y/n) y
✓ Platform9 packages installed successfully
✓ Initialised host successfully
✓ Host successfully attached to the Platform9 control-plane
```

Node was onboarded and was healthy. Was able to create a cluster using that node:
![image](https://user-images.githubusercontent.com/98585473/228506398-e364e104-cfef-4668-b35f-6b0359c795c1.png)

Could also delete the cluster succesfully.

<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->

## DEPENDS ON:
https://github.com/platform9/pf9-kube/pull/818
https://github.com/platform9/pf9-du/pull/156

[PMK-5721]: https://platform9.atlassian.net/browse/PMK-5721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ