### PR TITLE
[PMK-6387] remove pf9 container proxy configs

### DIFF
--- a/pkg/pmk/decomissionNode.go
+++ b/pkg/pmk/decomissionNode.go
@@ -50,7 +50,7 @@ func removeHostagent(c client.Client, hostOS string) {
 	} else {
 		fmt.Println("Removed hostagent")
 	}
-	fmt.Println("Removing logs...")
+	fmt.Println("Removing PF9 logs and configs...")
 	for _, file := range util.Files {
 		cmd := fmt.Sprintf("rm -rf %s", file)
 		c.Executor.RunCommandWait(cmd)

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -141,7 +141,7 @@ func init() {
 	RequiredPorts = []string{"443", "2379", "2380", "8285", "10250", "10255", "4194", "3306", "8158", "5672", "5673", "8023", "9080", "6264", "5395", "8558"}
 	ProcessesList = []string{"kubelet", "kube-proxy", "kube-apiserver", "kube-scheduler", "kube-controller", "etcd"}
 	Pf9Packages = []string{"pf9-hostagent", "pf9-comms", "pf9-kube", "pf9-muster"}
-	Files = []string{"/opt/pf9", "/etc/pf9", "/var/opt/pf9", "/var/log/pf9", "/tmp/authbs-certs*", "/tmp/python-eggs", "/var/spool/mail/pf9", "/opt/cni", "/etc/cni", "/var/lib/docker", "/run/containerd", "/opt/containerd", "/var/lib/containerd", "/var/lib/nerdctl"}
+	Files = []string{"/opt/pf9", "/etc/pf9", "/var/opt/pf9", "/var/log/pf9", "/tmp/authbs-certs*", "/tmp/python-eggs", "/var/spool/mail/pf9", "/opt/cni", "/etc/cni", "/var/lib/docker", "/run/containerd", "/opt/containerd", "/var/lib/containerd", "/var/lib/nerdctl", "/etc/systemd/system/docker.service.d", "/etc/systemd/system/containerd.service.d"}
 
 	AzureContributorID = "b24988ac-6180-42a0-ab88-20f7382dd24c"
 


### PR DESCRIPTION
# Issue:
https://platform9.atlassian.net/issues/PMK-6387

## Summary:
added pf9 container proxy configs also to be removed as part of `decommission-node`.


 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR enhances the decommission node process by improving logging clarity and expanding the cleanup configuration with additional file paths. The changes ensure PF9 logs and configuration files are properly handled during removal, making the decommissioning process more comprehensive and streamlined.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>