### PR TITLE
exit if node is attached to cluster and ask to run detach-node

### DIFF
--- a/pkg/pmk/decomissionNode.go
+++ b/pkg/pmk/decomissionNode.go
@@ -132,6 +132,7 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 		} else {
 			//detach node from cluster
 			fmt.Printf("Node is connected to %s cluster\n", nodeInfo.ClusterName)
+			zap.S().Fatalf("Please run detach-node command first and wait for node to completely remove from cluster and then run decommision-node command")
 			fmt.Println("Detaching node from cluster...")
 			err = c.Qbert.DetachNode(nodeInfo.ClusterUuid, auth.ProjectID, auth.Token, hostID)
 			if err != nil {

--- a/pkg/pmk/decomissionNode.go
+++ b/pkg/pmk/decomissionNode.go
@@ -130,10 +130,15 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 			fmt.Println("Node decommissioning started....This may take a few minutes....Check the latest status in UI")
 			time.Sleep(50 * time.Second)
 		} else {
-			//detach node from cluster
+			// If node is connected to cluster exit, because need to redesign detach and deauthorize flows
 			fmt.Printf("Node is connected to %s cluster\n", nodeInfo.ClusterName)
-			zap.S().Fatalf("Please run detach-node command first and wait for node to completely remove from cluster and then run decommision-node command")
-			fmt.Println("Detaching node from cluster...")
+			zap.S().Fatalf("Node is still attached to a cluster. Please run detach-node command first and wait for the node to be completely removed from the cluster and only then run decommision-node command")
+
+			//This code will not be called since we are exiting if node is attached to cluster
+			//TODO : https://platform9.atlassian.net/browse/PMK-5938 https://platform9.atlassian.net/browse/PMK-5784
+
+			//detach node from cluster
+			/*fmt.Println("Detaching node from cluster...")
 			err = c.Qbert.DetachNode(nodeInfo.ClusterUuid, auth.ProjectID, auth.Token, hostID)
 			if err != nil {
 				zap.S().Fatalf("Failed to detach host from cluster")
@@ -156,7 +161,7 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 				removePf9Installation(c)
 			}
 			fmt.Println("Node decommissioning started....This may take a few minutes....Check the latest status in UI")
-			time.Sleep(50 * time.Second)
+			time.Sleep(50 * time.Second)*/
 		}
 	} else {
 		fmt.Println("Host is not connected to Platform9 Management Plane")


### PR DESCRIPTION
## ISSUE(S):
<!--- Links to JIRA tickets -->
<!--- [FT-XXXX](link.to/FT-XXXX): Subject of FT-XXXX -->

## SUMMARY
<!--- Describe the change below -->

<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## IMPACTED FEATURES/COMPONENTS:
<!--- List of impacted features/components due to this change -->
<!--- delete section if not relevant -->
decommission-node

## TESTING DONE
#### Manual
<!--- Please list down various use case which were part of manual testing. -->
**Ran decommisssion-node on node which is attached to cluster**
```
root@test-pf9-bare-os-u20-2793249-610-2:~/pf9/bin# pf9ctl decommission-node
New version found. Please upgrade to the latest version
✓ Loaded Config Successfully
Node is connected to vgi-docker-testclus cluster
2023-08-16T05:12:29.2157Z	FATAL	Please run detach-node command first and wait for node to completely remove from cluster and then run decommision-node command
```
#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->
/cc @psarwate @sudhakarg @NeelavaChatterjee 