### PR TITLE
Change the go version in Makefile to 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GOFLAGS ?= ""
 default: $(BIN)
 
 container-build:
-	docker run --rm --env XDG_CACHE_HOME=$(XDG_CACHE_HOME) --env SEGMENT_KEY_PRD_PMKFT=$(SEGMENT_KEY_PRD_PMKFT) --env VERSION_OVERRIDE=${VERSION_OVERRIDE} --env GOPATH=/tmp --env GOFLAGS=$(GOFLAGS) --user $(CONT_USER):$(CONT_GRP) --volume $(PWD):$(PACKAGE_GOPATH) $(GIT_STORAGE_MOUNT) --workdir $(PACKAGE_GOPATH) golang:1.23 make ldflags="-s -w -extldflags '-static'"
+	docker run --rm --env XDG_CACHE_HOME=$(XDG_CACHE_HOME) --env SEGMENT_KEY_PRD_PMKFT=$(SEGMENT_KEY_PRD_PMKFT) --env VERSION_OVERRIDE=${VERSION_OVERRIDE} --env GOPATH=/tmp --env GOFLAGS=$(GOFLAGS) --user $(CONT_USER):$(CONT_GRP) --volume $(PWD):$(PACKAGE_GOPATH) $(GIT_STORAGE_MOUNT) --workdir $(PACKAGE_GOPATH) golang:1.18 make ldflags="-s -w -extldflags '-static'"
 
 $(BIN): test
 	go build -o $(BIN_DIR)/$(BIN) -ldflags "$(LDFLAGS) -X github.com/platform9/pf9ctl/pkg/client.SegmentWriteKey=$(SEGMENT_KEY_PRD_PMKFT) -s -w"

--- a/pkg/platform/centos/centos.go
+++ b/pkg/platform/centos/centos.go
@@ -135,7 +135,7 @@ func (c *CentOS) checkOSPackages() (bool, error) {
 	errLines := []string{packageInstallError}
 	zap.S().Debug("Checking OS Packages")
 
-	rhel8, _ = regexp.MatchString(`.*8\.[5-10]\.*`, string(version))
+	rhel8, _ = regexp.MatchString(`.*8\.([5-9]|1[0])\.*`, string(version))
 	rocky9, _ = regexp.MatchString(`.*9\.[1-5]\.*`, string(version))
 
 	if platform.SkipOSChecks {
@@ -181,7 +181,7 @@ func (c *CentOS) checkEnabledRepos() (bool, error) {
 
 	var centos, rhel8 bool
 	centos, _ = regexp.MatchString(`.*7\.[3-9]\.*`, string(version))
-	rhel8, _ = regexp.MatchString(`.*8\.[5-10]\.*`, string(version))
+	rhel8, _ = regexp.MatchString(`.*8\.([5-9]|1[0])\.*`, string(version))
 
 	if platform.SkipOSChecks {
 		centos, _ = regexp.MatchString(`7\.\d{1,2}`, string(version))
@@ -379,7 +379,7 @@ func (c *CentOS) Version() (string, error) {
 			return "redhat", nil
 		}
 	}
-	if match, _ := regexp.MatchString(`.*7\.[3-9]\.*|.*8\.[5-10]\.*|.*9\.[1-5]\.*`, string(version)); match {
+	if match, _ := regexp.MatchString(`.*7\.[3-9]\.*|.*8\.([5-9]|1[0])\.*|.*9\.[1-5]\.*`, string(version)); match {
 		return "redhat", nil
 	}
 	return "", fmt.Errorf("Unable to determine OS type: %s", string(version))


### PR DESCRIPTION
Testing to see If the version is something that's causing pf9ctl not work properly.

Output that we get when testing with latest pf9ctl,
```
* Connection #0 to host pmkft-assets.s3.us-west-1.amazonaws.com left intact
/root/pf9/bin/pf9ctl_new: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /root/pf9/bin/pf9ctl_new)
/root/pf9/bin/pf9ctl_new: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /root/pf9/bin/pf9ctl_new)
16:14:37.694003794 :63 : ASSERT: Installation of Platform9 CLI Failed
```

With this change, pf9ctl install works fine.

Making an additional change to match regex with double digits e.g., to match '8.10'
