### PR TITLE
In retryablehttp client CheckRetry method, return err object when we …

### DIFF
--- a/cmd/detachNode.go
+++ b/cmd/detachNode.go
@@ -126,7 +126,7 @@ func detachNodeRun(cmd *cobra.Command, args []string) {
 
 }
 
-//returns the nodes whos ip's were passed in the flag (or the node installed on the machine if no ip was passed)
+// returns the nodes whos ip's were passed in the flag (or the node installed on the machine if no ip was passed)
 func getNodesFromUuids(nodeUuids []string, allNodes []qbert.Node) ([]qbert.Node, error) {
 
 	var nodesUuid []qbert.Node
@@ -147,7 +147,7 @@ func getNodesFromUuids(nodeUuids []string, allNodes []qbert.Node) ([]qbert.Node,
 	return nodesUuid, nil
 }
 
-//returns a list of all clusters the nodes are attached to
+// returns a list of all clusters the nodes are attached to
 func getClusters(allNodes []qbert.Node) []string {
 
 	var clusters []string
@@ -170,7 +170,7 @@ func getClusters(allNodes []qbert.Node) []string {
 
 }
 
-//returns all nodes attached to a specific clusters, used to detach all nodes from clusters
+// returns all nodes attached to a specific clusters, used to detach all nodes from clusters
 func getAllClusterNodes(allNodes []qbert.Node, clusters []string) []qbert.Node {
 
 	var clusterNodes []qbert.Node

--- a/pkg/util/helper.go
+++ b/pkg/util/helper.go
@@ -38,17 +38,17 @@ func RetryPolicyOn404(ctx context.Context, resp *http.Response, err error) (bool
 		if v, ok := err.(*url.Error); ok {
 			// Don't retry if the error was due to too many redirects.
 			if redirectsErrorRe.MatchString(v.Error()) {
-				return false, nil
+				return false, err
 			}
 
 			// Don't retry if the error was due to an invalid protocol scheme.
 			if schemeErrorRe.MatchString(v.Error()) {
-				return false, nil
+				return false, err
 			}
 
 			// Don't retry if the error was due to TLS cert verification failure.
 			if _, ok := v.Err.(x509.UnknownAuthorityError); ok {
-				return false, nil
+				return false, err
 			}
 		}
 
@@ -73,7 +73,7 @@ func RetryPolicyOn404(ctx context.Context, resp *http.Response, err error) (bool
 		return true, nil
 	}
 
-	return false, nil
+	return false, err
 }
 
 // AskBool function asks for the user input


### PR DESCRIPTION
…don't want to retry

In the current implementation, the error from the HTTP client is gobbled up when a retryablehttp client is used. Changing it to have the CheckRetry implementation used by pf9ctl to return any error the request receieved and retry was not needed.

Fixes: PCD-3055
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR enhances documentation by improving inline comment spacing in cmd/detachNode.go for better clarity. It also strengthens error handling in pkg/util/helper.go by returning actual error objects instead of nils, ensuring proper error propagation throughout the codebase.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>