### PR TITLE
PCD-649 remove region'\''s default value and make it compulsory

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -323,7 +323,7 @@ func ConfigCmdCreateRun(cfg *objects.Config) error {
 	}
 	var region string
 	if cfg.Region == "" {
-		fmt.Printf("Region [RegionOne]: ")
+		fmt.Printf("Region: ")
 		region, _ = reader.ReadString('\n')
 		cfg.Region = strings.TrimSpace(region)
 	}
@@ -339,11 +339,11 @@ func ConfigCmdCreateRun(cfg *objects.Config) error {
 		proxyURL, _ = reader.ReadString('\n')
 		cfg.ProxyURL = strings.TrimSpace(proxyURL)
 	}
-
+	/* Removing Default Region.
 	if cfg.Region == "" {
 		cfg.Region = "RegionOne"
 	}
-
+	*/
 	if cfg.Tenant == "" {
 		cfg.Tenant = "service"
 	}


### PR DESCRIPTION
## ISSUE(S):
[PCD-649](https://platform9.atlassian.net/browse/PCD-649)
<!--- Links to JIRA tickets -->
<!--- [FT-XXXX](link.to/FT-XXXX): Subject of FT-XXXX -->

## SUMMARY
<!--- Describe the change below -->
Region Name defaulted to "RegionOne" before, now no default its a mandatory feild.
<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [X] Bug fix (non-breaking change which fixes an issue)




## IMPACTED FEATURES/COMPONENTS:
<!--- List of impacted features/components due to this change -->
<!--- delete section if not relevant -->
cloud-ctl

## RELATED ISSUE(S):
<!--- Links to Related issues/Jira tickets if any -->
<!--- delete section if not relevant -->

## DEPENDS ON:
<!--- Links to related PRs if any -->
<!--- delete section if not relevant -->

## TESTING DONE
#### Automated
<!--- Please give link to teamcity build if there are any automated tests -->
<!--- that gets executed as a part of build.-->
#### Manual
<!--- Please list down various use case which were part of manual testing. -->
Inprogress
#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->


[PCD-649]: https://platform9.atlassian.net/browse/PCD-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<h3>Summary by Bito</h3>
Removed default 'RegionOne' value from configuration system, making region specification mandatory for users. Updated region prompt messaging and documentation to reflect this change. This modification enforces explicit region selection rather than relying on default values.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>