### PR TITLE
[PMK-6396] Addressing issue of pf9ctl failing silently

### DIFF
--- a/cmd/attachNode.go
+++ b/cmd/attachNode.go
@@ -107,15 +107,10 @@ func attachNodeRun(cmd *cobra.Command, args []string) {
 		} else if clusterName == "" {
 			zap.S().Fatalf("cluster with given uuid does not exist")
 		}
-	} else {
-		_, clusterUuid, _, err = c.Qbert.CheckClusterExists(clusterName, projectId, token)
-		if err != nil {
-			zap.S().Fatalf("unable to fetch clusterUuid from cluster-name. Error: %s", err.Error())
-		}
 	}
-	_, _, clusterStatus, err := c.Qbert.CheckClusterExists(clusterName, projectId, token)
+	_, clusterUuid, clusterStatus, err := c.Qbert.CheckClusterExists(clusterName, projectId, token)
 	if err != nil {
-		zap.S().Fatalf("unable to fetch cluster status from cluster-name. Error: %s", err.Error())
+		zap.S().Fatalf("unable to fetch cluster-uuid and cluster-status from cluster-name. Error: %s", err.Error())
 	}
 
 	if clusterStatus == "ok" {

--- a/cmd/attachNode.go
+++ b/cmd/attachNode.go
@@ -97,7 +97,7 @@ func attachNodeRun(cmd *cobra.Command, args []string) {
 
 	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken)
 	if err != nil {
-		zap.S().Debug("Failed to get keystone %s", err.Error())
+		zap.S().Fatalf("Failed to get keystone %s", err.Error())
 	}
 	projectId := auth.ProjectID
 	token := auth.Token
@@ -108,9 +108,15 @@ func attachNodeRun(cmd *cobra.Command, args []string) {
 			zap.S().Fatalf("cluster with given uuid does not exist")
 		}
 	} else {
-		_, clusterUuid, _, _ = c.Qbert.CheckClusterExists(clusterName, projectId, token)
+		_, clusterUuid, _, err = c.Qbert.CheckClusterExists(clusterName, projectId, token)
+		if err != nil {
+			zap.S().Fatalf("unable to fetch clusterUuid from cluster-name. Error: %s", err.Error())
+		}
 	}
-	_, _, clusterStatus, _ := c.Qbert.CheckClusterExists(clusterName, projectId, token)
+	_, _, clusterStatus, err := c.Qbert.CheckClusterExists(clusterName, projectId, token)
+	if err != nil {
+		zap.S().Fatalf("unable to fetch cluster status from cluster-name. Error: %s", err.Error())
+	}
 
 	if clusterStatus == "ok" {
 
@@ -136,7 +142,7 @@ func attachNodeRun(cmd *cobra.Command, args []string) {
 			for _, worker := range workerHostIDs {
 				cname, err := c.Qbert.GetNodeInfo(token, projectId, worker)
 				if err != nil {
-					zap.S().Debugf("Failed to get node info for host %s: %s", worker, err.Error())
+					zap.S().Fatalf("Failed to get node info for host %s: %s", worker, err.Error())
 				} else if cname.ClusterName != "" {
 					zap.S().Infof("Node with host id %s is connected to %s cluster", worker, cname)
 				} else {
@@ -150,7 +156,7 @@ func attachNodeRun(cmd *cobra.Command, args []string) {
 					if err := c.Segment.SendEvent("Attaching-node", auth, "Failed to attach worker node", ""); err != nil {
 						zap.S().Debugf("Unable to send Segment event for attach node. Error: %s", err.Error())
 					}
-					zap.S().Info("Encountered an error while attaching worker node to a Kubernetes cluster : ", err1)
+					zap.S().Fatal("Encountered an error while attaching worker node to a Kubernetes cluster : ", err1)
 				} else {
 					if err := c.Segment.SendEvent("Attaching-node", auth, "Worker node attached", ""); err != nil {
 						zap.S().Debugf("Unable to send Segment event for attach node. Error: %s", err.Error())
@@ -169,7 +175,7 @@ func attachNodeRun(cmd *cobra.Command, args []string) {
 			for _, master := range masterHostIDs {
 				cname, err := c.Qbert.GetNodeInfo(token, projectId, master)
 				if err != nil {
-					zap.S().Debugf("Failed to get node info for host %s: %s", master, err.Error())
+					zap.S().Fatalf("Failed to get node info for host %s: %s", master, err.Error())
 				} else if cname.ClusterName != "" {
 					zap.S().Infof("Node with host id %s is connected to %s cluster", master, cname)
 				} else {
@@ -183,7 +189,7 @@ func attachNodeRun(cmd *cobra.Command, args []string) {
 					if err := c.Segment.SendEvent("Attaching-node", auth, "Failed to attach master node", ""); err != nil {
 						zap.S().Debugf("Unable to send Segment event for attach node. Error: %s", err.Error())
 					}
-					zap.S().Info("Encountered an error while attaching master node to a Kubernetes cluster : ", err1)
+					zap.S().Fatal("Encountered an error while attaching master node to a Kubernetes cluster : ", err1)
 				} else {
 					if err := c.Segment.SendEvent("Attaching-node", auth, "Master node attached", ""); err != nil {
 						zap.S().Debugf("Unable to send Segment event for attach node. Error: %s", err.Error())

--- a/cmd/authoriseNode.go
+++ b/cmd/authoriseNode.go
@@ -70,7 +70,7 @@ func authNodeRun(cmd *cobra.Command, args []string) {
 
 	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken)
 	if err != nil {
-		zap.S().Debug("Failed to get keystone %s", err.Error())
+		zap.S().Fatalf("Failed to get keystone %s", err.Error())
 	}
 
 	var nodeIPs []string

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -444,7 +444,7 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 		}
 
 		zap.S().Debugf("Unable to bootstrap node: %s\n", err.Error())
-		zap.S().Fatalf("Failed to bootstrap node, error: %s. See %s or use --verbose for logs\n", err.Error(), log.GetLogLocation(util.Pf9Log))
+		zap.S().Fatalf("Failed to bootstrap node. %s. See %s or use --verbose for logs\n", err.Error(), log.GetLogLocation(util.Pf9Log))
 	}
 	zap.S().Debug("==========Finished running bootstrap==========")
 }

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -368,7 +368,7 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 			}
 
 			zap.S().Debugf("Unable to prep node: %s\n", err.Error())
-			zap.S().Fatalf("\nFailed to prepare node, error: %s. See %s or use --verbose for logs\n", err.Error(), log.GetLogLocation(util.Pf9Log))
+			zap.S().Fatalf("\nFailed to prepare node. %s. See %s or use --verbose for logs\n", err.Error(), log.GetLogLocation(util.Pf9Log))
 		}
 
 		zap.S().Debug("==========Finished running prep-node==========")

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -256,6 +256,9 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 		cfg.Tenant,
 		cfg.MfaToken,
 	)
+	if err != nil {
+		zap.S().Fatalf("Unable to fetch keystone token: %s", err.Error())
+	}
 
 	//Getting all pmk versions
 	pmkRoles := c.Qbert.GetPMKVersions(auth.Token, auth.ProjectID)
@@ -365,7 +368,7 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 			}
 
 			zap.S().Debugf("Unable to prep node: %s\n", err.Error())
-			zap.S().Fatalf("\nFailed to prepare node. See %s or use --verbose for logs\n", log.GetLogLocation(util.Pf9Log))
+			zap.S().Fatalf("\nFailed to prepare node, error: %s. See %s or use --verbose for logs\n", err.Error(), log.GetLogLocation(util.Pf9Log))
 		}
 
 		zap.S().Debug("==========Finished running prep-node==========")
@@ -441,7 +444,7 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 		}
 
 		zap.S().Debugf("Unable to bootstrap node: %s\n", err.Error())
-		zap.S().Fatalf("Failed to bootstrap node. See %s or use --verbose for logs\n", log.GetLogLocation(util.Pf9Log))
+		zap.S().Fatalf("Failed to bootstrap node, error: %s. See %s or use --verbose for logs\n", err.Error(), log.GetLogLocation(util.Pf9Log))
 	}
 	zap.S().Debug("==========Finished running bootstrap==========")
 }

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -257,7 +257,7 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 		cfg.MfaToken,
 	)
 	if err != nil {
-		zap.S().Fatalf("Unable to fetch keystone token: %s", err.Error())
+		zap.S().Fatalf("Failed to get keystone %s", err.Error())
 	}
 
 	//Getting all pmk versions

--- a/cmd/deauthoriseNode.go
+++ b/cmd/deauthoriseNode.go
@@ -69,7 +69,7 @@ func deauthNodeRun(cmd *cobra.Command, args []string) {
 
 	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken)
 	if err != nil {
-		zap.S().Debugf("Failed to get keystone %s", err.Error())
+		zap.S().Fatalf("Failed to get keystone %s", err.Error())
 	}
 
 	var nodeIPs []string

--- a/cmd/deleteCluster.go
+++ b/cmd/deleteCluster.go
@@ -89,7 +89,7 @@ func deleteClusterRun(cmd *cobra.Command, args []string) {
 		_, clusterUuid, _, err = c.Qbert.CheckClusterExists(clusterName, projectId, token)
 
 		if err != nil {
-			zap.S().Fatalf("Could not delete the cluster")
+			zap.S().Fatalf("Could not delete the cluster, error while fetching cluster uuid: %s", err.Error())
 		}
 
 	}
@@ -99,6 +99,9 @@ func deleteClusterRun(cmd *cobra.Command, args []string) {
 	projectNodes := c.Qbert.GetAllNodes(token, projectId)
 	nodeUuids := c.Resmgr.GetHostId(token, nodeIPs)
 	localNode, err := getNodesFromUuids(nodeUuids, projectNodes)
+	if err != nil {
+		zap.S().Fatalf("Could not delete cluster, error %s", err.Error())
+	}
 
 	if len(localNode) == 1 && localNode[0].ClusterUuid == clusterUuid {
 		c.Executor.RunCommandWait("sudo pkill -9 `pidof kubelet`")

--- a/cmd/deleteCluster.go
+++ b/cmd/deleteCluster.go
@@ -79,7 +79,7 @@ func deleteClusterRun(cmd *cobra.Command, args []string) {
 
 	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken)
 	if err != nil {
-		zap.S().Debug("Failed to get keystone %s", err.Error())
+		zap.S().Fatalf("Failed to get keystone %s", err.Error())
 	}
 
 	projectId := auth.ProjectID

--- a/cmd/deleteCluster.go
+++ b/cmd/deleteCluster.go
@@ -100,7 +100,7 @@ func deleteClusterRun(cmd *cobra.Command, args []string) {
 	nodeUuids := c.Resmgr.GetHostId(token, nodeIPs)
 	localNode, err := getNodesFromUuids(nodeUuids, projectNodes)
 	if err != nil {
-		zap.S().Fatalf("Could not delete cluster, error %s", err.Error())
+		zap.S().Fatalf("Could not delete cluster, error while fetch nodes info: %s", err.Error())
 	}
 
 	if len(localNode) == 1 && localNode[0].ClusterUuid == clusterUuid {

--- a/cmd/detachNode.go
+++ b/cmd/detachNode.go
@@ -83,10 +83,6 @@ func detachNodeRun(cmd *cobra.Command, args []string) {
 
 	projectNodes := c.Qbert.GetAllNodes(token, projectId)
 	nodeUuids := c.Resmgr.GetHostId(token, nodeIPs)
-	if err != nil {
-		zap.S().Fatalf("%v", err)
-		return
-	}
 
 	detachNodes, err := getNodesFromUuids(nodeUuids, projectNodes)
 

--- a/cmd/detachNode.go
+++ b/cmd/detachNode.go
@@ -76,7 +76,7 @@ func detachNodeRun(cmd *cobra.Command, args []string) {
 
 	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken)
 	if err != nil {
-		zap.S().Debug("Failed to get keystone %s", err.Error())
+		zap.S().Fatalf("Failed to get keystone %s", err.Error())
 	}
 	projectId := auth.ProjectID
 	token := auth.Token
@@ -104,8 +104,8 @@ func detachNodeRun(cmd *cobra.Command, args []string) {
 
 		isMaster, err := c.Qbert.GetNodeInfo(token, projectId, nodeUuids[0])
 		if err != nil {
-			zap.S().Debugf("Failed to get node info for host %s: %s", nodeUuids[0], err.Error())
-			continue
+			zap.S().Fatalf("Failed to get node info for host %s: %s", nodeUuids[0], err.Error())
+			//continue
 		}
 		clusterNodes := getAllClusterNodes(projectNodes, []string{isMaster.ClusterUuid})
 
@@ -119,7 +119,7 @@ func detachNodeRun(cmd *cobra.Command, args []string) {
 			if err := c.Segment.SendEvent("Detaching-node", auth, "Failed to detach node", ""); err != nil {
 				zap.S().Debugf("Unable to send Segment event for detach node. Error: %s", err.Error())
 			}
-			zap.S().Info("Encountered an error while detaching the", detachNodes[i].PrimaryIp, " node from a Kubernetes cluster : ", err1)
+			zap.S().Fatalf("Encountered an error while detaching the", detachNodes[i].PrimaryIp, " node from a Kubernetes cluster : ", err1)
 		} else {
 			if err := c.Segment.SendEvent("Detaching-node", detachNodes[i].PrimaryIp, "Node detached", ""); err != nil {
 				zap.S().Debugf("Unable to send Segment event for detach node. Error: %s", err.Error())

--- a/cmd/detachNode.go
+++ b/cmd/detachNode.go
@@ -119,7 +119,7 @@ func detachNodeRun(cmd *cobra.Command, args []string) {
 			if err := c.Segment.SendEvent("Detaching-node", auth, "Failed to detach node", ""); err != nil {
 				zap.S().Debugf("Unable to send Segment event for detach node. Error: %s", err.Error())
 			}
-			zap.S().Fatalf("Encountered an error while detaching the", detachNodes[i].PrimaryIp, " node from a Kubernetes cluster : ", err1)
+			zap.S().Fatal("Encountered an error while detaching the", detachNodes[i].PrimaryIp, " node from a Kubernetes cluster : ", err1)
 		} else {
 			if err := c.Segment.SendEvent("Detaching-node", detachNodes[i].PrimaryIp, "Node detached", ""); err != nil {
 				zap.S().Debugf("Unable to send Segment event for detach node. Error: %s", err.Error())

--- a/cmd/detachNode.go
+++ b/cmd/detachNode.go
@@ -115,7 +115,7 @@ func detachNodeRun(cmd *cobra.Command, args []string) {
 			if err := c.Segment.SendEvent("Detaching-node", auth, "Failed to detach node", ""); err != nil {
 				zap.S().Debugf("Unable to send Segment event for detach node. Error: %s", err.Error())
 			}
-			zap.S().Fatal("Encountered an error while detaching the", detachNodes[i].PrimaryIp, " node from a Kubernetes cluster : ", err1)
+			zap.S().Fatalf("Encountered an error while detaching the %s node from a Kubernetes cluster : %s", detachNodes[i].PrimaryIp, err1)
 		} else {
 			if err := c.Segment.SendEvent("Detaching-node", detachNodes[i].PrimaryIp, "Node detached", ""); err != nil {
 				zap.S().Debugf("Unable to send Segment event for detach node. Error: %s", err.Error())

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -182,7 +182,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 		}
 
 		zap.S().Debugf("Unable to prep node: %s\n", err.Error())
-		zap.S().Fatalf("\nFailed to prepare node, error: %s. See %s or use --verbose for logs\n", err.Error(), log.GetLogLocation(util.Pf9Log))
+		zap.S().Fatalf("\nFailed to prepare node. %s. See %s or use --verbose for logs\n", err.Error(), log.GetLogLocation(util.Pf9Log))
 	}
 
 	zap.S().Debug("==========Finished running prep-node==========")

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -182,7 +182,7 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 		}
 
 		zap.S().Debugf("Unable to prep node: %s\n", err.Error())
-		zap.S().Fatalf("\nFailed to prepare node. See %s or use --verbose for logs\n", log.GetLogLocation(util.Pf9Log))
+		zap.S().Fatalf("\nFailed to prepare node, error: %s. See %s or use --verbose for logs\n", err.Error(), log.GetLogLocation(util.Pf9Log))
 	}
 
 	zap.S().Debug("==========Finished running prep-node==========")

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -371,7 +371,7 @@ func ValidatePlatform(exec cmdexec.Executor) (string, error) {
 		if err == nil {
 			return osVersion, nil
 		} else {
-			zap.S().Debugf("Error : %s", err)
+			return "", fmt.Errorf("error in fetching version: %s", err.Error())
 		}
 	case strings.Contains(strData, util.Ubuntu):
 		platform = debian.NewDebian(exec)
@@ -379,7 +379,7 @@ func ValidatePlatform(exec cmdexec.Executor) (string, error) {
 		if err == nil {
 			return osVersion, nil
 		} else {
-			zap.S().Debugf("Error : %s", err)
+			return "", fmt.Errorf("error in fetching version: %s", err.Error())
 		}
 	}
 

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -371,7 +371,7 @@ func ValidatePlatform(exec cmdexec.Executor) (string, error) {
 		if err == nil {
 			return osVersion, nil
 		} else {
-			return "", fmt.Errorf("error in fetching version: %s", err.Error())
+			return "", fmt.Errorf("error in fetching OS version: %s", err.Error())
 		}
 	case strings.Contains(strData, util.Ubuntu):
 		platform = debian.NewDebian(exec)
@@ -379,7 +379,7 @@ func ValidatePlatform(exec cmdexec.Executor) (string, error) {
 		if err == nil {
 			return osVersion, nil
 		} else {
-			return "", fmt.Errorf("error in fetching version: %s", err.Error())
+			return "", fmt.Errorf("error in fetching OS version: %s", err.Error())
 		}
 	}
 

--- a/pkg/qbert/qbert.go
+++ b/pkg/qbert/qbert.go
@@ -639,7 +639,7 @@ func (c QbertImpl) GetPMKVersions(token, projectID string) PMKVersions {
 	pmkVersions := PMKVersions{}
 	err = json.Unmarshal(body, &pmkVersions)
 	if err != nil {
-		zap.S().Fatalf("Unable to unmarshal resp body: %w", err)
+		zap.S().Infof("Unable to unmarshal resp body: %w", err)
 	}
 	return pmkVersions
 }

--- a/pkg/qbert/qbert.go
+++ b/pkg/qbert/qbert.go
@@ -612,7 +612,7 @@ func (c QbertImpl) GetAllNodes(token, projectID string) []Node {
 	}
 	err = json.Unmarshal(body, &nodes)
 	if err != nil {
-		zap.S().Fatalf("Unable to unmarshal node info: %w", err)
+		zap.S().Infof("Unable to unmarshal node info: %w", err)
 	}
 	return nodes
 }

--- a/pkg/qbert/qbert.go
+++ b/pkg/qbert/qbert.go
@@ -602,17 +602,17 @@ func (c QbertImpl) GetAllNodes(token, projectID string) []Node {
 	client := http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		zap.S().Infof("Unable to send request to qbert: %w", err)
+		zap.S().Fatalf("Unable to send request to qbert: %w", err)
 	}
 
 	var nodes []Node
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		zap.S().Infof("Unable to read resp body of node info: %w", err)
+		zap.S().Fatalf("Unable to read resp body of node info: %w", err)
 	}
 	err = json.Unmarshal(body, &nodes)
 	if err != nil {
-		zap.S().Infof("Unable to unmarshal node info: %w", err)
+		zap.S().Fatalf("Unable to unmarshal node info: %w", err)
 	}
 	return nodes
 }
@@ -621,25 +621,25 @@ func (c QbertImpl) GetPMKVersions(token, projectID string) PMKVersions {
 	url := fmt.Sprintf("%s/qbert/v4/%s/clusters/supportedRoleVersions", c.fqdn, projectID)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		zap.S().Infof("Unable to create request to get pmk versions: %w", err)
+		zap.S().Fatalf("Unable to create request to get pmk versions: %w", err)
 	}
 	req.Header.Set("X-Auth-Token", token)
 	req.Header.Set("Content-Type", "application/json")
 	client := http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		zap.S().Infof("Unable to send request to qbert: %w", err)
+		zap.S().Fatalf("Unable to send request to qbert: %w", err)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		zap.S().Infof("Unable to read resp body: %w", err)
+		zap.S().Fatalf("Unable to read resp body: %w", err)
 	}
 
 	pmkVersions := PMKVersions{}
 	err = json.Unmarshal(body, &pmkVersions)
 	if err != nil {
-		zap.S().Infof("Unable to unmarshal resp body: %w", err)
+		zap.S().Fatalf("Unable to unmarshal resp body: %w", err)
 	}
 	return pmkVersions
 }

--- a/pkg/qbert/qbert.go
+++ b/pkg/qbert/qbert.go
@@ -612,7 +612,7 @@ func (c QbertImpl) GetAllNodes(token, projectID string) []Node {
 	}
 	err = json.Unmarshal(body, &nodes)
 	if err != nil {
-		zap.S().Infof("Unable to unmarshal node info: %w", err)
+		zap.S().Debugf("Unable to unmarshal node info: %w", err)
 	}
 	return nodes
 }
@@ -639,7 +639,7 @@ func (c QbertImpl) GetPMKVersions(token, projectID string) PMKVersions {
 	pmkVersions := PMKVersions{}
 	err = json.Unmarshal(body, &pmkVersions)
 	if err != nil {
-		zap.S().Infof("Unable to unmarshal resp body: %w", err)
+		zap.S().Debugf("Unable to unmarshal resp body: %w", err)
 	}
 	return pmkVersions
 }

--- a/pkg/resmgr/resmgr.go
+++ b/pkg/resmgr/resmgr.go
@@ -107,7 +107,7 @@ func (c *ResmgrImpl) GetHostId(token string, hostIPs []string) []string {
 	nodeData := hostInfo{}
 	err = json.Unmarshal(body, &nodeData)
 	if err != nil {
-		zap.S().Fatalf("Unable to unmarshal resp body to struct: %w", err)
+		zap.S().Infof("Unable to unmarshal resp body to struct: %w", err)
 	}
 	var hostUUIDs []string
 
@@ -155,7 +155,7 @@ func (c *ResmgrImpl) HostStatus(token string, hostID string) bool {
 	host := hostInfo{}
 	err = json.Unmarshal(body, &host)
 	if err != nil {
-		zap.S().Fatalf("Unable to unmarshal resp body to struct: %w", err)
+		zap.S().Infof("Unable to unmarshal resp body to struct: %w", err)
 	}
 	return host.Info.Responding
 }

--- a/pkg/resmgr/resmgr.go
+++ b/pkg/resmgr/resmgr.go
@@ -78,9 +78,9 @@ func (c *ResmgrImpl) AuthorizeHost(hostID string, token string, version string) 
 	if resp.StatusCode != 200 {
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("Unable to authorize host, code: %d. Unable to read response body", resp.StatusCode)
+			return fmt.Errorf("Url %s returned status code: %d. Unable to read response body", url, resp.StatusCode)
 		}
-		return fmt.Errorf("Unable to authorize host, code: %d, error: %s", resp.StatusCode, string(bodyBytes))
+		return fmt.Errorf("Url %s returned status code: %d, error: %s", url, resp.StatusCode, string(bodyBytes))
 	}
 
 	return nil

--- a/pkg/resmgr/resmgr.go
+++ b/pkg/resmgr/resmgr.go
@@ -107,7 +107,7 @@ func (c *ResmgrImpl) GetHostId(token string, hostIPs []string) []string {
 	nodeData := hostInfo{}
 	err = json.Unmarshal(body, &nodeData)
 	if err != nil {
-		zap.S().Infof("Unable to unmarshal resp body to struct: %w", err)
+		zap.S().Debugf("Unable to unmarshal resp body to struct: %w", err)
 	}
 	var hostUUIDs []string
 
@@ -155,7 +155,7 @@ func (c *ResmgrImpl) HostStatus(token string, hostID string) bool {
 	host := hostInfo{}
 	err = json.Unmarshal(body, &host)
 	if err != nil {
-		zap.S().Infof("Unable to unmarshal resp body to struct: %w", err)
+		zap.S().Debugf("Unable to unmarshal resp body to struct: %w", err)
 	}
 	return host.Info.Responding
 }

--- a/pkg/resmgr/resmgr.go
+++ b/pkg/resmgr/resmgr.go
@@ -80,7 +80,7 @@ func (c *ResmgrImpl) AuthorizeHost(hostID string, token string, version string) 
 		if err != nil {
 			return fmt.Errorf("url %s returned status code: %d. Unable to read response body", url, resp.StatusCode)
 		}
-		return fmt.Errorf("Url %s returned status code: %d, error: %s", url, resp.StatusCode, string(bodyBytes))
+		return fmt.Errorf("url %s returned status code: %d, error: %s", url, resp.StatusCode, string(bodyBytes))
 	}
 
 	return nil

--- a/pkg/resmgr/resmgr.go
+++ b/pkg/resmgr/resmgr.go
@@ -78,7 +78,7 @@ func (c *ResmgrImpl) AuthorizeHost(hostID string, token string, version string) 
 	if resp.StatusCode != 200 {
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("Url %s returned status code: %d. Unable to read response body", url, resp.StatusCode)
+			return fmt.Errorf("url %s returned status code: %d. Unable to read response body", url, resp.StatusCode)
 		}
 		return fmt.Errorf("Url %s returned status code: %d, error: %s", url, resp.StatusCode, string(bodyBytes))
 	}


### PR DESCRIPTION
## ISSUE(S):
[PMK-6396](https://platform9.atlassian.net/browse/PMK-6396)

## SUMMARY
<!--- Describe the change below -->
Many errors were being logged as "INFO", changed it to Fatal, so that pf9ctl doesn't fail silently. Increased error logging.

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## TESTING

#### Manual

**Attach node**: If attach node fails, error is logged and command ends with exit code 1
```
./pf9ctl_err3 attach-node test-2 --worker-ip 172.29.20.105 --verbose
Error checking versions  open /usr/bin/pf9ctl: no such file or directory
2024-05-02T09:33:19.8475Z	DEBUG	==========Running Attach Node==========
2024-05-02T09:33:19.8477Z	DEBUG	Loading configuration details. pf9ctl version: pf9ctl version: v1.26
2024-05-02T09:33:19.8482Z	DEBUG	Using local executor
2024-05-02T09:33:19.8484Z	DEBUG	Received a call to fetch keystone authentication for fqdn: https://test-du-bare-os-u20-3196727.platform9.horse and user: pf9@platform9.com and tenant: service, mfa_token: 

2024-05-02T09:33:20.2237Z	DEBUG	returning successfully

2024-05-02T09:33:20.2238Z	DEBUG	Fetching service ID for service: regionInfo
2024-05-02T09:33:20.2239Z	DEBUG	Fetching service ID for regionInfo
2024-05-02T09:33:20.2748Z	DEBUG	service ID : .a616653a8a194d44957e5b737d16f98c
2024-05-02T09:33:20.2749Z	DEBUG	service ID : a616653a8a194d44957e5b737d16f98c
2024-05-02T09:33:20.275Z	DEBUG	Service ID fetched : a616653a8a194d44957e5b737d16f98c
2024-05-02T09:33:20.2751Z	DEBUG	Fetching endpoint for region: RegionOne
2024-05-02T09:33:20.2752Z	DEBUG	Fetching endpoints for region RegionOne
2024-05-02T09:33:20.3253Z	DEBUG	endpoint: https://test-du-bare-os-u20-3196727.platform9.horse/download-links/
2024-05-02T09:33:20.3253Z	DEBUG	FQDN: test-du-bare-os-u20-3196727.platform9.horse
2024-05-02T09:33:20.3254Z	DEBUG	Endpoint found: test-du-bare-os-u20-3196727.platform9.horse
2024-05-02T09:33:20.3254Z	DEBUG	endpointURL fetched : test-du-bare-os-u20-3196727.platform9.horse
✓ Loaded Config Successfully
2024-05-02T09:33:20.3255Z	DEBUG	Loaded Config Successfully
2024-05-02T09:33:20.3255Z	DEBUG	Using local executor
2024-05-02T09:33:20.3255Z	DEBUG	Received a call to fetch keystone authentication for fqdn: https://test-du-bare-os-u20-3196727.platform9.horse and user: pf9@platform9.com and tenant: service, mfa_token: 

2024-05-02T09:33:20.6844Z	DEBUG	returning successfully

2024-05-02T09:33:20.6886Z	FATAL	unable to fetch clusterUuid from cluster-name. Error: Couldn't query the qbert Endpoint: 502
root@manasa-test:~# echo $?
1
```

**Prep-node**

If prep-node fails, error is logged with prep-node failure statement, and prep node fails with exit code 1

Examples of `Authorise host` failures:
```
✓ Platform9 packages installed successfully
✓ Initialised host successfully
2024-04-30T09:09:10.953Z	FATAL	
Failed to prepare node. Error: Unable to authorise host. Client is unable to send the request: PUT https://test-du-bare-os-u20-3196727.platform9.horse/resmgr/v1/hosts/8f7fc6bc-ad5e-44b0-bed2-1631495be61b/roles/pf9-kube giving up after 16 attempt(s). See /root/pf9/log/pf9ctl-20240430.log or use --verbose for logs

root@manasa-test:~# echo $?
1
```

```
- Downloading the Hostagent (this might take a few minutes...) 
Error : HOSTAGENT_PKG_INSTALLATION_FAILED
2024-04-30T09:38:26.6747Z	FATAL	
Failed to prepare node. Error: Unable to install hostagent. error while running installer script: HOSTAGENT_PKG_INSTALLATION_FAILED. See /root/pf9/log/pf9ctl-20240430.log or use --verbose for logs
```


[PMK-6396]: https://platform9.atlassian.net/browse/PMK-6396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ