### PR TITLE
PCD-2945 add PrivatePackageRepository option in objects.config

### DIFF
--- a/pkg/objects/objects.go
+++ b/pkg/objects/objects.go
@@ -4,26 +4,27 @@ import "time"
 
 // objects stores information to contact with the pf9 controller.
 type Config struct {
-	Fqdn               string        `json:"fqdn"`
-	Username           string        `json:"username"`
-	Password           string        `json:"password"`
-	Tenant             string        `json:"tenant"`
-	Region             string        `json:"region"`
-	WaitPeriod         time.Duration `json:"wait_period"`
-	AllowInsecure      bool          `json:"allow_insecure"`
-	ProxyURL           string        `json:"proxy_url"`
-	MfaToken           string        `json:"mfa_token"`
-	AwsIamUsername     string        `json:"aws_iam_username"`
-	AwsAccessKey       string        `json:"aws_access_key"`
-	AwsSecretKey       string        `json:"aws_secret_key"`
-	AwsRegion          string        `json:"aws_region"`
-	AzureTenant        string        `json:"azure_tenant"`
-	AzureClient        string        `json:"azure_application"`
-	AzureSubscription  string        `json:"azure_subscription"`
-	AzureSecret        string        `json:"azure_secret"`
-	GooglePath         string        `json:"google_path"`
-	GoogleProjectName  string        `json:"google_project_name"`
-	GoogleServiceEmail string        `json:"google_service_email"`
+	Fqdn                     string        `json:"fqdn"`
+	Username                 string        `json:"username"`
+	Password                 string        `json:"password"`
+	Tenant                   string        `json:"tenant"`
+	Region                   string        `json:"region"`
+	WaitPeriod               time.Duration `json:"wait_period"`
+	AllowInsecure            bool          `json:"allow_insecure"`
+	ProxyURL                 string        `json:"proxy_url"`
+	MfaToken                 string        `json:"mfa_token"`
+	AwsIamUsername           string        `json:"aws_iam_username"`
+	AwsAccessKey             string        `json:"aws_access_key"`
+	AwsSecretKey             string        `json:"aws_secret_key"`
+	AwsRegion                string        `json:"aws_region"`
+	AzureTenant              string        `json:"azure_tenant"`
+	AzureClient              string        `json:"azure_application"`
+	AzureSubscription        string        `json:"azure_subscription"`
+	AzureSecret              string        `json:"azure_secret"`
+	GooglePath               string        `json:"google_path"`
+	GoogleProjectName        string        `json:"google_project_name"`
+	GoogleServiceEmail       string        `json:"google_service_email"`
+	PrivatePackageRepository string        `json:"private_package_repository"`
 }
 
 type NodeConfig struct {


### PR DESCRIPTION
[PCD-2945](https://platform9.atlassian.net/browse/PCD-2945)
[PCD-2838](https://platform9.atlassian.net/browse/PCD-2838)

## Testing Notes
```bash
root@chirag-onprem-host-1:~# sudo mv /etc/apt/sources.list /etc/apt/sources.list.bak
root@chirag-onprem-host-1:~# sudo apt update

root@chirag-onprem-host-1:~# pcdctl config set -u https://airctl-1-4222194-420-sfo.platform9.localnet -e admin@airctl.localnet -r SFO -t service --private-package-repo http://10.10.11.171
root@chirag-onprem-host-1:~# pcdctl prep-node
✓ Loaded Config Successfully
✓ Configured private package repository successfully
✓ Missing package(s) installed successfully
✓ Removal of existing CLI
✓ Existing Platform9 Packages Check
✓ Required OS Packages Check
✓ SudoCheck
✓ CPUCheck
✓ DiskCheck
x MemoryCheck - At least 12 GB of memory is needed on host. Total memory found: 8 GB
✓ DefaultRouteCheck
✓ PortCheck
✓ Check lock on dpkg
✓ Check lock on apt
✓ Check if system is booted with systemd
✓ Check if firewalld service is not running
✓ Check if virtualization is enabled
✓ Distro specific setup
✓ Load the modules needed for Neutron
✓ Add sysctl options
x Enable NTP for time synchronization (not mandatory because systemd-timesyncd is installed)
✓ Install the SDN dependencies (OVS, OVN)
✓ Start and Enable iscsid service
✓ Install the Router Advertisement Daemon
✓ Adding OpenStack Services FQDN in /etc/hosts

✓ Completed Pre-Requisite Checks successfully


Optional pre-requisite check(s) failed. Do you want to continue? (y/n) y

Proceeding for prep-node with failed optional check(s)
✓ Required components set up successfully
✓ Hostagent download complete                                                  |  
✓ Hostagent installation succeeded
✓ Platform9 packages installed successfully

root@chirag-onprem-host-1:~# dpkg -l | grep pf9
ii  pf9-comms                       2025.10.1-1424.dbc2302                  amd64        Platform9 communications deb package. Built on git hash
ii  pf9-hostagent                   2025.10.1-2642.6f598c0                  all          Platform9 host agent

#### Reviewers
<!--- Add reviewers by appending their github usernames after "/cc" -->
<!--- delete section if not relevant -->
<!--- /cc @REVIEWER1_GITHUB_USERNAME, @REVIEWER2_GITHUB_USERNAME, ... --->
/cc @psarwate , @Sven27 


[PCD-2945]: https://platform9.atlassian.net/browse/PCD-2945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PCD-2838]: https://platform9.atlassian.net/browse/PCD-2838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request introduces a new configuration option for a private package repository in the objects package.</li>

<li>The change enhances the existing configuration structure by adding a new field, allowing users to specify a private package repository URL.</li>

<li>This addition aims to improve the flexibility and usability of the configuration for users who require access to private packages.</li>

<li>Overall, this update introduces a new configuration option in the objects package, enhancing usability for private package access.</li>

</ul>

</div>