### PR TITLE
[PMK-5833] Making pf9ctl idempotent

### DIFF
--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -42,7 +42,7 @@ func (c *CentOS) Check() []platform.Check {
 	checks = append(checks, platform.Check{"Removal of existing CLI", false, result, err, util.PyCliErr})
 
 	result, err = c.CheckExistingInstallation()
-	checks = append(checks, platform.Check{"Existing Platform9 Packages Check", true, result, err, util.ExisitngInstallationErr})
+	checks = append(checks, platform.Check{"Existing Platform9 Packages Check", false, result, err, util.ExisitngInstallationErr})
 
 	result, err = c.checkOSPackages()
 	checks = append(checks, platform.Check{"Required OS Packages Check", true, result, err, fmt.Sprintf("%s. %s", util.OSPackagesErr, err)})
@@ -63,10 +63,10 @@ func (c *CentOS) Check() []platform.Check {
 	checks = append(checks, platform.Check{"MemoryCheck", false, result, err, fmt.Sprintf("%s %s", util.MemErr, err)})
 
 	result, err = c.checkPort()
-	checks = append(checks, platform.Check{"PortCheck", true, result, err, fmt.Sprintf("%s", err)})
+	checks = append(checks, platform.Check{"PortCheck", false, result, err, fmt.Sprintf("%s", err)})
 
 	result, err = c.CheckKubernetesCluster()
-	checks = append(checks, platform.Check{"Existing Kubernetes Cluster Check", true, result, err, fmt.Sprintf("%s", err)})
+	checks = append(checks, platform.Check{"Existing Kubernetes Cluster Check", false, result, err, fmt.Sprintf("%s", err)})
 
 	result, err = c.checkPIDofSystemd()
 	checks = append(checks, platform.Check{"Check if system is booted with systemd", true, result, err, fmt.Sprintf("%s", err)})

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -39,7 +39,7 @@ func (d *Debian) Check() []platform.Check {
 	checks = append(checks, platform.Check{"Removal of existing CLI", false, result, err, util.PyCliErr})
 
 	result, err = d.CheckExistingInstallation()
-	checks = append(checks, platform.Check{"Existing Platform9 Packages Check", true, result, err, util.ExisitngInstallationErr})
+	checks = append(checks, platform.Check{"Existing Platform9 Packages Check", false, result, err, util.ExisitngInstallationErr})
 
 	result, err = d.checkOSPackages()
 	checks = append(checks, platform.Check{"Required OS Packages Check", true, result, err, fmt.Sprintf("%s. %s", util.OSPackagesErr, err)})
@@ -57,10 +57,10 @@ func (d *Debian) Check() []platform.Check {
 	checks = append(checks, platform.Check{"MemoryCheck", false, result, err, fmt.Sprintf("%s %s", util.MemErr, err)})
 
 	result, err = d.checkPort()
-	checks = append(checks, platform.Check{"PortCheck", true, result, err, fmt.Sprintf("%s", err)})
+	checks = append(checks, platform.Check{"PortCheck", false, result, err, fmt.Sprintf("%s", err)})
 
 	result, err = d.CheckKubernetesCluster()
-	checks = append(checks, platform.Check{"Existing Kubernetes Cluster Check", true, result, err, fmt.Sprintf("%s", err)})
+	checks = append(checks, platform.Check{"Existing Kubernetes Cluster Check", false, result, err, fmt.Sprintf("%s", err)})
 
 	result, err = d.CheckIfdpkgISLock()
 	checks = append(checks, platform.Check{"Check lock on dpkg", true, result, err, fmt.Sprintf("%s", err)})

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -181,7 +181,7 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 			return CleanInstallFail, nil
 		}
 
-		return RequiredFail, nil
+		return OptionalFail, nil
 
 	}
 

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -170,19 +170,19 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 
 	removeCurrentInstallation := ""
 	if !cleanInstallCheck {
-		fmt.Println(color.Yellow("\nPrevious installation found"))
-		if !nc.RemoveExistingPkgs {
-			fmt.Println(color.Yellow("Reinstall Required..."))
-			fmt.Print("Remove Current Installation Type ('yes'/'no'):")
-			fmt.Scanf("%s", &removeCurrentInstallation)
+		if !WarningOptionalChecks {
+			fmt.Println(color.Yellow("\nPrevious installation found"))
+			if !nc.RemoveExistingPkgs {
+				fmt.Println(color.Yellow("Reinstall Required..."))
+				fmt.Print("Remove Current Installation Type ('yes'/'no'):")
+				fmt.Scanf("%s", &removeCurrentInstallation)
+			}
+			if nc.RemoveExistingPkgs || strings.ToLower(removeCurrentInstallation) == "yes" {
+				DecommissionNode(&ctx, nc, false)
+				return CleanInstallFail, nil
+			}
 		}
-		if nc.RemoveExistingPkgs || strings.ToLower(removeCurrentInstallation) == "yes" {
-			DecommissionNode(&ctx, nc, false)
-			return CleanInstallFail, nil
-		}
-
 		return OptionalFail, nil
-
 	}
 
 	if !mandatoryCheck {

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -99,45 +99,43 @@ func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.Keysto
 			return fmt.Errorf("Dpkg is under lock")
 		}
 	}
-	if !WarningOptionalChecks {
-		packagesPresent, newPackagesPresent, errStr := pf9PackagesPresent(hostOS, allClients.Executor, auth.Token, ctx.Fqdn)
-		if errStr != nil {
-			return fmt.Errorf("error while checking pf9 packages: %w", errStr)
-		}
-		//pf9ctl errors out if old packages are present
-		if packagesPresent && !newPackagesPresent {
-			errStr := "\n\nOld Platform9 packages already present on the host." +
-				"\nPlease uninstall these packages if you want to prep the node again.\n" +
-				"Instructions to uninstall these are at:" +
-				"\nhttps://docs.platform9.com/kubernetes/pmk-cli-unistall-hostagent"
-			sendSegmentEvent(allClients, "Error: Platform9 packages already present.", auth, true)
+
+	packagesPresent, newPackagesPresent, errStr := pf9PackagesPresent(hostOS, allClients.Executor, auth.Token, ctx.Fqdn)
+	if errStr != nil {
+		return fmt.Errorf("error while checking pf9 packages: %w", errStr)
+	}
+	//pf9ctl errors out if old packages are present
+	if packagesPresent && !newPackagesPresent {
+		errStr := "\n\nOld Platform9 packages already present on the host." +
+			"\nPlease uninstall these packages if you want to prep the node again.\n" +
+			"Instructions to uninstall these are at:" +
+			"\nhttps://docs.platform9.com/kubernetes/pmk-cli-unistall-hostagent"
+		sendSegmentEvent(allClients, "Error: Platform9 packages already present.", auth, true)
+		return fmt.Errorf(errStr)
+	}
+
+	//If new packages are not present, download and install them
+	if !newPackagesPresent {
+		sendSegmentEvent(allClients, "Installing hostagent - 2", auth, false)
+		s.Suffix = " Downloading the Hostagent (this might take a few minutes...)"
+		if err := installHostAgent(ctx, auth, hostOS, allClients.Executor); err != nil {
+			errStr := "Error: Unable to install hostagent. " + err.Error()
+			sendSegmentEvent(allClients, errStr, auth, true)
 			return fmt.Errorf(errStr)
 		}
 
-		//If new packages are not present, download and install them
-		if !newPackagesPresent {
-			sendSegmentEvent(allClients, "Installing hostagent - 2", auth, false)
-			s.Suffix = " Downloading the Hostagent (this might take a few minutes...)"
-			if err := installHostAgent(ctx, auth, hostOS, allClients.Executor); err != nil {
-				errStr := "Error: Unable to install hostagent. " + err.Error()
-				sendSegmentEvent(allClients, errStr, auth, true)
-				return fmt.Errorf(errStr)
-			}
+		s.Suffix = " Platform9 packages installed successfully"
 
+		if HostAgent == HostAgentCertless {
 			s.Suffix = " Platform9 packages installed successfully"
-
-			if HostAgent == HostAgentCertless {
-				s.Suffix = " Platform9 packages installed successfully"
-				s.Stop()
-				fmt.Println(color.Green("✓ ") + "Platform9 packages installed successfully")
-			} else if HostAgent == HostAgentLegacy {
-				s.Suffix = " Hostagent installed successfully"
-				s.Stop()
-				fmt.Println(color.Green("✓ ") + "Hostagent installed successfully")
-			}
-			s.Restart()
+			s.Stop()
+			fmt.Println(color.Green("✓ ") + "Platform9 packages installed successfully")
+		} else if HostAgent == HostAgentLegacy {
+			s.Suffix = " Hostagent installed successfully"
+			s.Stop()
+			fmt.Println(color.Green("✓ ") + "Hostagent installed successfully")
 		}
-
+		s.Restart()
 	}
 
 	sendSegmentEvent(allClients, "Initialising host - 3", auth, false)

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -429,6 +429,7 @@ func pf9PackagesPresent(hostOS string, exec cmdexec.Executor, token string, fqdn
 	}
 
 	if !packagesPresent {
+		zap.S().Infof("Pf9 packages are not present")
 		return false, false, nil
 	}
 	//If pkgs are present, check version

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -26,6 +26,7 @@ import (
 var HostAgent int
 var IsRemoteExecutor bool
 var homeDir string
+var isCDU bool
 
 const (
 	// Response Status Codes
@@ -61,6 +62,7 @@ func sendSegmentEvent(allClients client.Client, eventStr string, auth keystone.K
 // PrepNode sets up prerequisites for k8s stack
 func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.KeystoneAuth) error {
 	// Building our new spinner
+	isCDU = false
 	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 	s.Color("red")
 
@@ -105,7 +107,7 @@ func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.Keysto
 		return fmt.Errorf("error while checking pf9 packages: %w", errStr)
 	}
 	//pf9ctl errors out if old packages are present
-	if packagesPresent && !newPackagesPresent {
+	if packagesPresent && (!newPackagesPresent || isCDU) {
 		errStr := "\n\nOld Platform9 packages already present on the host." +
 			"\nPlease uninstall these packages if you want to prep the node again.\n" +
 			"Instructions to uninstall these are at:" +
@@ -441,7 +443,11 @@ func pf9PackagesPresent(hostOS string, exec cmdexec.Executor, token string, fqdn
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return true, false, fmt.Errorf("error: List packages request returned status code: %d", resp.StatusCode)
+			if resp.StatusCode == 302 {
+				isCDU = true
+				return true, false, nil
+			}
+			return true, false, fmt.Errorf("Error: List packages request returned status code: %d", resp.StatusCode)
 		}
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -99,14 +99,13 @@ func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.Keysto
 		}
 	}
 
-	zap.S().Debug("BEFORE ANY PACKAGE CHECK STARTS")
-	token := auth.Token
-	fqdn := ctx.Fqdn
-	packagesPresent, newPackagesPresent := pf9PackagesPresent(hostOS, allClients.Executor, token, fqdn)
+	packagesPresent, newPackagesPresent, errStr := pf9PackagesPresent(hostOS, allClients.Executor, auth.Token, ctx.Fqdn)
+	if errStr != nil {
+		return fmt.Errorf("error while checking pf9 packages: %w", errStr)
+	}
 	//pf9ctl errors out if old packages are present
-	zap.S().Debugf("Values of packagesPresent, newPackagesPresent ", packagesPresent, newPackagesPresent)
 	if packagesPresent && !newPackagesPresent {
-		errStr := "\n\nPlatform9 packages already present on the host." +
+		errStr := "\n\nOld Platform9 packages already present on the host." +
 			"\nPlease uninstall these packages if you want to prep the node again.\n" +
 			"Instructions to uninstall these are at:" +
 			"\nhttps://docs.platform9.com/kubernetes/pmk-cli-unistall-hostagent"
@@ -403,7 +402,7 @@ func OpenOSReleaseFile(exec cmdexec.Executor) (string, error) {
 	return strings.ToLower(string(data)), nil
 }
 
-func pf9PackagesPresent(hostOS string, exec cmdexec.Executor, token string, fqdn string) (bool, bool) {
+func pf9PackagesPresent(hostOS string, exec cmdexec.Executor, token string, fqdn string) (bool, bool, error) {
 	var packagesPresent, newPackagesPresent bool = false, false
 
 	pattern := `-(\d+\.\d+\.\d+-\d+)`
@@ -419,25 +418,23 @@ func pf9PackagesPresent(hostOS string, exec cmdexec.Executor, token string, fqdn
 		}
 		//check version of existing pkgs, if present
 		if packagesPresent {
-			zap.S().Debug("Packages present")
 			cmd := fmt.Sprintf(`curl --retry 5 --show-error  -f -H "X-Auth-Token: %s" "%s/protected/nocert-packagelist.deb"`, token, fqdn)
 			out, err := exec.RunWithStdout("bash", "-c", cmd)
 			if err != nil {
-				zap.S().Debugf("error while listing packages: %s", err)
+				return packagesPresent, newPackagesPresent, fmt.Errorf("error in running curl command to list packages")
 			}
 			lines := strings.Split(string(out), "\n")
 			for _, line := range lines {
-				//lineStr := string(line)
-				zap.S().Debug("lineStr ", line)
 				if strings.Contains(line, ".deb") {
 					match := reg.FindStringSubmatch(line)
-					zap.S().Debug("version extracted", match[1])
-					cmd := fmt.Sprintf("dpkg -l | { grep -i '%s' || true; }", match[1]) //len(match) check karna hai
+					if len(match) <= 1 {
+						return packagesPresent, newPackagesPresent, fmt.Errorf("error in extracting version from packages")
+					}
+					cmd := fmt.Sprintf("dpkg -l | { grep -i '%s' || true; }", match[1])
 					out, _ = exec.RunWithStdout("bash", "-c", cmd)
 					if out != "" {
-						zap.S().Debug("Output of version check", out)
 						newPackagesPresent = true
-						return packagesPresent, true
+						return packagesPresent, true, nil
 					}
 				}
 			}
@@ -454,29 +451,30 @@ func pf9PackagesPresent(hostOS string, exec cmdexec.Executor, token string, fqdn
 			}
 		}
 		if packagesPresent {
-			cmd := fmt.Sprintf(`curl --retry 5 --show-error  -f -H "X-Auth-Token: %s" "https://%s/protected/nocert-packagelist.rpm"`, token, fqdn)
+			cmd := fmt.Sprintf(`curl --retry 5 --show-error  -f -H "X-Auth-Token: %s" "%s/protected/nocert-packagelist.rpm"`, token, fqdn)
 			out, err := exec.RunWithStdout("bash", "-c", cmd)
 			if err != nil {
-				fmt.Errorf("error while listing packages: %s", err)
+				return packagesPresent, newPackagesPresent, fmt.Errorf("error in running curl command to list packages")
 			}
-			for _, line := range out {
-				lineStr := string(line)
-				fmt.Println("lineStr ", lineStr)
-				if strings.Contains(lineStr, ".rpm") {
-					match := reg.FindStringSubmatch(lineStr)
-					fmt.Println("version ", match[1])
-					cmd := fmt.Sprintf("yum list installed | { grep -i '%s' || true; }", match[1]) //len(match) check karna hai
+			lines := strings.Split(string(out), "\n")
+			for _, line := range lines {
+				if strings.Contains(line, ".rpm") {
+					match := reg.FindStringSubmatch(line)
+					if len(match) <= 1 {
+						return packagesPresent, newPackagesPresent, fmt.Errorf("error in extracting version from packages")
+					}
+					cmd := fmt.Sprintf("yum list installed | { grep -i '%s' || true; }", match[1])
 					out, _ = exec.RunWithStdout("bash", "-c", cmd)
 					if out != "" {
 						newPackagesPresent = true
-						return packagesPresent, true
+						return packagesPresent, true, nil
 					}
 				}
 			}
 		}
 	}
 
-	return packagesPresent, newPackagesPresent
+	return packagesPresent, newPackagesPresent, nil
 }
 
 func installHostAgentLegacy(ctx objects.Config, regionURL string, auth keystone.KeystoneAuth, hostOS string, exec cmdexec.Executor) error {


### PR DESCRIPTION
## ISSUE(S):
[PMK-5833](https://platform9.atlassian.net/browse/PMK-5833)

## SUMMARY
Addressing pf9 packages cleanup issue: When retrying prep-node, even if the needed packages are already installed, pf9ctl breaks and asks to uninstall pf9 pkgs

Currently I've kept `Existing pkgs check` as optional, and edited pf9PackagesPresent function such that it compares the version of pf9 pkgs installed on node to needed versions, and if they're the same, prep-node continues with the other steps. If version is not same as needed, pf9ctl breaks.

So the flow for prep-node will be:
```
checknode runs -> this also runs existing pkgs check(optional) -> asks for uninstalling existing pkgs if found -> If I say no to uninstall, prep-node can still continue since it's optional check now -> pf9PackagesPresent(called from function prepNode) checks for version of the packages, if they are old pf9ctl breaks, if they're new pf9ctl skips download& install of pf9 pkgs and continues with other steps
```


<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [ ] Bug fix (non-breaking change which fixes an issue)


## IMPACTED FEATURES/COMPONENTS:
pf9ctl

## TESTING DONE

#### Manual
1. Tested on **ubuntu** 22.04 machine. After running prep-node once on the node, re-ran it again for the same DU (packages already present use case), verbose logs:
```
Previous installation found
Reinstall Required...
Remove Current Installation Type ('yes'/'no'):no

Optional pre-requisite check(s) failed. Do you want to continue? (y/n) y
2024-04-24T05:21:47.0124Z	DEBUG	Received a call to start preparing node(s).
2024-04-24T05:21:47.0125Z	DEBUG	OVF Service not present
2024-04-24T05:21:47.0126Z	DEBUG	Sending Segment Event: Prep-node : Starting prep-node
| 2024-04-24T05:21:47.0126Z	DEBUG	Received a call to validate platform
2024-04-24T05:21:47.0361Z	DEBUG	Ran command sudo "cat" "/etc/os-release"
2024-04-24T05:21:47.0362Z	DEBUG	stdout:PRETTY_NAME="Ubuntu 22.04.2 LTS"
...

2024-04-26T13:33:26.8449Z	DEBUG	Stopping unattended-upgrades
- Starting prep-node 2024-04-26T13:33:26.8997Z	DEBUG	Ran command sudo "bash" "-c" "systemctl stop unattended-upgrades"
2024-04-26T13:33:26.8998Z	DEBUG	stdout:stderr:
2024-04-26T13:33:26.8998Z	DEBUG	Stopped unattended-upgrades
2024-04-26T13:33:26.8998Z	DEBUG	Checking if unattended-upgrades is enabled
2024-04-26T13:33:26.9337Z	DEBUG	Ran command sudo "bash" "-c" "systemctl is-enabled unattended-upgrades"
2024-04-26T13:33:26.9337Z	DEBUG	stdout:enabled
stderr:
2024-04-26T13:33:26.9338Z	DEBUG	Disabling unattended-upgrades
| Starting prep-node 2024-04-26T13:33:52.003Z	DEBUG	Ran command sudo "bash" "-c" "systemctl disable unattended-upgrades"
2024-04-26T13:33:52.0031Z	DEBUG	stdout:stderr:
2024-04-26T13:33:52.0031Z	DEBUG	Disabled unattended-upgrades
/ Starting prep-node 2024-04-26T13:33:52.0581Z	DEBUG	Ran command sudo "bash" "-c" "dpkg -l | { grep -i 'pf9-hostagent' || true; }"
2024-04-26T13:33:52.0581Z	DEBUG	stdout:ii  pf9-hostagent                    5.9.3-1524.21c37c7                      all          Platform9 host agent
stderr:
\ Starting prep-node 2024-04-26T13:33:52.7376Z	DEBUG	Ran command sudo "bash" "-c" "dpkg -l | { grep -i 'hostagent.*5.9.3-1524' || true; }"
2024-04-26T13:33:52.7377Z	DEBUG	stdout:ii  pf9-hostagent                    5.9.3-1524.21c37c7                      all          Platform9 host agent
stderr:
2024-04-26T13:33:52.7378Z	DEBUG	OVF Service not present
2024-04-26T13:33:52.7378Z	DEBUG	Sending Segment Event: Prep-node : Initialising host - 3
2024-04-26T13:33:52.7379Z	DEBUG	Initialising host
2024-04-26T13:33:52.7379Z	DEBUG	Identifying the hostID from conf
| Initialising host 2024-04-26T13:33:52.7694Z	DEBUG	Ran command sudo "bash" "-c" "grep host_id /etc/pf9/host_id.conf | cut -d '=' -f2"
2024-04-26T13:33:52.7695Z	DEBUG	stdout: 2fd3d0ea-5636-4e6a-8feb-2a3727fb1cef
stderr:
✓ Initialised host successfully
2024-04-26T13:33:52.7696Z	DEBUG	Initialised host successfully
2024-04-26T13:33:52.7697Z	DEBUG	Authorising host
- Authorising host 2024-04-26T13:34:52.7707Z	DEBUG	Authorizing the host: 2fd3d0ea-5636-4e6a-8feb-2a3727fb1cef with DU: https://test-du-bare-os-u20-3196727.platform9.horse
2024-04-26T13:34:52.7711Z	DEBUG	performing request%!(EXTRA []interface {}=[method PUT url https://test-du-bare-os-u20-3196727.platform9.horse/resmgr/v1/hosts/2fd3d0ea-5636-4e6a-8feb-2a3727fb1cef/roles/pf9-kube])
| Authorising host 2024-04-26T13:34:53.0455Z	DEBUG	Host successfully attached to the Platform9 control-plane
2024-04-26T13:34:53.0456Z	DEBUG	OVF Service not present
2024-04-26T13:34:53.0456Z	DEBUG	Sending Segment Event: Prep-node : Successful
✓ Host successfully attached to the Platform9 control-plane
2024-04-26T13:34:53.0457Z	DEBUG	Enabling unattended-upgrades
2024-04-26T13:35:17.1703Z	DEBUG	Ran command sudo "bash" "-c" "systemctl enable unattended-upgrades"
2024-04-26T13:35:17.1704Z	DEBUG	stdout:stderr:
2024-04-26T13:35:17.1705Z	DEBUG	Enabled unattended-upgrades
2024-04-26T13:35:17.1705Z	DEBUG	Start unattended-upgrades
2024-04-26T13:35:17.2159Z	DEBUG	Ran command sudo "bash" "-c" "systemctl start unattended-upgrades"
2024-04-26T13:35:17.216Z	DEBUG	stdout:stderr:
2024-04-26T13:35:17.216Z	DEBUG	Started unattended-upgrades
2024-04-26T13:35:17.216Z	DEBUG	==========Finished running prep-node==========
```
As visible in logs, we don't see any issue with `Initialising host` and `Authorising host` step even if the node is already onboarded to the needed DU & authorized.
2. Tested on **centos** vm, re-ran prep-node on an already authorised host for the same DU (packages alreay present use case)
```
Previous installation found
Reinstall Required...
Remove Current Installation Type ('yes'/'no'):no

Optional pre-requisite check(s) failed. Do you want to continue? (y/n) y
2024-04-25T09:47:29.7155Z	DEBUG	Received a call to start preparing node(s).
2024-04-25T09:47:29.7157Z	DEBUG	OVF Service not present
...
2024-04-26T13:39:40.7293Z	DEBUG	Ran command sudo "bash" "-c" "cat /etc/*release | grep 'CentOS Linux release' -m 1 | cut -f4 -d ' '"
2024-04-26T13:39:40.7294Z	DEBUG	stdout:7.9.2009
stderr:
- Starting prep-node 2024-04-26T13:39:41.2905Z	DEBUG	Ran command sudo "bash" "-c" "yum list installed | { grep -i 'pf9-hostagent' || true; }"
2024-04-26T13:39:41.2906Z	DEBUG	stdout:pf9-hostagent.x86_64                  5.9.3-1524.21c37c7            @/pf9-hostagent-5.9.3-1524.21c37c7.x86_64
stderr:
- Starting prep-node 2024-04-26T13:39:42.1319Z	DEBUG	Ran command sudo "bash" "-c" "yum list installed | { grep -i 'hostagent.*5.9.3-1524' || true; }"
2024-04-26T13:39:42.132Z	DEBUG	stdout:pf9-hostagent.x86_64                  5.9.3-1524.21c37c7            @/pf9-hostagent-5.9.3-1524.21c37c7.x86_64
stderr:
2024-04-26T13:39:42.132Z	DEBUG	OVF Service not present
2024-04-26T13:39:42.132Z	DEBUG	Sending Segment Event: Prep-node : Initialising host - 3
2024-04-26T13:39:42.132Z	DEBUG	Initialising host
2024-04-26T13:39:42.1321Z	DEBUG	Identifying the hostID from conf
2024-04-26T13:39:42.1492Z	DEBUG	Ran command sudo "bash" "-c" "grep host_id /etc/pf9/host_id.conf | cut -d '=' -f2"
2024-04-26T13:39:42.1493Z	DEBUG	stdout: 5e78be33-ba8f-445b-b5ae-3ab289d5ca19
stderr:
✓ Initialised host successfully
2024-04-26T13:39:42.1493Z	DEBUG	Initialised host successfully
2024-04-26T13:39:42.1493Z	DEBUG	Authorising host
| Authorising host 2024-04-26T13:40:42.1502Z	DEBUG	Authorizing the host: 5e78be33-ba8f-445b-b5ae-3ab289d5ca19 with DU: https://test-du-bare-os-u20-3196727.platform9.horse
2024-04-26T13:40:42.1507Z	DEBUG	performing request%!(EXTRA []interface {}=[method PUT url https://test-du-bare-os-u20-3196727.platform9.horse/resmgr/v1/hosts/5e78be33-ba8f-445b-b5ae-3ab289d5ca19/roles/pf9-kube])
\ Authorising host 2024-04-26T13:40:42.4615Z	DEBUG	Host successfully attached to the Platform9 control-plane
2024-04-26T13:40:42.4616Z	DEBUG	OVF Service not present
2024-04-26T13:40:42.4617Z	DEBUG	Sending Segment Event: Prep-node : Successful
✓ Host successfully attached to the Platform9 control-plane
2024-04-26T13:40:42.4618Z	DEBUG	==========Finished running prep-node==========
```
3. When node is onboarded to a DU, and trying to onboard to a different DU (old pkgs are present use case):
```
Previous installation found
Reinstall Required...
Remove Current Installation Type ('yes'/'no'):no

Optional pre-requisite check(s) failed. Do you want to continue? (y/n) y
2024-04-25T10:57:01.5729Z	DEBUG	Received a call to start preparing node(s).
...

/ Starting prep-node 2024-04-25T10:57:02.1479Z	DEBUG	Ran command sudo "bash" "-c" "yum list installed | { grep -i 'pf9-hostagent' || true; }"
2024-04-25T10:57:02.148Z	DEBUG	stdout:pf9-hostagent.x86_64                  5.9.3-1524.21c37c7            @/pf9-hostagent-5.9.3-1524.21c37c7.x86_64
stderr:
| Starting prep-node 2024-04-25T10:57:02.4317Z	DEBUG	Ran command sudo "bash" "-c" "curl --retry 5 --show-error  -f -H "X-Auth-Token: gAAAAABmKjbyhGh9N8K_Jj6EWnxu00Np3Nv54Ngc4S5pPW8bvwy_TLOm9ExJkMLnxEaMzztrkNZ1jhk_LNU62h2Y9rsf-pmZ6qT-SP0WBHA4MfWOoMzxUecRXf8vFTDcL6CjKxqk809OtYXCwYGw6MyCi42DigDRo8YW_kF4W5bR9sG1AAt4U6Q" "https://test-du-bare-os-u20-2770839.platform9.horse/protected/nocert-packagelist.rpm""
2024-04-25T10:57:02.4318Z	DEBUG	stdout:etc/pf9/certs/hostagent/cert.pem
etc/pf9/certs/hostagent/key.pem
etc/pf9/certs/ca/cert.pem
etc/pf9/hostagent.conf
pf9-hostagent-5.10.0-1234.c60cab3.x86_64.rpm
pf9-comms-5.10.0-1164.99bd9ba.x86_64.rpm
stderr:
/ Starting prep-node 2024-04-25T10:57:02.9549Z	DEBUG	Ran command sudo "bash" "-c" "yum list installed | { grep -i '5.10.0-1234' || true; }"
2024-04-25T10:57:02.955Z	DEBUG	stdout:stderr:
- Starting prep-node 2024-04-25T10:57:03.4666Z	DEBUG	Ran command sudo "bash" "-c" "yum list installed | { grep -i '5.10.0-1164' || true; }"
2024-04-25T10:57:03.4667Z	DEBUG	stdout:stderr:
2024-04-25T10:57:03.4667Z	DEBUG	OVF Service not present
...
2024-04-25T10:57:04.4708Z	DEBUG	OVF Service not present
2024-04-25T10:57:04.4708Z	DEBUG	Sending Segment Event: supportBundle upload Success
2024-04-25T10:57:04.4709Z	DEBUG	Unable to send Segment event for supportBundle. Error: the client was already closed
2024-04-25T10:57:04.4894Z	DEBUG	Unable to prep node: 

Old Platform9 packages already present on the host.
Please uninstall these packages if you want to prep the node again.
Instructions to uninstall these are at:
https://docs.platform9.com/kubernetes/pmk-cli-unistall-hostagent

2024-04-25T10:57:04.4895Z	FATAL	
Failed to prepare node. See /root/pf9/log/pf9ctl-20240425.log or use --verbose for logs
```


[PMK-5833]: https://platform9.atlassian.net/browse/PMK-5833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ