### PR TITLE
PMK-5887 Adding support for Rocky 9.2

### DIFF
--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -135,7 +135,7 @@ func (c *CentOS) checkOSPackages() (bool, error) {
 	zap.S().Debug("Checking OS Packages")
 
 	rhel8, _ := regexp.MatchString(`.*8\.[5-7]\.*`, string(version))
-	rocky9, _ := regexp.MatchString(`.*9\.1\.*`, string(version))
+	rocky9, _ := regexp.MatchString(`.*9\.[1-2]\.*`, string(version))
 	for _, p := range packages {
 		if !centos && (rhel8 || rocky9) {
 			switch p {
@@ -367,7 +367,7 @@ func (c *CentOS) Version() (string, error) {
 			return "redhat", nil
 		}
 	}
-	if match, _ := regexp.MatchString(`.*7\.[3-9]\.*|.*8\.[5-7]\.*|.*9\.1\.*`, string(version)); match {
+	if match, _ := regexp.MatchString(`.*7\.[3-9]\.*|.*8\.[5-7]\.*|.*9\.[1-2]\.*`, string(version)); match {
 		return "redhat", nil
 	}
 	return "", fmt.Errorf("Unable to determine OS type: %s", string(version))

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -65,7 +65,7 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 	case "redhat":
 		platform = centos.NewCentOS(allClients.Executor)
 	default:
-		return RequiredFail, fmt.Errorf("This OS is not supported. Supported operating systems are: Ubuntu (18.04, 20.04, 22.04), CentOS 7.[3-9], RHEL 7.[3-9] & RHEL 8.[5-7] & Rocky 9.1")
+		return RequiredFail, fmt.Errorf("This OS is not supported. Supported operating systems are: Ubuntu (18.04, 20.04, 22.04), CentOS 7.[3-9], RHEL 7.[3-9] & RHEL 8.[5-7] & Rocky 9.[1-2]")
 	}
 
 	if err = allClients.Segment.SendEvent("Starting CheckNode", auth, checkPass, ""); err != nil {


### PR DESCRIPTION
## ISSUE(S):
[PMK-5887](https://platform9.atlassian.net/browse/PMK-5887)

## SUMMARY
<!--- Describe the change below -->
Adding support for Rocky 9.2

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [x] New feature (non-breaking change which adds functionality)

## IMPACTED FEATURES/COMPONENTS:
pf9ctl

## TESTING DONE
#### Manual
Was able to onboard Rocky 9.2 node with `pf9ctl prep-node`. Was further able to create a 1.25 cluster as well.
<img width="1161" alt="image" src="https://github.com/platform9/pf9-kube/assets/98585473/9d81b383-9362-48ff-a6a6-19b6cd93f6e7">



[PMK-5887]: https://platform9.atlassian.net/browse/PMK-5887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ