### PR TITLE
PMK-6448 Checking if required repositories are enabled for RHEL 7

### DIFF
--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -177,15 +177,11 @@ func (c *CentOS) checkEnabledRepos() (bool, error) {
 	var rhel7, centos bool = false, false
 
 	if version7 {
-		output, err := c.exec.RunWithStdout("bash", "-c", "cat /etc/os-release | grep 'Red Hat Enterprise Linux'")
+		_, err := c.exec.RunWithStdout("bash", "-c", "grep -i 'Red Hat Enterprise Linux' /etc/*release")
 		if err != nil {
-			zap.S().Debug("Error checking the contents of /etc/os-release:", err)
-			return false, err
-		}
-		if output != "" {
-			rhel7 = true
-		} else {
 			centos = true
+		} else {
+			rhel7 = true
 		}
 	}
 


### PR DESCRIPTION
## ISSUE(S):
[PMK-6448](https://platform9.atlassian.net/browse/PMK-6448)

## SUMMARY
Pf9-kube 1.29 installation failed on rhel 7.9, because the repository `rhel-7-server-extras-rpms` wasn't enabled. Hence making it a part of `check enabled repositories` check for RHEL 7.9, and it will be enabled if it isn't already.

<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->

## ISSUE TYPE
- [ ] Bug fix (non-breaking change which fixes an issue)


## IMPACTED FEATURES/COMPONENTS:
pf9ctl

## TESTING DONE
#### Manual
1. a) Tested on a RHEL 7.9 host, when repositories are enabled
```
2024-05-14T19:28:41.7669Z	DEBUG	Ran command sudo "bash" "-c" "grep -i 'Red Hat Enterprise Linux' /etc/*release"
2024-05-14T19:28:41.767Z	DEBUG	stdout:/etc/os-release:NAME="Red Hat Enterprise Linux Server"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux Server release 7.9 (Maipo)
/etc/system-release:Red Hat Enterprise Linux Server release 7.9 (Maipo)
stderr:
/ Running pre-requisite checks and installing any missing OS packages 2024-05-14T19:28:48.3724Z	DEBUG	Ran command sudo "bash" "-c" "yum repolist"
2024-05-14T19:28:48.3725Z	DEBUG	stdout:Loaded plugins: product-id, search-disabled-repos, subscription-manager
repo id                           repo name                               status
epel/x86_64                       Extra Packages for Enterprise Linux 7 - 13796
rhel-7-server-extras-rpms/x86_64  Red Hat Enterprise Linux 7 Server - Ext  1476
rhel-7-server-rpms/7Server/x86_64 Red Hat Enterprise Linux 7 Server (RPMs 34394
repolist: 49666
stderr:
2024-05-14T19:28:48.3725Z	DEBUG	Required repositories are enabled
...
2024-05-14T19:28:48.5849Z	DEBUG	OVF Service not present
2024-05-14T19:28:48.5849Z	DEBUG	Sending Segment Event: CheckNode: Required Enabled Repositories Check
✓ Required Enabled Repositories Check
...
✓ Completed Pre-Requisite Checks successfully


2024-05-14T19:28:48.5859Z	DEBUG	Completed Pre-Requisite Checks successfully
```
hostagent logs, 1.29 gets installed succesfully
```
2024-05-15 05:41:47,644 - pf9_app_cache.py INFO - Downloading pf9-kube.1.29.2-pmk.20
2024-05-15 05:41:47,645 - pf9_app_cache.py WARNING - Could not detect OS distro. Defaulting to Red Hat Linux.
2024-05-15 05:41:47,645 - pf9_app_cache.py INFO - Downloading file https://s3-us-west-1.amazonaws.com/package-repo.platform9.com/host-packages/pf9-kube/1.29.2-pmk.20/pf9-kube-1.29.2-pmk.20.x86_64.rpm to /var/cache/pf9apps/pf9-kube/1.29.2-pmk.20/pf9-kube-1.29.2-pmk.20.x86_64.rpm
2024-05-15 05:41:47,645 - pf9_app_cache.py INFO - Writing to the .incomplete file pf9-kube-1.29.2-pmk.20.x86_64.rpm.incomplete. This will be renamed back to original file once the download is successfully complete
2024-05-15 05:41:50,199 - pf9_app_cache.py INFO - Renaming pf9-kube-1.29.2-pmk.20.x86_64.rpm.incomplete to pf9-kube-1.29.2-pmk.20.x86_64.rpm
2024-05-15 05:41:50,199 - pf9_app_cache.py INFO - Downloaded file https://s3-us-west-1.amazonaws.com/package-repo.platform9.com/host-packages/pf9-kube/1.29.2-pmk.20/pf9-kube-1.29.2-pmk.20.x86_64.rpm to /var/cache/pf9apps/pf9-kube/1.29.2-pmk.20/pf9-kube-1.29.2-pmk.20.x86_64.rpm
2024-05-15 05:41:50,200 - pf9_app.py INFO - Installing pf9-kube.1.29.2-pmk.20
2024-05-15 05:42:31,445 - pf9_app.py INFO - pf9-kube.1.29.2-pmk.20 installed successfully
2024-05-15 05:42:31,446 - pf9_app.py INFO - Setting config for pf9-kube.1.29.2-pmk.20
2024-05-15 05:42:31,574 - pf9_app.py INFO - Setting the desired service state
2024-05-15 05:42:31,575 - pf9_app.py INFO - Setting service state pf9-nodeletd.1.29.2-pmk.20. Command: sudo systemctl start pf9-nodeletd
2024-05-15 05:42:32,164 - session.py INFO - Converge succeeded
```

b) If repositories are not enabled from start:
```
\ Running pre-requisite checks and installing any missing OS packages 2024-05-15T05:51:32.8143Z	DEBUG	Ran command sudo "bash" "-c" "id -u | tr -d '\n'"
2024-05-15T05:51:32.8144Z	DEBUG	stdout:0stderr:
2024-05-15T05:51:32.8263Z	DEBUG	Ran command sudo "bash" "-c" "grep -i 'Red Hat Enterprise Linux' /etc/*release"
2024-05-15T05:51:32.8264Z	DEBUG	stdout:/etc/os-release:NAME="Red Hat Enterprise Linux Server"
/etc/os-release:PRETTY_NAME="Red Hat Enterprise Linux"
/etc/os-release:REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
/etc/os-release:REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
/etc/redhat-release:Red Hat Enterprise Linux Server release 7.9 (Maipo)
/etc/system-release:Red Hat Enterprise Linux Server release 7.9 (Maipo)
stderr:
- Running pre-requisite checks and installing any missing OS packages 2024-05-15T05:51:37.056Z	DEBUG	Ran command sudo "bash" "-c" "yum repolist"
2024-05-15T05:51:37.0561Z	DEBUG	stdout:Loaded plugins: product-id, search-disabled-repos, subscription-manager
repo id                           repo name                               status
epel/x86_64                       Extra Packages for Enterprise Linux 7 - 13796
rhel-7-server-rpms/7Server/x86_64 Red Hat Enterprise Linux 7 Server (RPMs 34394
repolist: 48190
stderr:
\ Running pre-requisite checks and installing any missing OS packages 2024-05-15T05:51:53.2612Z	DEBUG	Ran command sudo "bash" "-c" subscription-manager repos --enable rhel-7-server-extras-rpms
2024-05-15T05:51:53.2613Z	DEBUG	Required repositories are enabled
...

✓ Completed Pre-Requisite Checks successfully

2024-05-15T05:51:53.43Z	DEBUG	Completed Pre-Requisite Checks successfully
```

2. Tested on a centos 7.9 host

```
2024-05-14T18:53:34.0864Z	DEBUG	Ran command sudo "bash" "-c" "grep -i 'Red Hat Enterprise Linux' /etc/*release"
2024-05-14T18:53:34.0865Z	DEBUG	stdout:stderr:
- Running pre-requisite checks and installing any missing OS packages 2024-05-14T18:53:34.3261Z	DEBUG	Ran command sudo "bash" "-c" "yum repolist"
2024-05-14T18:53:34.3261Z	DEBUG	stdout:Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * base: mirror.chpc.utah.edu
 * extras: mirrors.sonic.net
 * updates: opencolo.mm.fcix.net
repo id                             repo name                             status
base/7/x86_64                       CentOS-7 - Base                       10072
extras/7/x86_64                     CentOS-7 - Extras                       526
updates/7/x86_64                    CentOS-7 - Updates                     5886
repolist: 16484
stderr:
2024-05-14T18:53:34.3261Z	DEBUG	Required repositories are enabled
...
2024-05-14T18:53:34.5256Z	DEBUG	OVF Service not present
2024-05-14T18:53:34.5256Z	DEBUG	Sending Segment Event: CheckNode: Required Enabled Repositories Check
✓ Required Enabled Repositories Check
...
✓ Completed Pre-Requisite Checks successfully

2024-05-14T18:53:34.5261Z	DEBUG	Completed Pre-Requisite Checks successfully

Optional pre-requisite check(s) failed. Do you want to continue? (y/n)
```

#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->


[PMK-6448]: https://platform9.atlassian.net/browse/PMK-6448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ