### PR TITLE
Add support for Ubuntu 24 

### DIFF
--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -291,15 +291,13 @@ func (d *Debian) Version() (string, error) {
 	//using cat command content of os-release file is printed on terminal
 	//using grep command os name and version are searched (pretty_name)
 	//using cut command required field is selected
-	//in this case (PRETTY_NAME="Ubuntu 18.04.2 LTS") second field(18.04.2) is selected using (cut -d ' ' -f 2) command
+	//in this case (PRETTY_NAME="Ubuntu 20.04.2 LTS") second field(20.04.2) is selected using (cut -d ' ' -f 2) command
 	majorVersion, minorVersion, _, err := d.getVersion()
 	if err != nil {
 		return "", fmt.Errorf("Couldn't read the OS configuration file os-release: %s", err.Error())
 	}
 	var isVersionMatch bool
-	if strings.Contains(string(majorVersion), "18") && strings.Contains(string(minorVersion), "04") {
-		isVersionMatch = true
-	} else if strings.Contains(string(majorVersion), "20") && strings.Contains(string(minorVersion), "04") {
+	if strings.Contains(string(majorVersion), "20") && strings.Contains(string(minorVersion), "04") {
 		isVersionMatch = true
 	} else if strings.Contains(string(majorVersion), "22") && strings.Contains(string(minorVersion), "04") {
 		isVersionMatch = true

--- a/pkg/platform/debian/debian.go
+++ b/pkg/platform/debian/debian.go
@@ -303,7 +303,10 @@ func (d *Debian) Version() (string, error) {
 		isVersionMatch = true
 	} else if strings.Contains(string(majorVersion), "22") && strings.Contains(string(minorVersion), "04") {
 		isVersionMatch = true
+	} else if strings.Contains(string(majorVersion), "24") && strings.Contains(string(minorVersion), "04") {
+		isVersionMatch = true
 	}
+
 
 	if isVersionMatch {
 		return "debian", nil
@@ -408,7 +411,7 @@ func (d *Debian) checkIfTimesyncServiceRunning() (bool, error) {
 				zap.S().Debugf("Couldn't read the OS configuration file os-release: %s", err1.Error())
 			}
 			var err error
-			if (strings.Contains(string(majorVersion), "20") || strings.Contains(string(majorVersion), "22")) && strings.Contains(string(minorVersion), "04") {
+			if (strings.Contains(string(majorVersion), "20") || strings.Contains(string(majorVersion), "22") || strings.Contains(string(majorVersion), "24")) && strings.Contains(string(minorVersion), "04") {
 				err = d.start("systemd-timesyncd")
 			} else {
 				err = d.start("ntp")
@@ -519,7 +522,7 @@ func (d *Debian) DownloadAndInstallTimesyncPkg() error {
 		zap.S().Debugf("Couldn't read the OS configuration file os-release: %s", err1.Error())
 	}
 	var err error
-	if (strings.Contains(string(majorVersion), "20") || strings.Contains(string(majorVersion), "22")) && strings.Contains(string(minorVersion), "04") {
+	if (strings.Contains(string(majorVersion), "20") || strings.Contains(string(majorVersion), "22") || strings.Contains(string(majorVersion), "24")) && strings.Contains(string(minorVersion), "04") {
 		err = d.installOSPackages("systemd-timesyncd")
 	} else {
 		err = d.installOSPackages("ntp")

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -65,7 +65,7 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 	case "redhat":
 		platform = centos.NewCentOS(allClients.Executor)
 	default:
-		return RequiredFail, fmt.Errorf("This OS is not supported. Supported operating systems are: Ubuntu (18.04, 20.04, 22.04,24.04), CentOS 7.[3-9], RHEL 7.[3-9], RHEL 8.[5-10] & Rocky 9.[1-5]")
+		return RequiredFail, fmt.Errorf("This OS is not supported. Supported operating systems are: Ubuntu (20.04, 22.04,24.04), CentOS 7.[3-9], RHEL 7.[3-9], RHEL 8.[5-10] & Rocky 9.[1-5]")
 	}
 
 	if err = allClients.Segment.SendEvent("Starting CheckNode", auth, checkPass, ""); err != nil {

--- a/pkg/pmk/checkNode.go
+++ b/pkg/pmk/checkNode.go
@@ -65,7 +65,7 @@ func CheckNode(ctx objects.Config, allClients client.Client, auth keystone.Keyst
 	case "redhat":
 		platform = centos.NewCentOS(allClients.Executor)
 	default:
-		return RequiredFail, fmt.Errorf("This OS is not supported. Supported operating systems are: Ubuntu (18.04, 20.04, 22.04), CentOS 7.[3-9], RHEL 7.[3-9], RHEL 8.[5-10] & Rocky 9.[1-5]")
+		return RequiredFail, fmt.Errorf("This OS is not supported. Supported operating systems are: Ubuntu (18.04, 20.04, 22.04,24.04), CentOS 7.[3-9], RHEL 7.[3-9], RHEL 8.[5-10] & Rocky 9.[1-5]")
 	}
 
 	if err = allClients.Segment.SendEvent("Starting CheckNode", auth, checkPass, ""); err != nil {

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -356,7 +356,7 @@ func installHostAgentCertless(ctx objects.Config, regionURL string, auth keyston
 		_, err = exec.RunWithStdout("bash", "-c", cmd)
 	}
 
-//		removeTempDirAndInstaller(exec)
+		removeTempDirAndInstaller(exec)
 
 	if err != nil {
 		_, exitCode := cmdexec.ExitCodeChecker(err)

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -356,7 +356,7 @@ func installHostAgentCertless(ctx objects.Config, regionURL string, auth keyston
 		_, err = exec.RunWithStdout("bash", "-c", cmd)
 	}
 
-		removeTempDirAndInstaller(exec)
+	removeTempDirAndInstaller(exec)
 
 	if err != nil {
 		_, exitCode := cmdexec.ExitCodeChecker(err)

--- a/pkg/pmk/node.go
+++ b/pkg/pmk/node.go
@@ -356,7 +356,7 @@ func installHostAgentCertless(ctx objects.Config, regionURL string, auth keyston
 		_, err = exec.RunWithStdout("bash", "-c", cmd)
 	}
 
-	removeTempDirAndInstaller(exec)
+//		removeTempDirAndInstaller(exec)
 
 	if err != nil {
 		_, exitCode := cmdexec.ExitCodeChecker(err)


### PR DESCRIPTION
1. Added changes for supporting ubuntu 24.
2. Onboarded ubuntu24  node to DU 
```
ubuntu@24ubuntu:~$ bash <(curl -sL https://pmkft-assets.s3.us-west-1.amazonaws.com/pf9ctl_internal_test/pf9ctl_setup)
 ____ _    _  __           ___
| _ \| | __ _| |_ / _| ___ _ __ _ __ ___ / _ \
| |_) | |/ _` | __| |_ / _ \| '__| '_ ` _ \ (_) |
| __/| | (_| | |_| _| (_) | | | | | | | \__, |
|_|  |_|\__,_|\__|_| \___/|_| |_| |_| |_| /_/

Note: SUDO access required to run Platform9 CLI.
   You might be prompted for your SUDO password.

Downloading Platform9 CLI binary...

Platform9 CLI binary downloaded.

Installing Platform9 CLI...

Platform9 CLI installation completed successfully !

To start building a Kubernetes cluster execute:
    pf9ctl help

root@ubuntu24-1:~# ./pf9ctl prep-node
Error checking versions open /usr/bin/pf9ctl: no such file or directory
x Existing config not found, prompting for new config
Platform9 Account URL: https://test-du-qbert-bare-os-u20-3784577.platform9.horse/
Username: [pf9@platform9.com](mailto:pf9@platform9.com)
Password:
Region [RegionOne]:
Tenant [service]:
Proxy URL [None]:
MFA Token [None]:
✓ Stored configuration details successfully
✓ Loaded Config Successfully
✓ Removal of existing CLI
✓ Existing Platform9 Packages Check
✓ Required OS Packages Check
✓ SudoCheck
✓ CPUCheck
✓ DiskCheck
✓ MemoryCheck
✓ PortCheck
✓ Existing Kubernetes Cluster Check
✓ Check lock on dpkg
✓ Check lock on apt
✓ Check if system is booted with systemd
✓ Check time synchronization
✓ Check if firewalld service is not running
✓ Disabling swap and removing swap in fstab
✓ Completed Pre-Requisite Checks successfully
/ Starting prep-node 2025-04-16T07:04:34.626Z	INFO	Pf9 packages are not present
✓ Platform9 packages installed successfully
✓ Initialised host successfully
✓ Host successfully attached to the Platform9 control-plane
```
<img width="1440" alt="Screenshot 2025-04-16 at 1 01 58 PM" src="https://github.com/user-attachments/assets/cce905bd-f196-43d8-9164-dcdb5e08ed93" /> 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR adds Ubuntu 24 support by extending version-checking logic in the debian platform module and updating error messages in the checkNode module. It removes references to Ubuntu 18.04 while implementing conditions for Ubuntu 20.04, 22.04, and 24 across multiple code segments to ensure proper OS identification and validation. These changes are part of a broader initiative to facilitate the onboarding of Ubuntu 24 nodes.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>