### PR TITLE
Bump attach node retry attempts

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -50,7 +50,7 @@ const (
 	// Counter variable max value
 	MaxLoopValue = 3
 	//Attach Status Loop variable
-	MaxRetryValue = 6
+	MaxRetryValue = 18
 
 	CheckPass       = "PASS"
 	CheckFail       = "FAIL"


### PR DESCRIPTION
Previously we would try 6 times which is about 3 mins with the 30 secs sleep between retries. However, this may not be long enough because after a prep-node, the host goes through a kube role install and till that completes an attach won't be successful. If users try to do the attach as soon as prep-node completes (say through automation), the 3 minute may not be sufficient time for the attach to succeed. Changing it to about 9 mins which should be a very conservative estimate.

