### PR TITLE
JIRA: PMK-5776 Use host id to decommission node

### DIFF
--- a/cmd/attachNode.go
+++ b/cmd/attachNode.go
@@ -134,7 +134,10 @@ func attachNodeRun(cmd *cobra.Command, args []string) {
 			fmt.Printf("Attaching node to the cluster %s\n", clusterName)
 			var wokerids []string
 			for _, worker := range workerHostIDs {
-				if cname := c.Qbert.GetNodeInfo(token, projectId, worker); cname.ClusterName != "" {
+				cname, err := c.Qbert.GetNodeInfo(token, projectId, worker)
+				if err != nil {
+					zap.S().Debugf("Failed to get node info for host %s: %s", worker, err.Error())
+				} else if cname.ClusterName != "" {
 					zap.S().Infof("Node with host id %s is connected to %s cluster", worker, cname)
 				} else {
 					wokerids = append(wokerids, worker)
@@ -164,7 +167,10 @@ func attachNodeRun(cmd *cobra.Command, args []string) {
 			fmt.Printf("Attaching node to the cluster %s\n", clusterName)
 			var masterids []string
 			for _, master := range masterHostIDs {
-				if cname := c.Qbert.GetNodeInfo(token, projectId, master); cname.ClusterName != "" {
+				cname, err := c.Qbert.GetNodeInfo(token, projectId, master)
+				if err != nil {
+					zap.S().Debugf("Failed to get node info for host %s: %s", master, err.Error())
+				} else if cname.ClusterName != "" {
 					zap.S().Infof("Node with host id %s is connected to %s cluster", master, cname)
 				} else {
 					masterids = append(masterids, master)

--- a/cmd/detachNode.go
+++ b/cmd/detachNode.go
@@ -102,7 +102,11 @@ func detachNodeRun(cmd *cobra.Command, args []string) {
 
 	for i := range detachNodes {
 
-		isMaster := c.Qbert.GetNodeInfo(token, projectId, nodeUuids[0])
+		isMaster, err := c.Qbert.GetNodeInfo(token, projectId, nodeUuids[0])
+		if err != nil {
+			zap.S().Debugf("Failed to get node info for host %s: %s", nodeUuids[0], err.Error())
+			continue
+		}
 		clusterNodes := getAllClusterNodes(projectNodes, []string{isMaster.ClusterUuid})
 
 		if len(clusterNodes) == 1 || isMaster.IsMaster == 1 {

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -98,7 +98,7 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 					//If hostID is empty then host could be connected to other DU
 					var connected bool
 					if len(id) != 0 {
-						connected = allClients.Resmgr.HostSatus(auth.Token, id[0])
+						connected = allClients.Resmgr.HostStatus(auth.Token, id[0])
 					} else {
 						zap.S().Fatalf("Hostagent is installed on this host, but this host is not part of the DU %s specified in the config", ctx.Fqdn)
 					}

--- a/pkg/pmk/cluster.go
+++ b/pkg/pmk/cluster.go
@@ -71,7 +71,7 @@ func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateReque
 
 	LoopVariable := 1
 	for LoopVariable <= util.MaxLoopValue {
-		hostStatus := c.Resmgr.HostSatus(token, nodeID)
+		hostStatus := c.Resmgr.HostStatus(token, nodeID)
 		if !hostStatus {
 			zap.S().Debugf("Host is Down...Trying again")
 		} else {

--- a/pkg/pmk/decomissionNode.go
+++ b/pkg/pmk/decomissionNode.go
@@ -106,7 +106,10 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 		var nodeConnectedToDU bool
 		if len(hostID) != 0 {
 			nodeConnectedToDU = true
-			nodeInfo = c.Qbert.GetNodeInfo(auth.Token, auth.ProjectID, hostID)
+			nodeInfo, err = c.Qbert.GetNodeInfo(auth.Token, auth.ProjectID, hostID)
+			if err != nil {
+				zap.S().Fatalf("Failed to get node info for host %s: %s", hostID, err.Error())
+			}
 		}
 
 		if nodeInfo.ClusterName == "" {

--- a/pkg/pmk/decomissionNode.go
+++ b/pkg/pmk/decomissionNode.go
@@ -80,20 +80,20 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 		zap.S().Debug("Failed to get keystone %s", err.Error())
 	}
 
-	ip, err := c.Executor.RunWithStdout("bash", "-c", "hostname -I")
-	//Handling case where host can have multiple IPs
-	ip = strings.Split(ip, " ")[0]
-	ip = strings.TrimSpace(ip)
+	// Directly use host_id instead of relying on IP to get host details
+	cmd := `grep host_id /etc/pf9/host_id.conf | cut -d '=' -f2`
+	hostID, err := c.Executor.RunWithStdout("bash", "-c", cmd)
 	if err != nil {
-		zap.S().Fatalf("ERROR : unable to get host ip")
+		zap.S().Fatalf("Unable to get host id %s", err.Error())
 	}
+	if len(hostID) == 0 {
+		zap.S().Fatalf("Invalid host id found")
+	}
+	hostID = strings.TrimSpace(hostID)
 	hostOS, err := ValidatePlatform(c.Executor)
 	if err != nil {
 		zap.S().Fatalf("Error getting OS version")
 	}
-	var nodeIPs []string
-	nodeIPs = append(nodeIPs, ip)
-	hostID := c.Resmgr.GetHostId(auth.Token, nodeIPs)
 	//check if hostagent is installed on host
 	if hostOS == "debian" {
 		_, err = c.Executor.RunWithStdout("bash", "-c", "dpkg -s pf9-hostagent")
@@ -106,13 +106,13 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 		var nodeConnectedToDU bool
 		if len(hostID) != 0 {
 			nodeConnectedToDU = true
-			nodeInfo = c.Qbert.GetNodeInfo(auth.Token, auth.ProjectID, hostID[0])
+			nodeInfo = c.Qbert.GetNodeInfo(auth.Token, auth.ProjectID, hostID)
 		}
 
 		if nodeInfo.ClusterName == "" {
 			fmt.Println("Node is not connected to any cluster")
 			if nodeConnectedToDU {
-				err = c.Qbert.DeauthoriseNode(hostID[0], auth.Token)
+				err = c.Qbert.DeauthoriseNode(hostID, auth.Token)
 				if err != nil {
 					zap.S().Fatalf("Failed to deauthorize node")
 				} else {
@@ -133,7 +133,7 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 			//detach node from cluster
 			fmt.Printf("Node is connected to %s cluster\n", nodeInfo.ClusterName)
 			fmt.Println("Detaching node from cluster...")
-			err = c.Qbert.DetachNode(nodeInfo.ClusterUuid, auth.ProjectID, auth.Token, hostID[0])
+			err = c.Qbert.DetachNode(nodeInfo.ClusterUuid, auth.ProjectID, auth.Token, hostID)
 			if err != nil {
 				zap.S().Fatalf("Failed to detach host from cluster")
 			} else {
@@ -142,7 +142,7 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 
 			//deauthorize host from UI
 			fmt.Println("Deauthorizing node from UI...")
-			err = c.Qbert.DeauthoriseNode(hostID[0], auth.Token)
+			err = c.Qbert.DeauthoriseNode(hostID, auth.Token)
 			if err != nil {
 				zap.S().Fatalf("Failed to deauthorize node")
 			} else {

--- a/pkg/resmgr/resmgr.go
+++ b/pkg/resmgr/resmgr.go
@@ -18,7 +18,7 @@ import (
 type Resmgr interface {
 	AuthorizeHost(hostID, token string, version string) error
 	GetHostId(token string, hostIP []string) []string
-	HostSatus(token string, hostID string) bool
+	HostStatus(token string, hostID string) bool
 }
 
 type ResmgrImpl struct {
@@ -124,7 +124,7 @@ func (c *ResmgrImpl) GetHostId(token string, hostIPs []string) []string {
 	return hostUUIDs
 }
 
-func (c *ResmgrImpl) HostSatus(token string, hostID string) bool {
+func (c *ResmgrImpl) HostStatus(token string, hostID string) bool {
 	url := fmt.Sprintf("%s/resmgr/v1/hosts/%s", c.fqdn, hostID)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -305,7 +305,7 @@ func init() {
 
 // These are the constants needed for everything version related
 const (
-	Version         string = "pf9ctl version: v1.21"
+	Version         string = "pf9ctl version: v1.22"
 	AWSBucketName   string = "pmkft-assets"
 	AWSBucketKey    string = "pf9ctl"
 	AWSBucketRegion string = "us-west-1"


### PR DESCRIPTION
Use host id from conf file to decommission node

## ISSUE(S):
PMK-5776

## SUMMARY
Currently, pf9ctl uses local IP address to identify the host id with resmgr. In customers case he had a RoCE IP that was also tagged for a completely different node on a different cluster in the resmgr. Pf9ctl,
- got list of IPs using hostname -I
- Used the first found IP to fetch hostid from resource manager which turned out to be completely different node from a different cluster
- pf9ctl did not validate the received host detail if it was part of the same cluster or that it was self node
- It initiated a decommision for the received host through resmgr API, causing outage in a completely different cluster

## ISSUE TYPE
- [ ] Bug fix (non-breaking change which fixes an issue)

## IMPACTED FEATURES/COMPONENTS:
pf9ctl
PMK

## TESTING DONE

#### Manual
1) Tested decommission of local node
```
ubuntu@psarwate-public-nodelet01:~$ sudo cat /etc/pf9/host_id.conf
sudo: unable to resolve host psarwate-public-nodelet01: Name or service not known
[hostagent]
host_id = 08fb165f-98e3-439f-b707-eed63c3763e9  << Self node

ubuntu@psarwate-public-nodelet01:~$ pf9ctl decommission-node --verbose
New version found. Please upgrade to the latest version
2023-04-27T15:50:41.6076Z	DEBUG	Loading configuration details. pf9ctl version: pf9ctl version: v1.22
...
2023-04-27T15:50:42.454Z	DEBUG	Ran command sudo "bash" "-c" "grep host_id /etc/pf9/host_id.conf | cut -d '=' -f2"
2023-04-27T15:50:42.4542Z	DEBUG	stdout: 08fb165f-98e3-439f-b707-eed63c3763e9
...
2023-04-27T15:50:42.7199Z	DEBUG	Deauthorising the 08fb165f-98e3-439f-b707-eed63c3763e9 node:
...
Node decommissioning started....This may take a few minutes....Check the latest status in UI
```
2) Tested decommission of remote node
```
ubuntu@psarwate-public-nodelet02:~$ sudo cat /etc/pf9/host_id.conf
[hostagent]
host_id = d339ff18-4b86-460c-9ec7-7e5e937af623 << Remote node

ubuntu@psarwate-public-nodelet01:~$ pf9ctl decommission-node -i 172.20.7.156 -u ubuntu -s ~/.ssh/id_rsa --verbose
New version found. Please upgrade to the latest version
2023-04-27T15:34:35.3621Z	DEBUG	Loading configuration details. pf9ctl version: pf9ctl version: v1.22
...
2023-04-27T15:34:38.1131Z	DEBUG	Running command bash "-c" "grep host_id /etc/pf9/host_id.conf | cut -d '=' -f2"stdout: d339ff18-4b86-460c-9ec7-7e5e937af623
...
2023-04-27T15:34:38.3688Z	DEBUG	Deauthorising the d339ff18-4b86-460c-9ec7-7e5e937af623 node:
...
Node decommissioning started....This may take a few minutes....Check the latest status in UI
```