### PR TITLE
JIRA: PMK-5805

### DIFF
--- a/pkg/pmk/decomissionNode.go
+++ b/pkg/pmk/decomissionNode.go
@@ -80,16 +80,6 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 		zap.S().Debug("Failed to get keystone %s", err.Error())
 	}
 
-	// Directly use host_id instead of relying on IP to get host details
-	cmd := `grep host_id /etc/pf9/host_id.conf | cut -d '=' -f2`
-	hostID, err := c.Executor.RunWithStdout("bash", "-c", cmd)
-	if err != nil {
-		zap.S().Fatalf("Unable to get host id %s", err.Error())
-	}
-	if len(hostID) == 0 {
-		zap.S().Fatalf("Invalid host id found")
-	}
-	hostID = strings.TrimSpace(hostID)
 	hostOS, err := ValidatePlatform(c.Executor)
 	if err != nil {
 		zap.S().Fatalf("Error getting OS version")
@@ -104,6 +94,13 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 		//check if node is connected to any cluster
 		var nodeInfo qbert.Node
 		var nodeConnectedToDU bool
+		// Directly use host_id instead of relying on IP to get host details
+		cmd := `grep host_id /etc/pf9/host_id.conf | cut -d '=' -f2`
+		hostID, err := c.Executor.RunWithStdout("bash", "-c", cmd)
+		if err != nil {
+			zap.S().Debugf("Unable to get host id %s", err.Error())
+		}
+		hostID = strings.TrimSpace(hostID)
 		if len(hostID) != 0 {
 			nodeConnectedToDU = true
 			nodeInfo, err = c.Qbert.GetNodeInfo(auth.Token, auth.ProjectID, hostID)


### PR DESCRIPTION
Allow decommission for partial installation of hostagent Similar fix implemented in prep-node

## ISSUE(S):
[PMK-5805
](https://platform9.atlassian.net/browse/PMK-5790)

## SUMMARY
Extension of PR : https://github.com/platform9/pf9ctl/pull/348
Host id is more reliable than trying to fetch host information from resmgr/qbert using local IP. For customer usecase both hostname and IP can be duplicated across clusters.

## ISSUE TYPE

- [ ] Bug fix (non-breaking change which fixes an issue)

## IMPACTED FEATURES/COMPONENTS:
pf9ctl

## RELATED ISSUE(S):
https://platform9.atlassian.net/browse/PMK-5776


## TESTING DONE
1) pf9ctl prep-node and pf9cl decommission-node
2) Tested for partial install use case using instrumented binary
3) Tested by deleting host_id.conf file
4) Tested running back to back prep-node 
5) Tested pf9ctl prep-node --skip-connected
6) Tested decommission when node is still reconciling. Decommission correctly fails.