### PR TITLE
Introducing variable for cloud-ctl ldflag for better errors messages

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -26,7 +25,7 @@ import (
 var (
 	REGION_INVALID     error = errors.New("Invalid Region")
 	INVALID_CREDS      error = errors.New("Invalid Credentials")
-	NO_CONFIG                = errors.New(fmt.Sprintf("No config found, please create with `%s config set`", filepath.Base(os.Args[0])))
+	NO_CONFIG                = errors.New(fmt.Sprintf("No config found, please create with `%s config set`", util.ExeName))
 	MISSSING_FIELDS          = errors.New("Missing mandatory field(s) (Platform9 Account URL/Username/Password/Region/Tenant)")
 	MAX_ATTEMPTS_ERROR       = errors.New("Invalid credentials entered multiple times (Platform9 Account URL/Username/Password/Region/Tenant/Proxy URL/MFA Token)")
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,7 @@ import (
 var (
 	REGION_INVALID     error = errors.New("Invalid Region")
 	INVALID_CREDS      error = errors.New("Invalid Credentials")
-	NO_CONFIG                = errors.New("No config found, please create with `pf9ctl config set`")
+	NO_CONFIG                = errors.New(fmt.Sprintf("No config found, please create with `%s config set`", util.Ctl))
 	MISSSING_FIELDS          = errors.New("Missing mandatory field(s) (Platform9 Account URL/Username/Password/Region/Tenant)")
 	MAX_ATTEMPTS_ERROR       = errors.New("Invalid credentials entered multiple times (Platform9 Account URL/Username/Password/Region/Tenant/Proxy URL/MFA Token)")
 )
@@ -369,7 +369,7 @@ func createClient(cfg *objects.Config, nc objects.NodeConfig) (client.Client, er
 	return client.NewClient(cfg.Fqdn, executor, cfg.AllowInsecure, false)
 }
 
-//This function clears the context if it is invalid. Before storing it.
+// This function clears the context if it is invalid. Before storing it.
 func clearContext(v interface{}) {
 	p := reflect.ValueOf(v).Elem()
 	p.Set(reflect.Zero(p.Type()))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,7 @@ import (
 var (
 	REGION_INVALID     error = errors.New("Invalid Region")
 	INVALID_CREDS      error = errors.New("Invalid Credentials")
-	NO_CONFIG                = errors.New(fmt.Sprintf("No config found, please create with `%s config set`", util.ExeName))
+	NO_CONFIG                = fmt.Errorf("No config found, please create with `%s config set`", util.ExeName)
 	MISSSING_FIELDS          = errors.New("Missing mandatory field(s) (Platform9 Account URL/Username/Password/Region/Tenant)")
 	MAX_ATTEMPTS_ERROR       = errors.New("Invalid credentials entered multiple times (Platform9 Account URL/Username/Password/Region/Tenant/Proxy URL/MFA Token)")
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -25,7 +26,7 @@ import (
 var (
 	REGION_INVALID     error = errors.New("Invalid Region")
 	INVALID_CREDS      error = errors.New("Invalid Credentials")
-	NO_CONFIG                = errors.New(fmt.Sprintf("No config found, please create with `%s config set`", util.Ctl))
+	NO_CONFIG                = errors.New(fmt.Sprintf("No config found, please create with `%s config set`", filepath.Base(os.Args[0])))
 	MISSSING_FIELDS          = errors.New("Missing mandatory field(s) (Platform9 Account URL/Username/Password/Region/Tenant)")
 	MAX_ATTEMPTS_ERROR       = errors.New("Invalid credentials entered multiple times (Platform9 Account URL/Username/Password/Region/Tenant/Proxy URL/MFA Token)")
 )

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -68,9 +68,9 @@ const (
 
 var (
 	// Constants for check failure messages
-	PyCliErr                = fmt.Errorf("Earlier version of %s already exists. This must be uninstalled.", os.Args[0])
+	PyCliErr                = fmt.Sprintf("Earlier version of %s already exists. This must be uninstalled.", Ctl)
 	ExisitngInstallationErr = "Platform9 packages already exist. These must be uninstalled."
-	SudoErr                 = fmt.Errorf("User running %s must have privilege (sudo) mode enabled.", os.Args[0])
+	SudoErr                 = fmt.Sprintf("User running %s must have privilege (sudo) mode enabled.", Ctl)
 	OSPackagesErr           = "Some OS packages needed for the CLI not found"
 	CPUErr                  = "At least 2 CPUs are needed on host."
 	DiskErr                 = "At least 30 GB of total disk space and 15 GB of free space is needed on host."

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -68,9 +68,9 @@ const (
 
 var (
 	// Constants for check failure messages
-	PyCliErr                = fmt.Errorf("Earlier version of %s already exists. This must be uninstalled.", Ctl)
+	PyCliErr                = fmt.Sprintf("Earlier version of %s already exists. This must be uninstalled.", Ctl)
 	ExisitngInstallationErr = "Platform9 packages already exist. These must be uninstalled."
-	SudoErr                 = fmt.Errorf("User running %s must have privilege (sudo) mode enabled.", Ctl)
+	SudoErr                 = fmt.Sprintf("User running %s must have privilege (sudo) mode enabled.", Ctl)
 	OSPackagesErr           = "Some OS packages needed for the CLI not found"
 	CPUErr                  = "At least 2 CPUs are needed on host."
 	DiskErr                 = "At least 30 GB of total disk space and 15 GB of free space is needed on host."

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -62,13 +63,15 @@ const (
 	PmkVersion = "1.20.11"
 	Docker     = "docker"
 	Calico     = "calico"
+
+	Ctl = "pf9ctl"
 )
 
 var (
 	// Constants for check failure messages
-	PyCliErr                = "Earlier version of pf9ctl already exists. This must be uninstalled."
+	PyCliErr                = fmt.Sprintf("Earlier version of %s already exists. This must be uninstalled.", Ctl)
 	ExisitngInstallationErr = "Platform9 packages already exist. These must be uninstalled."
-	SudoErr                 = "User running pf9ctl must have privilege (sudo) mode enabled."
+	SudoErr                 = fmt.Sprintf("User running %s must have privilege (sudo) mode enabled.", Ctl)
 	OSPackagesErr           = "Some OS packages needed for the CLI not found"
 	CPUErr                  = "At least 2 CPUs are needed on host."
 	DiskErr                 = "At least 30 GB of total disk space and 15 GB of free space is needed on host."

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -68,9 +68,9 @@ const (
 
 var (
 	// Constants for check failure messages
-	PyCliErr                = fmt.Sprintf("Earlier version of %s already exists. This must be uninstalled.", Ctl)
+	PyCliErr                = fmt.Errorf("Earlier version of %s already exists. This must be uninstalled.", os.Args[0])
 	ExisitngInstallationErr = "Platform9 packages already exist. These must be uninstalled."
-	SudoErr                 = fmt.Sprintf("User running %s must have privilege (sudo) mode enabled.", Ctl)
+	SudoErr                 = fmt.Errorf("User running %s must have privilege (sudo) mode enabled.", os.Args[0])
 	OSPackagesErr           = "Some OS packages needed for the CLI not found"
 	CPUErr                  = "At least 2 CPUs are needed on host."
 	DiskErr                 = "At least 30 GB of total disk space and 15 GB of free space is needed on host."

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -36,6 +36,7 @@ var GoogleCloudPermissions []string
 var AzureContributorID string
 var InstallerErrors = make(map[int]string)
 var LogFileNamePath string
+var = "pf9ctl"
 
 const (
 
@@ -63,8 +64,6 @@ const (
 	PmkVersion = "1.20.11"
 	Docker     = "docker"
 	Calico     = "calico"
-
-	Ctl = "pf9ctl"
 )
 
 var (

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -36,7 +36,7 @@ var GoogleCloudPermissions []string
 var AzureContributorID string
 var InstallerErrors = make(map[int]string)
 var LogFileNamePath string
-var = "pf9ctl"
+var Ctl = "pf9ctl"
 
 const (
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -36,7 +36,6 @@ var GoogleCloudPermissions []string
 var AzureContributorID string
 var InstallerErrors = make(map[int]string)
 var LogFileNamePath string
-var Ctl = "pf9ctl"
 
 const (
 
@@ -68,9 +67,9 @@ const (
 
 var (
 	// Constants for check failure messages
-	PyCliErr                = fmt.Sprintf("Earlier version of %s already exists. This must be uninstalled.", Ctl)
+	PyCliErr                = fmt.Sprintf("Earlier version of %s already exists. This must be uninstalled.", filepath.Base(os.Args[0]))
 	ExisitngInstallationErr = "Platform9 packages already exist. These must be uninstalled."
-	SudoErr                 = fmt.Sprintf("User running %s must have privilege (sudo) mode enabled.", Ctl)
+	SudoErr                 = fmt.Sprintf("User running %s must have privilege (sudo) mode enabled.", filepath.Base(os.Args[0]))
 	OSPackagesErr           = "Some OS packages needed for the CLI not found"
 	CPUErr                  = "At least 2 CPUs are needed on host."
 	DiskErr                 = "At least 30 GB of total disk space and 15 GB of free space is needed on host."

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -36,6 +36,7 @@ var GoogleCloudPermissions []string
 var AzureContributorID string
 var InstallerErrors = make(map[int]string)
 var LogFileNamePath string
+var ExeName string = filepath.Base(os.Args[0])
 
 const (
 
@@ -67,9 +68,9 @@ const (
 
 var (
 	// Constants for check failure messages
-	PyCliErr                = fmt.Sprintf("Earlier version of %s already exists. This must be uninstalled.", filepath.Base(os.Args[0]))
+	PyCliErr                = fmt.Sprintf("Earlier version of %s already exists. This must be uninstalled.", ExeName)
 	ExisitngInstallationErr = "Platform9 packages already exist. These must be uninstalled."
-	SudoErr                 = fmt.Sprintf("User running %s must have privilege (sudo) mode enabled.", filepath.Base(os.Args[0]))
+	SudoErr                 = fmt.Sprintf("User running %s must have privilege (sudo) mode enabled.", ExeName)
 	OSPackagesErr           = "Some OS packages needed for the CLI not found"
 	CPUErr                  = "At least 2 CPUs are needed on host."
 	DiskErr                 = "At least 30 GB of total disk space and 15 GB of free space is needed on host."

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -68,9 +68,9 @@ const (
 
 var (
 	// Constants for check failure messages
-	PyCliErr                = fmt.Sprintf("Earlier version of %s already exists. This must be uninstalled.", Ctl)
+	PyCliErr                = fmt.Errorf("Earlier version of %s already exists. This must be uninstalled.", Ctl)
 	ExisitngInstallationErr = "Platform9 packages already exist. These must be uninstalled."
-	SudoErr                 = fmt.Sprintf("User running %s must have privilege (sudo) mode enabled.", Ctl)
+	SudoErr                 = fmt.Errorf("User running %s must have privilege (sudo) mode enabled.", Ctl)
 	OSPackagesErr           = "Some OS packages needed for the CLI not found"
 	CPUErr                  = "At least 2 CPUs are needed on host."
 	DiskErr                 = "At least 30 GB of total disk space and 15 GB of free space is needed on host."


### PR DESCRIPTION
## ISSUE(S):
https://platform9.atlassian.net/browse/PCD-607

## SUMMARY
Using os.Args[0] as for cloud-ctl the fucntions are imported from here the error displays pf9ctl when doing a prep-node and the config does not exist so this variable will accordingly change the error output as per the ctl used

## ISSUE TYPE
<!--- To checkmark and select applicable option(s), edit [ ] to [x]  -->
<!--- Alternatively, just delete options that do not apply and remove [ ] checkmarks  -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that may cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## IMPACTED FEATURES/COMPONENTS:
<!--- List of impacted features/components due to this change -->
<!--- delete section if not relevant -->

## RELATED ISSUE(S):
<!--- Links to Related issues/Jira tickets if any -->
<!--- delete section if not relevant -->

## DEPENDS ON:
<!--- Links to related PRs if any -->
<!--- delete section if not relevant -->

## TESTING DONE
#### Automated
<!--- Please give link to teamcity build if there are any automated tests -->
<!--- that gets executed as a part of build.-->
#### Manual
<!--- Please list down various use case which were part of manual testing. -->
<img width="1110" alt="Screenshot 2025-03-28 at 3 06 06 PM" src="https://github.com/user-attachments/assets/d1dcccd9-b578-49ab-9458-7e44e4933032" />

https://teamcity.platform9.horse/buildConfiguration/Pf9project_Platform9Components_Pf9ctl/3665841?buildTab=artifacts

<img width="567" alt="Screenshot 2025-03-31 at 11 29 02 AM" src="https://github.com/user-attachments/assets/c4fcefbe-777c-4edc-b2eb-f7d2a4a3b09d" />
latest changes
This binary is scp in a amd64 based host and tested with a different name just to check if the ctl name is taken correctly

#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... ---> 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances error message handling by replacing static strings with dynamic command name retrieval and formatting. It introduces a dynamic ExeName variable to replace static os.Args[0] calls in pkg/config/config.go, improving accuracy and consistency in user-facing error messages for the cloud-ctl tool. Changes in config.go and constants.go modify error message formats, add required imports, and manage constants for more maintainable outputs.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>