### PR TITLE
Updating readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ When node is connected to a cluster:
 ```sh
 #pf9ctl decommission-node
 ✓ Loaded Config Successfully
-Node is connected to test-2 cluster
+Node is attached to test-2 cluster
 2024-05-03T08:58:57.4328Z	FATAL	Node is still attached to a cluster. Please run detach-node command first and wait for the node to be completely removed from the cluster and only then run decommision-node command
 ```
 

--- a/README.md
+++ b/README.md
@@ -556,23 +556,26 @@ Global Flags:
       --verbose          print verbose logs
 ```
 
+When node is connected to a cluster:
 ```sh
 #pf9ctl decommission-node
 ✓ Loaded Config Successfully
-Node is connected to fivefiveBareOS cluster
-Detaching node from cluster...
-Detached node from cluster
-Deauthorizing node from UI...
+Node is connected to test-2 cluster
+2024-05-03T08:58:57.4328Z	FATAL	Node is still attached to a cluster. Please run detach-node command first and wait for the node to be completely removed from the cluster and only then run decommision-node command
+```
+
+When node is not connected to any cluster:
+```sh
+#pf9ctl decommission-node
+✓ Loaded Config Successfully
 Deauthorized node from UI
 Removing pf9-hostagent (this might take a few minutes...)
 Removed hostagent
 Removing logs...
-Removing /etc/pf9 logs
-Removing /var/opt/pf9 logs
+Running clean all
 Removing pf9 HOME dir
 Node decommissioning started....This may take a few minutes....Check the latest status in UI
 ```
-
 
   **check-amazon-provider**
 ```sh

--- a/pkg/pmk/decomissionNode.go
+++ b/pkg/pmk/decomissionNode.go
@@ -140,7 +140,7 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 			time.Sleep(50 * time.Second)
 		} else {
 			// If node is connected to cluster exit, because need to redesign detach and deauthorize flows
-			fmt.Printf("Node is connected to %s cluster\n", nodeInfo.ClusterName)
+			fmt.Printf("Node is attached to %s cluster\n", nodeInfo.ClusterName)
 			zap.S().Fatalf("Node is still attached to a cluster. Please run detach-node command first and wait for the node to be completely removed from the cluster and only then run decommision-node command")
 
 			//This code will not be called since we are exiting if node is attached to cluster

--- a/pkg/pmk/decomissionNode.go
+++ b/pkg/pmk/decomissionNode.go
@@ -120,7 +120,6 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 		}
 
 		if nodeInfo.ClusterName == "" {
-			fmt.Println("Node is not connected to any cluster")
 			if nodeConnectedToDU {
 				err = c.Qbert.DeauthoriseNode(hostID, auth.Token)
 				if err != nil {

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -466,6 +466,7 @@ func pf9PackagesPresent(hostOS string, exec cmdexec.Executor, token string, fqdn
 				}
 			}
 		}
+		return packagesPresent, false, nil
 	}
 
 	if resp.StatusCode == http.StatusFound {


### PR DESCRIPTION
## ISSUE(S):
In the README.md, `pf9ctl decommission-node` refers to the older behaviour where if the node was attached to a cluster, it used to detach it from the cluster. Since that doesn't happen anymore, updated readme with the current behaviour.
Also removed the line https://github.com/platform9/pf9ctl/blob/179c803610854f51cd134189c9b6af8eceb364a5/pkg/pmk/decomissionNode.go#L123 as it was suggested that this was confusing, and gives an impression that detach happened.

Slack thread: https://platform9.slack.com/archives/C1HN79N73/p1714653717770189

Also addressing a minor fix related to pkg cleanup (https://platform9.atlassian.net/browse/PMK-5833)
<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [x] Bug fix (non-breaking change which fixes an issue)

## IMPACTED FEATURES/COMPONENTS:
pf9ctl

## TESTING DONE
#### Manual
Decommission node:

```
./pf9ctl-read decommission-node
Error checking versions  open /usr/bin/pf9ctl: no such file or directory
✓ Loaded Config Successfully
Deauthorized node from UI
Removing pf9-hostagent (this might take a few minutes...)
Removed hostagent
Removing logs...
Running clean all
Removing pf9 HOME dir
Node decommissioning started....This may take a few minutes....Check the latest status in UI
```

Minor fix where if old packages are present we will return immediately:
```
./pf9ctl-read prep-node
Error checking versions  open /usr/bin/pf9ctl: no such file or directory
✓ Loaded Config Successfully
✓ Removal of existing CLI
x Existing Platform9 Packages Check - Platform9 packages already exist. These must be uninstalled.
✓ Required OS Packages Check
✓ SudoCheck
✓ CPUCheck
✓ DiskCheck
x MemoryCheck - At least 12 GB of memory is needed on host. Total memory found: 4 GB
x PortCheck - Following port(s) should not be in use: 3306, 5395, 5672, 5673, 6264, 8023, 8158, 8558, 9080
✓ Existing Kubernetes Cluster Check
✓ Check lock on dpkg
✓ Check lock on apt
✓ Check if system is booted with systemd
✓ Check time synchronization
✓ Check if firewalld service is not running
✓ Disabling swap and removing swap in fstab

✓ Completed Pre-Requisite Checks successfully


Previous installation found
Reinstall Required...
Remove Current Installation Type ('yes'/'no'):no

Optional pre-requisite check(s) failed. Do you want to continue? (y/n) y
2024-05-03T09:37:03.7801Z	FATAL	
Failed to prepare node. See /root/pf9/log/pf9ctl-20240503.log or use --verbose for logs
```

--verbose:
```
- Starting prep-node 2024-05-03T09:37:17.3301Z	DEBUG	Ran command sudo "bash" "-c" "dpkg -l | { grep -i 'pf9-hostagent' || true; }"
2024-05-03T09:37:17.3302Z	DEBUG	stdout:ii  pf9-hostagent                  5.10.0-1609.d9a2938                   all          Platform9 host agent
stderr:
\ Starting prep-node 2024-05-03T09:37:17.4289Z	DEBUG	Ran command sudo "bash" "-c" "dpkg -l | { grep -i 'hostagent.*5.9.3-1524' || true; }"
2024-05-03T09:37:17.4291Z	DEBUG	stdout:stderr:
2024-05-03T09:37:17.4518Z	DEBUG	Ran command sudo "bash" "-c" "dpkg -l | { grep -i 'comms.*5.9.3-1192' || true; }"
...
2024-05-03T09:37:19.0554Z	DEBUG	Unable to send Segment event for supportBundle. Error: the client was already closed
2024-05-03T09:37:19.0645Z	DEBUG	Unable to prep node: 

Old Platform9 packages already present on the host.
Please uninstall these packages if you want to prep the node again.
Instructions to uninstall these are at:
https://docs.platform9.com/kubernetes/pmk-cli-unistall-hostagent

2024-05-03T09:37:19.0646Z	FATAL	
Failed to prepare node. See /root/pf9/log/pf9ctl-20240503.log or use --verbose for logs
```

