### PR TITLE
change the order of config params to match it with PCD UI

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -321,17 +321,17 @@ func ConfigCmdCreateRun(cfg *objects.Config) error {
 		cfg.Password = string(passwordBytes)
 		fmt.Println()
 	}
-	var region string
-	if cfg.Region == "" {
-		fmt.Printf("Region [RegionOne]: ")
-		region, _ = reader.ReadString('\n')
-		cfg.Region = strings.TrimSuffix(region, "\n")
-	}
 	var service string
 	if cfg.Tenant == "" {
 		fmt.Printf("Tenant [service]: ")
 		service, _ = reader.ReadString('\n')
 		cfg.Tenant = strings.TrimSuffix(service, "\n")
+	}
+	var region string
+	if cfg.Region == "" {
+		fmt.Printf("Region [RegionOne]: ")
+		region, _ = reader.ReadString('\n')
+		cfg.Region = strings.TrimSuffix(region, "\n")
 	}
 	var proxyURL string
 	if cfg.ProxyURL == "" {
@@ -369,7 +369,7 @@ func createClient(cfg *objects.Config, nc objects.NodeConfig) (client.Client, er
 	return client.NewClient(cfg.Fqdn, executor, cfg.AllowInsecure, false)
 }
 
-//This function clears the context if it is invalid. Before storing it.
+// This function clears the context if it is invalid. Before storing it.
 func clearContext(v interface{}) {
 	p := reflect.ValueOf(v).Elem()
 	p.Set(reflect.Zero(p.Type()))


### PR DESCRIPTION

## ISSUE(S):
<!--- Links to JIRA tickets -->
[PCD-260](https://platform9.atlassian.net/browse/PCD-260): Fix the order of the host prep-node prompts in the UI
<!--- [FT-XXXX](link.to/FT-XXXX): Subject of FT-XXXX -->

## SUMMARY
<!--- Describe the change below -->
When adding a new host the PCD UI has the region and tenant sections out of order from what is prompted by cloud-ctl prep-node command.  This should match.
<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## IMPACTED FEATURES/COMPONENTS:
<!--- List of impacted features/components due to this change -->
cloud-ctl
pf9ctl
<!--- delete section if not relevant -->

## TESTING DONE
#### Manual

<!--- Please list down various use case which were part of manual testing. -->

#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->


[PCD-260]: https://platform9.atlassian.net/browse/PCD-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ