### PR TITLE
PMK-6388: fix prep-node failure with segmentation fault

### DIFF
--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -144,7 +144,7 @@ func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.Keysto
 	s.Suffix = " Initialising host"
 	zap.S().Debug("Initialising host")
 	zap.S().Debug("Identifying the hostID from conf")
-	cmd := `grep host_id /etc/pf9/host_id.conf | cut -d '=' -f2`
+	cmd := `grep host_id /etc/pf9/host_id.conf && cut -d '=' -f2`
 	output, err := allClients.Executor.RunWithStdout("bash", "-c", cmd)
 	output = strings.TrimSpace(output)
 	if err != nil || output == "" {


### PR DESCRIPTION
## ISSUE(S):
<!--- Links to JIRA tickets -->
<!--- [FT-XXXX](link.to/FT-XXXX): Subject of FT-XXXX -->
https://platform9.atlassian.net/browse/PMK-6388

## SUMMARY
<!--- Describe the change below -->
Root cause: Error was not reported back correctly.
`2023-09-06T17:49:09.0543Z DEBUG Running command https_proxy=http://qcwebproxylb.juniper.net:3128 bash "-c" "grep host_id /etc/pf9/host_id.conf | cut -d '=' -f2"stdout:stderr:grep: /etc/pf9/host_id.conf: No such file or directory`
In scenarios when "file is not found", it's expected to receive a non nil error.
When piping commands, the status code reported by `grep` is overwritten by that of `cut`

```
mridulgain@HXJN3GQY1WFV pf9ctl % grep host_id /etc/pf9/host_id.conf| cut -d '=' -f2
grep: /etc/pf9/host_id.conf: No such file or directory
mridulgain@HXJN3GQY1WFV pf9ctl % echo $?
0
```
Which leads to a nil `err` & despite of having error handling it fails to gracefully handle it and later panics with nil pointer dereference due to empty `hostID` inside `AuthorizeHost` function.

### Suggested fix:
use `&&` instead of `|` operator to achieve same behavior with correct exit status.
```
mridulgain@HXJN3GQY1WFV pf9ctl % grep host_id /etc/pf9/host_id.conf && cut -d '=' -f2`
grep: /etc/pf9/host_id.conf: No such file or directory
mridulgain@HXJN3GQY1WFV pf9ctl % echo $?
2
```


<!--- include "Fixes #FT-XXX" if you have a relevant Jira ticket -->

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## IMPACTED FEATURES/COMPONENTS:
<!--- List of impacted features/components due to this change -->
<!--- delete section if not relevant -->
`prepNode`

## RELATED ISSUE(S):
<!--- Links to Related issues/Jira tickets if any -->
<!--- delete section if not relevant -->

## DEPENDS ON:
<!--- Links to related PRs if any -->
<!--- delete section if not relevant -->

## TESTING DONE
#### Automated
<!--- Please give link to teamcity build if there are any automated tests -->
<!--- that gets executed as a part of build.-->
#### Manual
<!--- Please list down various use case which were part of manual testing. -->
Prior to the fix: the `prep-node` workflow was going into panic, leading to segmentation fault.
After the fix: It gracefully handles & reports the issue.
```
2025-02-20T06:41:59.2203Z       FATAL
Failed to prepare node. Error: Unable to fetch host ID. exit status 2. See /home/ubuntu/pf9/log/pf9ctl-20250220.log or use --verbose for logs
```

#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->
 
 <div id='description'>
<h3>Summary by Bito</h3>
Fixed a bug in command pipeline error handling by replacing the pipe operator (|) with logical AND (&&) when reading host_id from /etc/pf9/host_id.conf. This change ensures proper error reporting from grep commands and prevents potential nil pointer dereference panics.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>