### PR TITLE
[PMK-6629] send projectID during resmgr authorizeHost call

### DIFF
--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -165,7 +165,7 @@ func PrepNode(ctx objects.Config, allClients client.Client, auth keystone.Keysto
 	zap.S().Debug("Authorising host")
 	time.Sleep(ctx.WaitPeriod * time.Second)
 
-	if err := allClients.Resmgr.AuthorizeHost(hostID, auth.Token, util.KubeVersion); err != nil {
+	if err := allClients.Resmgr.AuthorizeHost(hostID, auth.Token, util.KubeVersion, auth.ProjectID); err != nil {
 		errStr := "Error: Unable to authorise host. " + err.Error()
 		sendSegmentEvent(allClients, errStr, auth, true)
 		return fmt.Errorf(errStr)


### PR DESCRIPTION
## ISSUE(S):
https://platform9.atlassian.net/browse/PMK-6629
projectID is not getting reflected in qbert DB after prep-node, due to which nodes are visible in all the tenants before cluster creation.

## SUMMARY
send projectID during resmgr authorizedHost call during prep-node

## DEPENDS ON:
https://github.com/platform9/pf9-qbert/pull/2352

## TESTING DONE
#### Manual
shared in above PR
