### PR TITLE
PMK-5848 Adding a check to enable required repositories

### DIFF
--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -193,9 +193,7 @@ func (c *CentOS) checkEnabledRepos() (bool, error) {
 		if !strings.Contains(string(output), "extras/") {
 			enable_repos = append(enable_repos, "extras")
 		}
-	}
-
-	if rhel8 {
+	} else if rhel8 {
 		command = "subscription-manager repos --enable %s"
 		if !strings.Contains(string(output), "BaseOS") {
 			enable_repos = append(enable_repos, "rhel-8-for-x86_64-baseos-rpms")


### PR DESCRIPTION
## ISSUE(S):
[PMK-5848](https://platform9.atlassian.net/browse/PMK-5848)

## SUMMARY
Some required repositories can be disabled by default. Checking if they are enabled, and if not, enabling them. Since this was observed for RHEL 8.5, added the check for redhat based distributions.

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [x] New feature (non-breaking change which adds functionality)

## IMPACTED FEATURES/COMPONENTS:
pf9ctl

## TESTING DONE
#### Manual
pf9ctl prep-node --verbose, logs:
-> Tested onboarding RHEL 8.5 node
In case repositories are enabled
```
Running pre-requisite checks and installing any missing OS packages 2023-06-21T21:11:24.9581Z	DEBUG	Ran command sudo "bash" "-c" "yum repolist"
2023-06-21T21:11:24.9582Z	DEBUG	stdout:Updating Subscription Management repositories.
repo id                          repo name
epel                             Extra Packages for Enterprise Linux 8 - x86_64
rhel-8-for-x86_64-appstream-rpms Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
rhel-8-for-x86_64-baseos-rpms    Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
stderr:
2023-06-21T21:11:24.9582Z	DEBUG	Required repositories are enabled
```

In case repositories are not enabled
```
Running pre-requisite checks and installing any missing OS packages 2023-06-21T20:35:37.2599Z	DEBUG	Ran command sudo "bash" "-c" "yum repolist"
2023-06-21T20:35:37.26Z	DEBUG	stdout:Updating Subscription Management repositories.
repo id              repo name
epel                 Extra Packages for Enterprise Linux 8 - x86_64
stderr:
| Running pre-requisite checks and installing any missing OS packages 2023-06-21T20:35:51.5129Z	DEBUG	Ran command sudo "bash" "-c" subscription-manager repos --enable rhel-8-for-x86_64-baseos-rpms
- Running pre-requisite checks and installing any missing OS packages 2023-06-21T20:36:08.9756Z	DEBUG	Ran command sudo "bash" "-c" subscription-manager repos --enable rhel-8-for-x86_64-appstream-rpms

```

```
2023-06-21T20:36:09.3099Z	DEBUG	Sending Segment Event: CheckNode: Required OS Packages Check
✓ Required OS Packages Check
2023-06-21T20:36:09.3099Z	DEBUG	OVF Service not present
2023-06-21T20:36:09.3099Z	DEBUG	Sending Segment Event: CheckNode: SudoCheck
✓ SudoCheck
2023-06-21T20:36:09.31Z	DEBUG	OVF Service not present
2023-06-21T20:36:09.31Z	DEBUG	Sending Segment Event: CheckNode: Required Enabled Repositories Check
✓ Required Enabled Repositories Check
2023-06-21T20:36:09.3101Z	DEBUG	OVF Service not present
2023-06-21T20:36:09.3101Z	DEBUG	Sending Segment Event: CheckNode: CPUCheck
✓ CPUCheck
2023-06-21T20:36:09.3101Z	DEBUG	OVF Service not present
2023-06-21T20:36:09.3102Z	DEBUG	Sending Segment Event: CheckNode: DiskCheck
```

-> Tested onboarding centos 7 node, 
In case repositories are enabled:
```
Running pre-requisite checks and installing any missing OS packages 2023-06-21T20:49:17.7636Z	DEBUG	Ran command sudo "bash" "-c" "yum repolist"
2023-06-21T20:49:17.7638Z	DEBUG	stdout:Loaded plugins: fastestmirror
Determining fastest mirrors
 * base: opencolo.mm.fcix.net
 * epel: mirror.tornadovps.com
 * extras: centos.mirror.shastacoe.net
 * updates: ridgewireless.mm.fcix.net
repo id               repo name                                           status
base/7/x86_64         CentOS-7 - Base                                     10072
epel/x86_64           Extra Packages for Enterprise Linux 7 - x86_64      13765
extras/7/x86_64       CentOS-7 - Extras                                     515
updates/7/x86_64      CentOS-7 - Updates                                   4996
repolist: 29348
stderr:
2023-06-21T20:49:17.7638Z	DEBUG	Required repositories are enabled
```
In case repositories are not enabled
```
 Running pre-requisite checks and installing any missing OS packages 2023-06-21T20:52:51.8185Z	DEBUG	Ran command sudo "bash" "-c" "yum repolist"
2023-06-21T20:52:51.8186Z	DEBUG	stdout:Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * epel: mirror.tornadovps.com
 * updates: ridgewireless.mm.fcix.net
repo id               repo name                                           status
epel/x86_64           Extra Packages for Enterprise Linux 7 - x86_64      13765
updates/7/x86_64      CentOS-7 - Updates                                   4996
repolist: 18761
stderr:
/ Running pre-requisite checks and installing any missing OS packages 2023-06-21T20:52:52.1194Z	DEBUG	Ran command sudo "bash" "-c" yum-config-manager --enable base
| Running pre-requisite checks and installing any missing OS packages 2023-06-21T20:52:52.4385Z	DEBUG	Ran command sudo "bash" "-c" yum-config-manager --enable extras
2023-06-21T20:52:52.4387Z	DEBUG	Required repositories are enabled
```

```
✓ SudoCheck
2023-06-21T20:52:52.8032Z	DEBUG	OVF Service not present
2023-06-21T20:52:52.8032Z	DEBUG	Sending Segment Event: CheckNode: Required Enabled Repositories Check
✓ Required Enabled Repositories Check
2023-06-21T20:52:52.8034Z	DEBUG	OVF Service not present
2023-06-21T20:52:52.8035Z	DEBUG	Sending Segment Event: CheckNode: CPUCheck
✓ CPUCheck
2023-06-21T20:52:52.8036Z	DEBUG	OVF Service not present
2023-06-21T20:52:52.8037Z	DEBUG	Sending Segment Event: CheckNode: DiskCheck
```
Manually checked in both cases if the required repositories were enabled.


[PMK-5848]: https://platform9.atlassian.net/browse/PMK-5848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ