### PR TITLE
Private/psarwate/master/pmk 5805

### DIFF
--- a/cmd/attachNode.go
+++ b/cmd/attachNode.go
@@ -134,7 +134,10 @@ func attachNodeRun(cmd *cobra.Command, args []string) {
 			fmt.Printf("Attaching node to the cluster %s\n", clusterName)
 			var wokerids []string
 			for _, worker := range workerHostIDs {
-				if cname := c.Qbert.GetNodeInfo(token, projectId, worker); cname.ClusterName != "" {
+				cname, err := c.Qbert.GetNodeInfo(token, projectId, worker)
+				if err != nil {
+					zap.S().Debugf("Failed to get node info for host %s: %s", worker, err.Error())
+				} else if cname.ClusterName != "" {
 					zap.S().Infof("Node with host id %s is connected to %s cluster", worker, cname)
 				} else {
 					wokerids = append(wokerids, worker)
@@ -164,7 +167,10 @@ func attachNodeRun(cmd *cobra.Command, args []string) {
 			fmt.Printf("Attaching node to the cluster %s\n", clusterName)
 			var masterids []string
 			for _, master := range masterHostIDs {
-				if cname := c.Qbert.GetNodeInfo(token, projectId, master); cname.ClusterName != "" {
+				cname, err := c.Qbert.GetNodeInfo(token, projectId, master)
+				if err != nil {
+					zap.S().Debugf("Failed to get node info for host %s: %s", master, err.Error())
+				} else if cname.ClusterName != "" {
 					zap.S().Infof("Node with host id %s is connected to %s cluster", master, cname)
 				} else {
 					masterids = append(masterids, master)

--- a/cmd/detachNode.go
+++ b/cmd/detachNode.go
@@ -102,7 +102,11 @@ func detachNodeRun(cmd *cobra.Command, args []string) {
 
 	for i := range detachNodes {
 
-		isMaster := c.Qbert.GetNodeInfo(token, projectId, nodeUuids[0])
+		isMaster, err := c.Qbert.GetNodeInfo(token, projectId, nodeUuids[0])
+		if err != nil {
+			zap.S().Debugf("Failed to get node info for host %s: %s", nodeUuids[0], err.Error())
+			continue
+		}
 		clusterNodes := getAllClusterNodes(projectNodes, []string{isMaster.ClusterUuid})
 
 		if len(clusterNodes) == 1 || isMaster.IsMaster == 1 {

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -98,7 +98,7 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 					//If hostID is empty then host could be connected to other DU
 					var connected bool
 					if len(id) != 0 {
-						connected = allClients.Resmgr.HostSatus(auth.Token, id[0])
+						connected = allClients.Resmgr.HostStatus(auth.Token, id[0])
 					} else {
 						zap.S().Fatalf("Hostagent is installed on this host, but this host is not part of the DU %s specified in the config", ctx.Fqdn)
 					}

--- a/pkg/pmk/cluster.go
+++ b/pkg/pmk/cluster.go
@@ -71,7 +71,7 @@ func Bootstrap(ctx objects.Config, c client.Client, req qbert.ClusterCreateReque
 
 	LoopVariable := 1
 	for LoopVariable <= util.MaxLoopValue {
-		hostStatus := c.Resmgr.HostSatus(token, nodeID)
+		hostStatus := c.Resmgr.HostStatus(token, nodeID)
 		if !hostStatus {
 			zap.S().Debugf("Host is Down...Trying again")
 		} else {

--- a/pkg/pmk/decomissionNode.go
+++ b/pkg/pmk/decomissionNode.go
@@ -80,16 +80,6 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 		zap.S().Debug("Failed to get keystone %s", err.Error())
 	}
 
-	// Directly use host_id instead of relying on IP to get host details
-	cmd := `grep host_id /etc/pf9/host_id.conf | cut -d '=' -f2`
-	hostID, err := c.Executor.RunWithStdout("bash", "-c", cmd)
-	if err != nil {
-		zap.S().Fatalf("Unable to get host id %s", err.Error())
-	}
-	if len(hostID) == 0 {
-		zap.S().Fatalf("Invalid host id found")
-	}
-	hostID = strings.TrimSpace(hostID)
 	hostOS, err := ValidatePlatform(c.Executor)
 	if err != nil {
 		zap.S().Fatalf("Error getting OS version")
@@ -104,6 +94,13 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 		//check if node is connected to any cluster
 		var nodeInfo qbert.Node
 		var nodeConnectedToDU bool
+		// Directly use host_id instead of relying on IP to get host details
+		cmd := `grep host_id /etc/pf9/host_id.conf | cut -d '=' -f2`
+		hostID, err := c.Executor.RunWithStdout("bash", "-c", cmd)
+		if err != nil {
+			zap.S().Debugf("Unable to get host id %s", err.Error())
+		}
+		hostID = strings.TrimSpace(hostID)
 		if len(hostID) != 0 {
 			nodeConnectedToDU = true
 			nodeInfo, err = c.Qbert.GetNodeInfo(auth.Token, auth.ProjectID, hostID)

--- a/pkg/pmk/decomissionNode.go
+++ b/pkg/pmk/decomissionNode.go
@@ -106,7 +106,10 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 		var nodeConnectedToDU bool
 		if len(hostID) != 0 {
 			nodeConnectedToDU = true
-			nodeInfo = c.Qbert.GetNodeInfo(auth.Token, auth.ProjectID, hostID)
+			nodeInfo, err = c.Qbert.GetNodeInfo(auth.Token, auth.ProjectID, hostID)
+			if err != nil {
+				zap.S().Fatalf("Failed to get node info for host %s: %s", hostID, err.Error())
+			}
 		}
 
 		if nodeInfo.ClusterName == "" {

--- a/pkg/pmk/decomissionNode.go
+++ b/pkg/pmk/decomissionNode.go
@@ -80,20 +80,20 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 		zap.S().Debug("Failed to get keystone %s", err.Error())
 	}
 
-	ip, err := c.Executor.RunWithStdout("bash", "-c", "hostname -I")
-	//Handling case where host can have multiple IPs
-	ip = strings.Split(ip, " ")[0]
-	ip = strings.TrimSpace(ip)
+	// Directly use host_id instead of relying on IP to get host details
+	cmd := `grep host_id /etc/pf9/host_id.conf | cut -d '=' -f2`
+	hostID, err := c.Executor.RunWithStdout("bash", "-c", cmd)
 	if err != nil {
-		zap.S().Fatalf("ERROR : unable to get host ip")
+		zap.S().Fatalf("Unable to get host id %s", err.Error())
 	}
+	if len(hostID) == 0 {
+		zap.S().Fatalf("Invalid host id found")
+	}
+	hostID = strings.TrimSpace(hostID)
 	hostOS, err := ValidatePlatform(c.Executor)
 	if err != nil {
 		zap.S().Fatalf("Error getting OS version")
 	}
-	var nodeIPs []string
-	nodeIPs = append(nodeIPs, ip)
-	hostID := c.Resmgr.GetHostId(auth.Token, nodeIPs)
 	//check if hostagent is installed on host
 	if hostOS == "debian" {
 		_, err = c.Executor.RunWithStdout("bash", "-c", "dpkg -s pf9-hostagent")
@@ -106,13 +106,13 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 		var nodeConnectedToDU bool
 		if len(hostID) != 0 {
 			nodeConnectedToDU = true
-			nodeInfo = c.Qbert.GetNodeInfo(auth.Token, auth.ProjectID, hostID[0])
+			nodeInfo = c.Qbert.GetNodeInfo(auth.Token, auth.ProjectID, hostID)
 		}
 
 		if nodeInfo.ClusterName == "" {
 			fmt.Println("Node is not connected to any cluster")
 			if nodeConnectedToDU {
-				err = c.Qbert.DeauthoriseNode(hostID[0], auth.Token)
+				err = c.Qbert.DeauthoriseNode(hostID, auth.Token)
 				if err != nil {
 					zap.S().Fatalf("Failed to deauthorize node")
 				} else {
@@ -133,7 +133,7 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 			//detach node from cluster
 			fmt.Printf("Node is connected to %s cluster\n", nodeInfo.ClusterName)
 			fmt.Println("Detaching node from cluster...")
-			err = c.Qbert.DetachNode(nodeInfo.ClusterUuid, auth.ProjectID, auth.Token, hostID[0])
+			err = c.Qbert.DetachNode(nodeInfo.ClusterUuid, auth.ProjectID, auth.Token, hostID)
 			if err != nil {
 				zap.S().Fatalf("Failed to detach host from cluster")
 			} else {
@@ -142,7 +142,7 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 
 			//deauthorize host from UI
 			fmt.Println("Deauthorizing node from UI...")
-			err = c.Qbert.DeauthoriseNode(hostID[0], auth.Token)
+			err = c.Qbert.DeauthoriseNode(hostID, auth.Token)
 			if err != nil {
 				zap.S().Fatalf("Failed to deauthorize node")
 			} else {

--- a/pkg/resmgr/resmgr.go
+++ b/pkg/resmgr/resmgr.go
@@ -18,7 +18,7 @@ import (
 type Resmgr interface {
 	AuthorizeHost(hostID, token string, version string) error
 	GetHostId(token string, hostIP []string) []string
-	HostSatus(token string, hostID string) bool
+	HostStatus(token string, hostID string) bool
 }
 
 type ResmgrImpl struct {
@@ -124,7 +124,7 @@ func (c *ResmgrImpl) GetHostId(token string, hostIPs []string) []string {
 	return hostUUIDs
 }
 
-func (c *ResmgrImpl) HostSatus(token string, hostID string) bool {
+func (c *ResmgrImpl) HostStatus(token string, hostID string) bool {
 	url := fmt.Sprintf("%s/resmgr/v1/hosts/%s", c.fqdn, hostID)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -305,7 +305,7 @@ func init() {
 
 // These are the constants needed for everything version related
 const (
-	Version         string = "pf9ctl version: v1.21"
+	Version         string = "pf9ctl version: v1.22"
 	AWSBucketName   string = "pmkft-assets"
 	AWSBucketKey    string = "pf9ctl"
 	AWSBucketRegion string = "us-west-1"


### PR DESCRIPTION
## ISSUE(S):
[PMK-5805
](https://platform9.atlassian.net/browse/PMK-5790)
## SUMMARY
Extension of PR : https://github.com/platform9/pf9ctl/pull/348
Host id is more reliable than trying to fetch host information from resmgr/qbert using local IP. For customer usecase both hostname and IP can be duplicated across clusters.

## ISSUE TYPE

- [ ] Bug fix (non-breaking change which fixes an issue)

## IMPACTED FEATURES/COMPONENTS:
pf9ctl

## RELATED ISSUE(S):
https://platform9.atlassian.net/browse/PMK-5776

## DEPENDS ON:
<!--- Links to related PRs if any -->
<!--- delete section if not relevant -->

## TESTING DONE
1) pf9ctl prep-node and pf9cl decommission-node
2) Tested for partial install use case using instrumented binary
3) Tested by deleting host_id.conf file
4) Tested running back to back prep-node 
5) Tested pf9ctl prep-node --skip-connected