### PR TITLE
RBAC: Support system-scoped tokens in pcdctl config/auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,13 @@ Usage:
 
 Flags:
   -u, --account-url string   sets account_url
+  -d, --domain string        sets domain
   -h, --help                 help for set
       --mfa string           set MFA token
   -p, --password string      sets password (use 'single quotes' to pass password)
   -l, --proxy-url string     sets proxy URL, can be specified as [<protocol>][<username>:<password>@]<host>:<port>
   -r, --region string        sets region
+  -s, --system               sets system scope
   -t, --tenant string        sets tenant
   -e, --username string      sets username
 

--- a/cmd/attachNode.go
+++ b/cmd/attachNode.go
@@ -95,7 +95,7 @@ func attachNodeRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("No nodes were specified to be attached to the cluster")
 	}
 
-	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken)
+	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken, cfg.SystemScope, cfg.UserDomain)
 	if err != nil {
 		zap.S().Fatalf("Failed to get keystone %s", err.Error())
 	}

--- a/cmd/authoriseNode.go
+++ b/cmd/authoriseNode.go
@@ -68,7 +68,7 @@ func authNodeRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Unable to create client: %s\n", err.Error())
 	}
 
-	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken)
+	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken, cfg.SystemScope, cfg.UserDomain)
 	if err != nil {
 		zap.S().Fatalf("Failed to get keystone %s", err.Error())
 	}

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -254,6 +254,8 @@ func bootstrapCmdRun(cmd *cobra.Command, args []string) {
 		cfg.Password,
 		cfg.Tenant,
 		cfg.MfaToken,
+		cfg.SystemScope,
+		cfg.UserDomain,
 	)
 	if err != nil {
 		zap.S().Fatalf("Failed to get keystone %s", err.Error())

--- a/cmd/checkNode.go
+++ b/cmd/checkNode.go
@@ -90,6 +90,8 @@ func checkNodeRun(cmd *cobra.Command, args []string) {
 		cfg.Password,
 		cfg.Tenant,
 		cfg.MfaToken,
+		cfg.SystemScope,
+		cfg.UserDomain,
 	)
 
 	if err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -75,6 +75,8 @@ func init() {
 	configCmdSet.Flags().StringVarP(&cfg.ProxyURL, "proxy-url", "l", "", "sets proxy URL, can be specified as [<protocol>][<username>:<password>@]<host>:<port>")
 	configCmdSet.Flags().StringVarP(&cfg.Region, "region", "r", "", "sets region")
 	configCmdSet.Flags().StringVarP(&cfg.Tenant, "tenant", "t", "", "sets tenant")
+	configCmdSet.Flags().BoolVarP(&cfg.SystemScope, "system", "s", false, "sets system scope")
+	configCmdSet.Flags().StringVarP(&cfg.UserDomain, "domain", "d", "", "sets domain")
 	configCmdSet.Flags().StringVar(&cfg.MfaToken, "mfa", "", "set MFA token")
 }
 

--- a/cmd/deauthoriseNode.go
+++ b/cmd/deauthoriseNode.go
@@ -67,7 +67,7 @@ func deauthNodeRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Unable to create client: %s\n", err.Error())
 	}
 
-	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken)
+	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken, cfg.SystemScope, cfg.UserDomain)
 	if err != nil {
 		zap.S().Fatalf("Failed to get keystone %s", err.Error())
 	}

--- a/cmd/deleteCluster.go
+++ b/cmd/deleteCluster.go
@@ -77,7 +77,7 @@ func deleteClusterRun(cmd *cobra.Command, args []string) {
 		zap.S().Fatalf("Unable to create client: %s\n", err.Error())
 	}
 
-	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken)
+	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken, cfg.SystemScope, cfg.UserDomain)
 	if err != nil {
 		zap.S().Fatalf("Failed to get keystone %s", err.Error())
 	}

--- a/cmd/detachNode.go
+++ b/cmd/detachNode.go
@@ -74,7 +74,7 @@ func detachNodeRun(cmd *cobra.Command, args []string) {
 
 	defer c.Segment.Close()
 
-	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken)
+	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken, cfg.SystemScope, cfg.UserDomain)
 	if err != nil {
 		zap.S().Fatalf("Failed to get keystone %s", err.Error())
 	}

--- a/cmd/prepNode.go
+++ b/cmd/prepNode.go
@@ -124,6 +124,8 @@ func prepNodeRun(cmd *cobra.Command, args []string) {
 		cfg.Password,
 		cfg.Tenant,
 		cfg.MfaToken,
+		cfg.SystemScope,
+		cfg.UserDomain,
 	)
 
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -178,6 +178,8 @@ func ValidateUserCredentials(cfg *objects.Config, nc objects.NodeConfig) error {
 		cfg.Password,
 		cfg.Tenant,
 		cfg.MfaToken,
+		cfg.SystemScope,
+		cfg.UserDomain,
 	)
 	if err != nil {
 		zap.S().Debug(err)
@@ -327,10 +329,9 @@ func ConfigCmdCreateRun(cfg *objects.Config) error {
 		region, _ = reader.ReadString('\n')
 		cfg.Region = strings.TrimSpace(region)
 	}
-	var service string
-	if cfg.Tenant == "" {
+	if cfg.Tenant == "" && !cfg.SystemScope {
 		fmt.Printf("Tenant [service]: ")
-		service, _ = reader.ReadString('\n')
+		service, _ := reader.ReadString('\n')
 		cfg.Tenant = strings.TrimSpace(service)
 	}
 	var proxyURL string
@@ -344,7 +345,7 @@ func ConfigCmdCreateRun(cfg *objects.Config) error {
 		cfg.Region = "RegionOne"
 	}
 
-	if cfg.Tenant == "" {
+	if cfg.Tenant == "" && !cfg.SystemScope {
 		cfg.Tenant = "service"
 	}
 
@@ -423,7 +424,11 @@ func SetProxy(proxyURL string) error {
 }
 
 func validateConfigFields(cfg *objects.Config) error {
-	if cfg.Fqdn == "" || cfg.Username == "" || cfg.Password == "" || cfg.Region == "" || cfg.Tenant == "" {
+	if cfg.Fqdn == "" || cfg.Username == "" || cfg.Password == "" || cfg.Region == "" {
+		return MISSSING_FIELDS
+	}
+	// Tenant is not required under system scope; the token ignores it.
+	if cfg.Tenant == "" && !cfg.SystemScope {
 		return MISSSING_FIELDS
 	}
 	return nil

--- a/pkg/keystone/keystone.go
+++ b/pkg/keystone/keystone.go
@@ -32,7 +32,7 @@ func keystoneRootCAs() *x509.CertPool {
 	// Load OS CA bundle directly (avoids per-process caching).
 	for _, p := range []string{
 		"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // RHEL-family
-		"/etc/ssl/certs/ca-certificates.crt",               // Debian-family
+		"/etc/ssl/certs/ca-certificates.crt",                // Debian-family
 	} {
 		if b, err := os.ReadFile(p); err == nil && rootCAs.AppendCertsFromPEM(b) {
 			return rootCAs
@@ -70,7 +70,74 @@ type KeystoneAuth struct {
 }
 
 type Keystone interface {
-	GetAuth(username, password, tenant string, mfa string) (KeystoneAuth, error)
+	GetAuth(username, password, tenant string, mfa string, systemScope bool, userDomain string) (KeystoneAuth, error)
+}
+
+// Returns the keystone identity-domain block (by id if UUID, else by name).
+// Empty defaults to the "default" domain by id, since its name is "Default".
+func buildUserDomain(userDomain string) string {
+	if userDomain == "" {
+		return `"domain": {"id": "default"}`
+	}
+	if _, err := uuid.Parse(userDomain); err == nil {
+		return fmt.Sprintf(`"domain": {"id": "%s"}`, userDomain)
+	}
+	return fmt.Sprintf(`"domain": {"name": "%s"}`, userDomain)
+}
+
+// Returns the keystone "identity" block; password+totp methods when mfa is set, else password only.
+func buildIdentity(username, password, mfa, userDomain string) string {
+	dom := buildUserDomain(userDomain)
+	if mfa != "" {
+		return fmt.Sprintf(`"identity": {
+			"methods": ["password", "totp"],
+			"password": {"user": {"name": "%s", %s, "password": "%s"}},
+			"totp": {"user": {"name": "%s", %s, "passcode": "%s"}}
+		}`, username, dom, password, username, dom, mfa)
+	}
+	return fmt.Sprintf(`"identity": {
+		"methods": ["password"],
+		"password": {"user": {"name": "%s", %s, "password": "%s"}}
+	}`, username, dom, password)
+}
+
+// Returns the keystone "scope" block; system-scoped when systemScope is set, else project-scoped to tenant.
+func buildScope(tenant string, systemScope bool) string {
+	if systemScope {
+		return `"scope": {"system": {"all": true}}`
+	}
+	if _, err := uuid.Parse(tenant); err == nil {
+		return fmt.Sprintf(`"scope": {"project": {"id": "%s", "domain": {"id": "default"}}}`, tenant)
+	}
+	return fmt.Sprintf(`"scope": {"project": {"name": "%s", "domain": {"id": "default"}}}`, tenant)
+}
+
+// Picks the project id a system-scoped actor operates on (its token carries none).
+// Precedence: explicit tenant, then user default project, then the "service" project.
+func resolveSystemTargetProject(fqdn, token, tenant, userID string) (string, error) {
+	if tenant != "" {
+		id, err := GetProjectID(fqdn, token, tenant)
+		if err != nil {
+			return "", fmt.Errorf("Unable to resolve target project %s, Error: %s", tenant, err)
+		}
+		return id, nil
+	}
+
+	if userID != "" {
+		id, err := GetUserDefaultProject(fqdn, token, userID)
+		if err != nil {
+			zap.S().Debugf("Unable to fetch user default project, falling back to service: %s", err)
+		} else if id != "" {
+			zap.S().Debugf("Using user default project %s as target", id)
+			return id, nil
+		}
+	}
+
+	id, err := GetProjectID(fqdn, token, "service")
+	if err != nil {
+		return "", fmt.Errorf("Unable to resolve a target project (no tenant, no user default project, service lookup failed), Error: %s", err)
+	}
+	return id, nil
 }
 
 type KeystoneImpl struct {
@@ -85,125 +152,17 @@ func (k KeystoneImpl) GetAuth(
 	username,
 	password,
 	tenant string,
-	mfa string) (auth KeystoneAuth, err error) {
+	mfa string,
+	systemScope bool,
+	userDomain string) (auth KeystoneAuth, err error) {
 
-	zap.S().Debugf("Received a call to fetch keystone authentication for fqdn: %s and user: %s and tenant: %s, mfa_token: %s\n", k.fqdn, username, tenant, mfa)
+	zap.S().Debugf("Received a call to fetch keystone authentication for fqdn: %s and user: %s and tenant: %s, mfa_token: %s, system_scope: %t, user_domain: %s\n", k.fqdn, username, tenant, mfa, systemScope, userDomain)
 
 	url := fmt.Sprintf("%s/keystone/v3/auth/tokens?nocatalog", k.fqdn)
 
-	var body string
-
-	//parsing the id or name passed in the tenant[] field
-	_, matcherr := uuid.Parse(tenant)
-
-	if mfa != "" {
-		// if err is nil, then it may be the correct ID
-		if matcherr == nil {
-			body = fmt.Sprintf(`{
-                	"auth": {
-                        	"identity": {
-                                	"methods": ["password", "totp"],
-                                	"password": {
-                                        	"user": {
-                                                	"name": "%s",
-                                                	"domain": {"id": "default"},
-                                                	"password": "%s"
-                                        	}
-                                	},
-					"totp": {
-						"user": {
-                                  			"name": "%s",
-                                  			"domain": {
-                                          			"id": "default"
-                                  			},
-                          				"passcode": "%s"
-                          			}
-					}
-                        	},
-                        	"scope": {
-                                	"project": {
-                                        	"id": "%s",
-                                        	"domain": {"id": "default"}
-                                	}
-                        	}
-                  	}
-        	}`, username, password, username, mfa, tenant)
-		} else { // if there is an error, then name is passed and we are accepting name field then
-			body = fmt.Sprintf(`{
-				"auth": {
-						"identity": {
-								"methods": ["password", "totp"],
-								"password": {
-										"user": {
-												"name": "%s",
-												"domain": {"id": "default"},
-												"password": "%s"
-										}
-								},
-				"totp": {
-					"user": {
-										  "name": "%s",
-										  "domain": {
-												  "id": "default"
-										  },
-									  "passcode": "%s"
-								  }
-				}
-						},
-						"scope": {
-								"project": {
-										"name": "%s",
-										"domain": {"id": "default"}
-								}
-						}
-				  }
-			}`, username, password, username, mfa, tenant)
-		}
-	} else {
-		if matcherr == nil {
-			body = fmt.Sprintf(`{
-				"auth": {
-					"identity": {
-						"methods": ["password"],
-						"password": {
-							"user": {
-								"name": "%s",
-								"domain": {"id": "default"},
-								"password": "%s"
-							}
-						}
-					},
-					"scope": {
-						"project": {
-							"id": "%s",
-							"domain": {"id": "default"}
-						}
-					}
-				}
-			}`, username, password, tenant)
-		} else {
-			body = fmt.Sprintf(`{
-				"auth": {
-					"identity": {
-						"methods": ["password"],
-						"password": {
-							"user": {
-								"name": "%s",
-								"domain": {"id": "default"},
-								"password": "%s"
-							}
-						}
-					},
-					"scope": {
-						"project": {
-							"name": "%s",
-							"domain": {"id": "default"}
-						}
-					}
-				}
-			}`, username, password, tenant)
-		}
-	}
+	body := fmt.Sprintf(`{"auth": {%s, %s}}`,
+		buildIdentity(username, password, mfa, userDomain),
+		buildScope(tenant, systemScope))
 
 	client := newKeystoneHTTPClient()
 
@@ -232,18 +191,39 @@ func (k KeystoneImpl) GetAuth(
 		zap.S().Debugf("Error in decoding payload\n")
 		return auth, fmt.Errorf("Unable to decode the payload")
 	}
-	t := payload["token"].(map[string]interface{})
-	project := t["project"].(map[string]interface{})
-	user := t["user"].(map[string]interface{})
-	token := resp.Header["X-Subject-Token"][0]
+	t, _ := payload["token"].(map[string]interface{})
+
+	var token string
+	if subjectToken := resp.Header["X-Subject-Token"]; len(subjectToken) > 0 {
+		token = subjectToken[0]
+	}
+
+	// A system-scoped token has no "project" block; leave ProjectID empty.
+	var projectID string
+	if project, ok := t["project"].(map[string]interface{}); ok {
+		projectID, _ = project["id"].(string)
+	}
+
+	var userID, email string
+	if user, ok := t["user"].(map[string]interface{}); ok {
+		userID, _ = user["id"].(string)
+		email, _ = user["name"].(string)
+	}
+
+	if systemScope {
+		projectID, err = resolveSystemTargetProject(k.fqdn, token, tenant, userID)
+		if err != nil {
+			return auth, err
+		}
+	}
 
 	zap.S().Debugf("returning successfully\n")
 
 	return KeystoneAuth{
 		DUFqdn:    k.fqdn,
 		Token:     token,
-		UserID:    user["id"].(string),
-		ProjectID: project["id"].(string),
-		Email:     user["name"].(string),
+		UserID:    userID,
+		ProjectID: projectID,
+		Email:     email,
 	}, nil
 }

--- a/pkg/keystone/keystone_resolve_test.go
+++ b/pkg/keystone/keystone_resolve_test.go
@@ -1,0 +1,69 @@
+package keystone_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	. "github.com/platform9/pf9ctl/pkg/keystone"
+	. "github.com/platform9/pf9ctl/pkg/test_utils"
+)
+
+var projectsInfo string = `{"projects": [{"id": "8f1d2c3b4a5e6f7081920a1b2c3d4e5f", "name": "service"}]}`
+
+func TestGetProjectID(t *testing.T) {
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		Equals(t, req.URL.String(), "http://example.com?name=service")
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(projectsInfo)),
+			Header:     make(http.Header),
+		}
+	})
+
+	p_api := ProjectManagerAPI{client, "http://example.com", "token"}
+	id, err := p_api.GetProjectID_API("service")
+	Ok(t, err)
+	Equals(t, "8f1d2c3b4a5e6f7081920a1b2c3d4e5f", id)
+}
+
+// A value that already looks like an id resolves without an API call.
+func TestGetProjectIDUUIDShortCircuit(t *testing.T) {
+	id, err := GetProjectID("https://example.platform9.horse", "token", "8f1d2c3b4a5e6f7081920a1b2c3d4e5f")
+	Ok(t, err)
+	Equals(t, "8f1d2c3b4a5e6f7081920a1b2c3d4e5f", id)
+}
+
+var userInfoWithDefaultProject string = `{"user": {"id": "u1", "default_project_id": "proj-default-id"}}`
+var userInfoNoDefaultProject string = `{"user": {"id": "u1"}}`
+
+func TestGetUserDefaultProject(t *testing.T) {
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(userInfoWithDefaultProject)),
+			Header:     make(http.Header),
+		}
+	})
+
+	u_api := UserManagerAPI{client, "http://example.com", "token"}
+	id, err := u_api.GetUserDefaultProject_API()
+	Ok(t, err)
+	Equals(t, "proj-default-id", id)
+}
+
+func TestGetUserDefaultProjectEmpty(t *testing.T) {
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(userInfoNoDefaultProject)),
+			Header:     make(http.Header),
+		}
+	})
+
+	u_api := UserManagerAPI{client, "http://example.com", "token"}
+	id, err := u_api.GetUserDefaultProject_API()
+	Ok(t, err)
+	Equals(t, "", id)
+}

--- a/pkg/keystone/keystone_scope_test.go
+++ b/pkg/keystone/keystone_scope_test.go
@@ -1,0 +1,95 @@
+package keystone
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func assertValidJSON(t *testing.T, body string) {
+	t.Helper()
+	if !json.Valid([]byte(body)) {
+		t.Fatalf("generated auth body is not valid JSON: %s", body)
+	}
+}
+
+func TestBuildScopeSystem(t *testing.T) {
+	scope := buildScope("service", true)
+	assertValidJSON(t, "{"+scope+"}")
+	if !strings.Contains(scope, `"system"`) || !strings.Contains(scope, `"all": true`) {
+		t.Fatalf("expected a system scope, got: %s", scope)
+	}
+	if strings.Contains(scope, `"project"`) {
+		t.Fatalf("system scope must not carry a project, got: %s", scope)
+	}
+}
+
+func TestBuildScopeProjectByName(t *testing.T) {
+	scope := buildScope("service", false)
+	assertValidJSON(t, "{"+scope+"}")
+	if !strings.Contains(scope, `"name": "service"`) {
+		t.Fatalf("expected project-by-name scope, got: %s", scope)
+	}
+}
+
+func TestBuildScopeProjectByID(t *testing.T) {
+	id := "6d30c85c033247548d6d93b0056b266b"
+	scope := buildScope(id, false)
+	assertValidJSON(t, "{"+scope+"}")
+	if !strings.Contains(scope, `"id": "`+id+`"`) {
+		t.Fatalf("expected project-by-id scope, got: %s", scope)
+	}
+}
+
+func TestBuildUserDomainDefault(t *testing.T) {
+	dom := buildUserDomain("")
+	assertValidJSON(t, "{"+dom+"}")
+	if !strings.Contains(dom, `"id": "default"`) {
+		t.Fatalf("empty domain must default to the default domain id, got: %s", dom)
+	}
+}
+
+func TestBuildUserDomainByName(t *testing.T) {
+	dom := buildUserDomain("domain-a")
+	assertValidJSON(t, "{"+dom+"}")
+	if !strings.Contains(dom, `"name": "domain-a"`) {
+		t.Fatalf("expected domain-by-name, got: %s", dom)
+	}
+}
+
+func TestBuildUserDomainByID(t *testing.T) {
+	id := "2a73b8f597c04551a0fdc8e95544be8a"
+	dom := buildUserDomain(id)
+	assertValidJSON(t, "{"+dom+"}")
+	if !strings.Contains(dom, `"id": "`+id+`"`) {
+		t.Fatalf("expected domain-by-id, got: %s", dom)
+	}
+}
+
+func TestBuildAuthBodyValidJSON(t *testing.T) {
+	cases := []struct {
+		name       string
+		tenant     string
+		mfa        string
+		sys        bool
+		userDomain string
+	}{
+		{"project-by-name", "service", "", false, ""},
+		{"project-by-id", "6d30c85c033247548d6d93b0056b266b", "", false, ""},
+		{"project-mfa", "service", "123456", false, ""},
+		{"system", "service", "", true, ""},
+		{"system-mfa", "service", "123456", true, ""},
+		{"system-domain-name", "service", "", true, "domain-a"},
+		{"system-domain-id", "service", "", true, "2a73b8f597c04551a0fdc8e95544be8a"},
+		{"project-domain-name-mfa", "service", "123456", false, "domain-a"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			body := fmt.Sprintf(`{"auth": {%s, %s}}`,
+				buildIdentity("someuser", "somepass", c.mfa, c.userDomain),
+				buildScope(c.tenant, c.sys))
+			assertValidJSON(t, body)
+		})
+	}
+}

--- a/pkg/keystone/projects.go
+++ b/pkg/keystone/projects.go
@@ -1,0 +1,76 @@
+// Copyright © 2021 The Platform9 Systems Inc.
+
+package keystone
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+// Type definition for struct encapsulating project manager APIs.
+type ProjectManagerAPI struct {
+	Client  *http.Client
+	BaseURL string
+	Token   string
+}
+
+// Type definition for project information reported as part of the
+// "get projects" request.
+type ProjectsInfo struct {
+	Projects []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"projects"`
+}
+
+// Resolves a project name to its ID; a value that is already a UUID is returned unchanged.
+func GetProjectID(fqdn, token, project string) (string, error) {
+	if _, err := uuid.Parse(project); err == nil {
+		return project, nil
+	}
+
+	url := fmt.Sprintf("%s/keystone/v3/projects", fqdn)
+	p_api := ProjectManagerAPI{newKeystoneHTTPClient(), url, token}
+	return p_api.GetProjectID_API(project)
+}
+
+// Project manager function to fetch the project ID for a given name.
+func (p_api *ProjectManagerAPI) GetProjectID_API(name string) (string, error) {
+	zap.S().Debug("Fetching project ID for ", name)
+	req, err := http.NewRequest("GET", p_api.BaseURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Add("X-Auth-Token", p_api.Token)
+
+	q := req.URL.Query()
+	q.Add("name", name)
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := p_api.Client.Do(req)
+	if err != nil {
+		zap.S().Errorf("Failed to fetch project information for %s, Error: %s", name, err)
+		return "", fmt.Errorf("Failed to fetch project information for %s, Error: %s", name, err)
+	}
+	defer resp.Body.Close()
+
+	projectsInfo := ProjectsInfo{}
+	err = json.NewDecoder(resp.Body).Decode(&projectsInfo)
+	if err != nil {
+		zap.S().Errorf("Failed to decode project information, Error: %s", err)
+		return "", fmt.Errorf("Failed to decode project information, Error: %s", err)
+	}
+
+	if len(projectsInfo.Projects) == 0 {
+		return "", fmt.Errorf("no project found with name %s", name)
+	}
+
+	projectID := projectsInfo.Projects[0].ID
+	zap.S().Debug("project ID: ", projectID)
+	return projectID, nil
+}

--- a/pkg/keystone/users.go
+++ b/pkg/keystone/users.go
@@ -1,0 +1,62 @@
+// Copyright © 2021 The Platform9 Systems Inc.
+
+package keystone
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+// Type definition for struct encapsulating user manager APIs.
+type UserManagerAPI struct {
+	Client  *http.Client
+	BaseURL string
+	Token   string
+}
+
+// Type definition for user information reported as part of the
+// "get user" request.
+type UserInfo struct {
+	User struct {
+		ID               string `json:"id"`
+		DefaultProjectID string `json:"default_project_id"`
+	} `json:"user"`
+}
+
+// Returns the user's default_project_id, or empty string if the user has none.
+func GetUserDefaultProject(fqdn, token, userID string) (string, error) {
+	url := fmt.Sprintf("%s/keystone/v3/users/%s", fqdn, userID)
+	u_api := UserManagerAPI{newKeystoneHTTPClient(), url, token}
+	return u_api.GetUserDefaultProject_API()
+}
+
+// User manager function to fetch the user's default project ID.
+func (u_api *UserManagerAPI) GetUserDefaultProject_API() (string, error) {
+	zap.S().Debug("Fetching default project for user")
+	req, err := http.NewRequest("GET", u_api.BaseURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Add("X-Auth-Token", u_api.Token)
+
+	resp, err := u_api.Client.Do(req)
+	if err != nil {
+		zap.S().Errorf("Failed to fetch user information, Error: %s", err)
+		return "", fmt.Errorf("Failed to fetch user information, Error: %s", err)
+	}
+	defer resp.Body.Close()
+
+	userInfo := UserInfo{}
+	err = json.NewDecoder(resp.Body).Decode(&userInfo)
+	if err != nil {
+		zap.S().Errorf("Failed to decode user information, Error: %s", err)
+		return "", fmt.Errorf("Failed to decode user information, Error: %s", err)
+	}
+
+	zap.S().Debug("default project ID: ", userInfo.User.DefaultProjectID)
+	return userInfo.User.DefaultProjectID, nil
+}

--- a/pkg/objects/objects.go
+++ b/pkg/objects/objects.go
@@ -8,6 +8,8 @@ type Config struct {
 	Username                 string        `json:"username"`
 	Password                 string        `json:"password"`
 	Tenant                   string        `json:"tenant"`
+	SystemScope              bool          `json:"system_scope"`
+	UserDomain               string        `json:"user_domain"`
 	Region                   string        `json:"region"`
 	WaitPeriod               time.Duration `json:"wait_period"`
 	AllowInsecure            bool          `json:"allow_insecure"`

--- a/pkg/pmk/decomissionNode.go
+++ b/pkg/pmk/decomissionNode.go
@@ -85,7 +85,7 @@ func DecommissionNode(cfg *objects.Config, nc objects.NodeConfig, removePf9 bool
 	if c, err = client.NewClient(cfg.Fqdn, executor, cfg.AllowInsecure, false); err != nil {
 		zap.S().Fatalf("Unable to create client: %s\n", err.Error())
 	}
-	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken)
+	auth, err := c.Keystone.GetAuth(cfg.Username, cfg.Password, cfg.Tenant, cfg.MfaToken, cfg.SystemScope, cfg.UserDomain)
 	if err != nil {
 		zap.S().Debug("Failed to get keystone %s", err.Error())
 	}


### PR DESCRIPTION
## ISSUE(S):
<!--- Links to JIRA tickets -->
<!--- [FT-XXXX](link.to/FT-XXXX): Subject of FT-XXXX -->

## SUMMARY
`config set` could only request **project-scoped** keystone tokens. A system-scoped
user (e.g. `platform_admin`, which has only a `system=all` role binding and no
project role) got a **401 at token issuance**, before any policy ran — so host
onboarding was impossible for them. Separately, the user identity domain was
hardcoded to `default`, so any user outside the `default` domain also got a 401
and could not authenticate at all.

## ISSUE TYPE
- [x] New feature (adds `-s`/`-d` system-scope support; end-user/project-scoped behavior unchanged)
- [x] Breaking change (Go API: `GetAuth` signature change breaks downstream importers, e.g. pcdctl, until updated)
- [x] This change requires a documentation update (README flag list updated in this PR)

## IMPACTED FEATURES/COMPONENTS:
- `pkg/keystone` — `GetAuth` (+`systemScope`,`userDomain`); new `projects.go`/`users.go` (project name→ID and user default-project lookups)
- `pkg/objects` — `Config` gains `SystemScope bool`, `UserDomain string`
- `pkg/config` — `validateConfigFields` (tenant optional under system scope); suppress `service` default under `-s`
- `cmd/config.go` — `-s/--system`, `-d/--domain` flags; 9 `GetAuth` call sites updated for the new signature
- **Downstream:** `platform9/pcdctl` (imports `pf9ctl/pkg/keystone`) — needs a companion update

## TESTING DONE
#### Automated
- New unit tests: `pkg/keystone/keystone_scope_test.go` (auth-body construction —
  project/system × mfa × domain, all valid JSON) and `keystone_resolve_test.go`
  (project name→ID, UUID short-circuit, user default-project present/absent).
- Project-scoped request bodies proven **byte-identical** to the pre-refactor bodies
  (no regression for existing users).
- `go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -s` all clean.
#### Manual
Live-validated on a CE DU (`pcd-community.pf9.io`) as `platform_admin@pf9.user`:
- `config set -s` (previously **401**) → succeeds; system-scoped token issued.
- Target-project precedence: no `-t` → user `default_project_id` (`81ae47…`);
  `-t service` → name lookup; `-t <uuid>` → short-circuit; `-t <nonexistent>` →
  clean "Unable to resolve target project" error (config left untouched).
- `prep-node` onboarded a host; resmgr **authorized the system-scoped token**
  (GET host → 200; the `pf9-kube` role 404 is a PCD-V DU not offering that role,
  not an auth failure).
- `-d` domain handling + default-domain back-compat verified.
- Project-only scope (no `-s`) confirmed unchanged (correct path taken; keystone
  returned 401 only on stale test creds, i.e. the body was well-formed).

Before:
```bash
./pf9ctl config set -u https://pcd-community.pf9.io -e platform_admin@pf9.user -p 'Pf9Persona!' -r Community -t service --no-prompt --verbose
Error checking versions  open /usr/bin/pf9ctl: no such file or directory
2026-06-24T22:20:47.1525Z       DEBUG   ==========Running set config==========
2026-06-24T22:20:47.1526Z       DEBUG   Using local executor
2026-06-24T22:20:47.1526Z       DEBUG   Received a call to fetch keystone authentication for fqdn: https://pcd-community.pf9.io and user: platform_admin@pf9.user and tenant: service, mfa_token: , system_scope: false, user_domain: 

2026-06-24T22:20:47.5747Z       DEBUG   Error in StatusCode:401

2026-06-24T22:20:47.5748Z       DEBUG   Unable to get keystone token, status: 401
2026-06-24T22:20:47.5749Z       FATAL   x Invalid Credentials
```

After (system scope support): 
```bash
./pf9ctl config set -u https://pcd-community.pf9.io -e platform_admin@pf9.user -p 'Pf9Persona!' -r Community -s --no-prompt --verbose
Error checking versions  open /usr/bin/pf9ctl: no such file or directory
2026-06-24T20:54:13.9839Z       DEBUG   ==========Running set config==========
2026-06-24T20:54:13.9841Z       DEBUG   Using local executor
2026-06-24T20:54:13.9841Z       DEBUG   Received a call to fetch keystone authentication for fqdn: https://pcd-community.pf9.io and user: platform_admin@pf9.user and tenant: , mfa_token: , system_scope: true, user_domain: 

2026-06-24T20:54:14.4172Z       DEBUG   Fetching default project for user
2026-06-24T20:54:14.6104Z       DEBUG   default project ID: 81ae47585ea74aa4b9f40de503b062b4
2026-06-24T20:54:14.6105Z       DEBUG   Using user default project 81ae47585ea74aa4b9f40de503b062b4 as target
2026-06-24T20:54:14.6105Z       DEBUG   returning successfully

2026-06-24T20:54:14.6105Z       DEBUG   Fetching service ID for service: regionInfo
2026-06-24T20:54:14.612Z        DEBUG   Fetching service ID for regionInfo
2026-06-24T20:54:14.7879Z       DEBUG   service ID : .f739a2c9c6fc45dd9013101e7620b8d3
2026-06-24T20:54:14.788Z        DEBUG   service ID : f739a2c9c6fc45dd9013101e7620b8d3
2026-06-24T20:54:14.7882Z       DEBUG   Service ID fetched : f739a2c9c6fc45dd9013101e7620b8d3
2026-06-24T20:54:14.7882Z       DEBUG   Fetching endpoint for region: Community
2026-06-24T20:54:14.7898Z       DEBUG   Fetching endpoints for region Community
2026-06-24T20:54:14.975Z        DEBUG   endpoint: https://pcd-community.pf9.io/download-links
2026-06-24T20:54:14.9751Z       DEBUG   FQDN: pcd-community.pf9.io
2026-06-24T20:54:14.9751Z       DEBUG   Endpoint found: pcd-community.pf9.io
2026-06-24T20:54:14.9751Z       DEBUG   endpointURL fetched : pcd-community.pf9.io
2026-06-24T20:54:14.9751Z       DEBUG   Storing configuration details
✓ Stored configuration details successfully
2026-06-24T20:54:14.9754Z       DEBUG   ==========Finished running set config=========
```