### PR TITLE
PMK-5674 Adding support for Rocky Linux 9

### DIFF
--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -313,7 +313,7 @@ func (c *CentOS) Version() (string, error) {
 			return "redhat", nil
 		}
 	}
-	if match, _ := regexp.MatchString(`.*7\.[3-9]\.*|.*8\.[5-7]\.*`, string(version)); match {
+	if match, _ := regexp.MatchString(`.*7\.[3-9]\.*|.*8\.[5-7]\.*|.*9\.1\.*`, string(version)); match {
 		return "redhat", nil
 	}
 	return "", fmt.Errorf("Unable to determine OS type: %s", string(version))

--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -295,7 +295,7 @@ func (c *CentOS) Version() (string, error) {
 	//using cut command required field (7.6.1810) is selected.
 	var cmd string
 
-	_, err := c.exec.RunWithStdout("bash", "-c", "grep -i 'centos' /etc/*release")
+	_, err := c.exec.RunWithStdout("bash", "-c", "grep -i 'CentOS Linux' /etc/*release")
 	if err != nil {
 		cmd = fmt.Sprintf("grep -oP '(?<=^VERSION_ID=).+' /etc/os-release")
 	} else {

--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -132,15 +132,22 @@ func (c *CentOS) checkOSPackages() (bool, error) {
 	zap.S().Debug("Checking OS Packages")
 
 	rhel8, _ := regexp.MatchString(`.*8\.[5-7]\.*`, string(version))
+	rocky9, _ := regexp.MatchString(`.*9\.1\.*`, string(version))
 	for _, p := range packages {
-		if !centos && rhel8 {
+		if !centos && (rhel8 || rocky9) {
 			switch p {
 			case "policycoreutils-python":
-				p = "python3-policycoreutils"
+				if rhel8 {
+					p = "python3-policycoreutils"
+				} else if rocky9 {
+					p = "policycoreutils-python-utils"
+				}
+
 			case "ntp":
 				p = "chrony"
 			}
 		}
+
 		err := c.exec.Run("bash", "-c", fmt.Sprintf("yum list installed %s", p))
 		if err != nil {
 			zap.S().Debug("Installing missing packages, this may take a few minutes")

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -65,7 +65,7 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 	case "redhat":
 		platform = centos.NewCentOS(allClients.Executor)
 	default:
-		return RequiredFail, fmt.Errorf("This OS is not supported. Supported operating systems are: Ubuntu (18.04, 20.04, 22.04), CentOS 7.[3-9], RHEL 7.[3-9] & RHEL 8.[5-7]")
+		return RequiredFail, fmt.Errorf("This OS is not supported. Supported operating systems are: Ubuntu (18.04, 20.04, 22.04), CentOS 7.[3-9], RHEL 7.[3-9] & RHEL 8.[5-7] & Rocky 9.1")
 	}
 
 	if err = allClients.Segment.SendEvent("Starting CheckNode", auth, checkPass, ""); err != nil {

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -365,7 +365,7 @@ func ValidatePlatform(exec cmdexec.Executor) (string, error) {
 	}
 	var platform platform.Platform
 	switch {
-	case strings.Contains(strData, util.Centos) || strings.Contains(strData, util.Redhat):
+	case strings.Contains(strData, util.Centos) || strings.Contains(strData, util.Redhat) || strings.Contains(strData, util.Rocky):
 		platform = centos.NewCentOS(exec)
 		osVersion, err := platform.Version()
 		if err == nil {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -83,6 +83,7 @@ var (
 	Centos         = "centos"
 	Redhat         = "red hat"
 	Ubuntu         = "ubuntu"
+	Rocky          = "rocky"
 	CertsExpireErr = "certificate has expired or is not yet valid"
 
 	//Pf9Dir is the base pf9dir


### PR DESCRIPTION
## ISSUE(S):
[PMK-5674](https://platform9.atlassian.net/browse/PMK-5674)

## SUMMARY
Added support for Rocky Linux 9.1. 

## ISSUE TYPE
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## TESTING DONE
#### Automated

#### Manual

Was able to onboard Rocky 9.1 node to the DU and create 1.25 cluster with the node, all addons are installed and are healthy.
Didn't see any errors in hostagent/nodelet logs. Was able to delete the cluster. 

<img width="1157" alt="image" src="https://github.com/platform9/pf9-kube/assets/98585473/5d6f26ca-6c81-41f5-8ea1-c1caadc83062">

`Addons`:

<img width="920" alt="image" src="https://github.com/platform9/pf9-kube/assets/98585473/032b9d3a-b7b9-4130-829c-16779c3a2e14">

<!--- The most relevant reviewers will be assigned automatically -->
<!--- Add specific reviewers by appending their github usernames after "/cc" (Use whitespace as separator, not commas) -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME @REVIEWER2_GITHUB_USERNAME ... -->

<!--- do-not-merge/hold label gives you power to control when the PR should be automatically merged -->
<!--- apply by uncommenting the line below -->
<!--- /hold -->
<!--- This label can be removed via comment -->
<!--- remove by commenting /hold cancel -->


[PMK-5674]: https://platform9.atlassian.net/browse/PMK-5674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ